### PR TITLE
Issue #5: Implement core APD data model and first migrations

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,6 +7,7 @@ from sqlalchemy import engine_from_config, pool
 
 from apd.app.db import Base
 from apd.app.settings import get_settings
+import apd.domain.models  # noqa: F401
 
 
 config = context.config

--- a/alembic/versions/20260427_0001_initial_core_schema.py
+++ b/alembic/versions/20260427_0001_initial_core_schema.py
@@ -1,0 +1,360 @@
+"""create initial APD core schema
+
+Revision ID: 20260427_0001
+Revises:
+Create Date: 2026-04-27 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260427_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+run_phase_enum = sa.Enum(
+    "vague_notion",
+    "evidence_collected",
+    "supported_opportunity",
+    "vetted_opportunity",
+    "prototype_ready",
+    "build_approved",
+    name="runphase",
+    native_enum=False,
+)
+
+review_status_enum = sa.Enum(
+    "unreviewed",
+    "accepted",
+    "weak",
+    "disputed",
+    "needs_followup",
+    name="reviewstatus",
+    native_enum=False,
+)
+
+decision_value_enum = sa.Enum(
+    "archive",
+    "watch",
+    "publish",
+    "prototype_later",
+    "build_approved",
+    name="decisionvalue",
+    native_enum=False,
+)
+
+evidence_relationship_enum = sa.Enum(
+    "supports",
+    "weakens",
+    "contradicts",
+    "context_for",
+    "example_of",
+    name="evidencerelationship",
+    native_enum=False,
+)
+
+validation_gate_status_enum = sa.Enum(
+    "not_started",
+    "in_progress",
+    "satisfied",
+    "weak",
+    "failed",
+    "waived",
+    name="validationgatestatus",
+    native_enum=False,
+)
+
+evidence_target_type_enum = sa.Enum(
+    "claim",
+    "theme",
+    "candidate",
+    "validation_gate",
+    name="evidencetargettype",
+    native_enum=False,
+)
+
+evidence_strength_enum = sa.Enum(
+    "weak",
+    "medium",
+    "strong",
+    name="evidencestrength",
+    native_enum=False,
+)
+
+review_target_type_enum = sa.Enum(
+    "run",
+    "source",
+    "evidence_excerpt",
+    "claim",
+    "theme",
+    "candidate",
+    "validation_gate",
+    "artifact",
+    "decision",
+    name="reviewtargettype",
+    native_enum=False,
+)
+
+review_note_status_enum = sa.Enum(
+    "open",
+    "resolved",
+    "wont_fix",
+    "superseded",
+    name="reviewnotestatus",
+    native_enum=False,
+)
+
+decision_target_type_enum = sa.Enum(
+    "run",
+    "candidate",
+    name="decisiontargettype",
+    native_enum=False,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "runs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("intent", sa.Text(), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("mode", sa.String(length=64), nullable=True),
+        sa.Column("phase", run_phase_enum, nullable=False),
+        sa.Column("current_decision", decision_value_enum, nullable=True),
+        sa.Column("recommendation", sa.Text(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("claim_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("theme_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("candidate_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+
+    op.create_table(
+        "sources",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("source_type", sa.String(length=64), nullable=False),
+        sa.Column("url", sa.String(length=1024), nullable=True),
+        sa.Column("origin", sa.String(length=255), nullable=True),
+        sa.Column("author_or_org", sa.String(length=255), nullable=True),
+        sa.Column("captured_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("raw_path", sa.String(length=1024), nullable=True),
+        sa.Column("normalized_path", sa.String(length=1024), nullable=True),
+        sa.Column("reliability_notes", sa.Text(), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_sources_run_id"), "sources", ["run_id"], unique=False)
+
+    op.create_table(
+        "evidence_excerpts",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("source_id", sa.Integer(), sa.ForeignKey("sources.id"), nullable=False),
+        sa.Column("excerpt_text", sa.Text(), nullable=False),
+        sa.Column("location_reference", sa.String(length=255), nullable=True),
+        sa.Column("excerpt_type", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_evidence_excerpts_run_id"), "evidence_excerpts", ["run_id"], unique=False)
+    op.create_index(op.f("ix_evidence_excerpts_source_id"), "evidence_excerpts", ["source_id"], unique=False)
+
+    op.create_table(
+        "claims",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("statement", sa.Text(), nullable=False),
+        sa.Column("claim_type", sa.String(length=64), nullable=True),
+        sa.Column("review_status", review_status_enum, nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column("is_agent_generated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_claims_run_id"), "claims", ["run_id"], unique=False)
+
+    op.create_table(
+        "themes",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("theme_type", sa.String(length=64), nullable=True),
+        sa.Column("severity", sa.String(length=32), nullable=True),
+        sa.Column("frequency", sa.String(length=32), nullable=True),
+        sa.Column("user_segment", sa.String(length=255), nullable=True),
+        sa.Column("workflow", sa.String(length=255), nullable=True),
+        sa.Column("review_status", review_status_enum, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_themes_run_id"), "themes", ["run_id"], unique=False)
+
+    op.create_table(
+        "candidates",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("target_user", sa.String(length=255), nullable=True),
+        sa.Column("first_workflow", sa.String(length=255), nullable=True),
+        sa.Column("first_wedge", sa.String(length=255), nullable=True),
+        sa.Column("prototype_success_event", sa.Text(), nullable=True),
+        sa.Column("monetization_path", sa.Text(), nullable=True),
+        sa.Column("substitutes", sa.Text(), nullable=True),
+        sa.Column("risks", sa.Text(), nullable=True),
+        sa.Column("why_now", sa.Text(), nullable=True),
+        sa.Column("why_it_might_fail", sa.Text(), nullable=True),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("rank", sa.Integer(), nullable=True),
+        sa.Column("review_status", review_status_enum, nullable=False),
+        sa.Column("decision", decision_value_enum, nullable=True),
+        sa.Column("is_agent_generated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_candidates_run_id"), "candidates", ["run_id"], unique=False)
+
+    op.create_table(
+        "validation_gates",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("candidate_id", sa.Integer(), sa.ForeignKey("candidates.id"), nullable=True),
+        sa.Column("phase", run_phase_enum, nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", validation_gate_status_enum, nullable=False),
+        sa.Column("blocking", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("evidence_summary", sa.Text(), nullable=True),
+        sa.Column("missing_evidence", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_validation_gates_candidate_id"), "validation_gates", ["candidate_id"], unique=False)
+    op.create_index(op.f("ix_validation_gates_run_id"), "validation_gates", ["run_id"], unique=False)
+
+    op.create_table(
+        "review_notes",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("target_type", review_target_type_enum, nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=False),
+        sa.Column("author", sa.String(length=255), nullable=True),
+        sa.Column("note", sa.Text(), nullable=False),
+        sa.Column("status", review_note_status_enum, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_review_notes_run_id"), "review_notes", ["run_id"], unique=False)
+
+    op.create_table(
+        "decisions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("candidate_id", sa.Integer(), sa.ForeignKey("candidates.id"), nullable=True),
+        sa.Column("target_type", decision_target_type_enum, nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=False),
+        sa.Column("decision", decision_value_enum, nullable=False),
+        sa.Column("rationale", sa.Text(), nullable=True),
+        sa.Column("decided_by", sa.String(length=255), nullable=True),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_decisions_candidate_id"), "decisions", ["candidate_id"], unique=False)
+    op.create_index(op.f("ix_decisions_run_id"), "decisions", ["run_id"], unique=False)
+
+    op.create_table(
+        "artifacts",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("candidate_id", sa.Integer(), sa.ForeignKey("candidates.id"), nullable=True),
+        sa.Column("artifact_type", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("path", sa.String(length=1024), nullable=True),
+        sa.Column("url", sa.String(length=1024), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_artifacts_candidate_id"), "artifacts", ["candidate_id"], unique=False)
+    op.create_index(op.f("ix_artifacts_run_id"), "artifacts", ["run_id"], unique=False)
+
+    op.create_table(
+        "evidence_links",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=False),
+        sa.Column("source_id", sa.Integer(), sa.ForeignKey("sources.id"), nullable=True),
+        sa.Column("excerpt_id", sa.Integer(), sa.ForeignKey("evidence_excerpts.id"), nullable=True),
+        sa.Column("target_type", evidence_target_type_enum, nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=False),
+        sa.Column("relationship", evidence_relationship_enum, nullable=False),
+        sa.Column("strength", evidence_strength_enum, nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+    op.create_index(op.f("ix_evidence_links_excerpt_id"), "evidence_links", ["excerpt_id"], unique=False)
+    op.create_index(op.f("ix_evidence_links_run_id"), "evidence_links", ["run_id"], unique=False)
+    op.create_index(op.f("ix_evidence_links_source_id"), "evidence_links", ["source_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_evidence_links_source_id"), table_name="evidence_links")
+    op.drop_index(op.f("ix_evidence_links_run_id"), table_name="evidence_links")
+    op.drop_index(op.f("ix_evidence_links_excerpt_id"), table_name="evidence_links")
+    op.drop_table("evidence_links")
+
+    op.drop_index(op.f("ix_artifacts_run_id"), table_name="artifacts")
+    op.drop_index(op.f("ix_artifacts_candidate_id"), table_name="artifacts")
+    op.drop_table("artifacts")
+
+    op.drop_index(op.f("ix_decisions_run_id"), table_name="decisions")
+    op.drop_index(op.f("ix_decisions_candidate_id"), table_name="decisions")
+    op.drop_table("decisions")
+
+    op.drop_index(op.f("ix_review_notes_run_id"), table_name="review_notes")
+    op.drop_table("review_notes")
+
+    op.drop_index(op.f("ix_validation_gates_run_id"), table_name="validation_gates")
+    op.drop_index(op.f("ix_validation_gates_candidate_id"), table_name="validation_gates")
+    op.drop_table("validation_gates")
+
+    op.drop_index(op.f("ix_candidates_run_id"), table_name="candidates")
+    op.drop_table("candidates")
+
+    op.drop_index(op.f("ix_themes_run_id"), table_name="themes")
+    op.drop_table("themes")
+
+    op.drop_index(op.f("ix_claims_run_id"), table_name="claims")
+    op.drop_table("claims")
+
+    op.drop_index(op.f("ix_evidence_excerpts_source_id"), table_name="evidence_excerpts")
+    op.drop_index(op.f("ix_evidence_excerpts_run_id"), table_name="evidence_excerpts")
+    op.drop_table("evidence_excerpts")
+
+    op.drop_index(op.f("ix_sources_run_id"), table_name="sources")
+    op.drop_table("sources")
+
+    op.drop_table("runs")

--- a/apd/app/db.py
+++ b/apd/app/db.py
@@ -30,3 +30,6 @@ _ensure_sqlite_directory(settings.database_url)
 
 engine = create_engine(settings.database_url, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+# Import model modules so SQLAlchemy metadata is fully registered.
+import apd.domain.models  # noqa: F401,E402

--- a/apd/domain/__init__.py
+++ b/apd/domain/__init__.py
@@ -1,1 +1,27 @@
-"""Domain layer namespace for future APD models."""
+"""Domain models for APD research runs."""
+
+from apd.domain.models import Artifact
+from apd.domain.models import Candidate
+from apd.domain.models import Claim
+from apd.domain.models import Decision
+from apd.domain.models import EvidenceExcerpt
+from apd.domain.models import EvidenceLink
+from apd.domain.models import ReviewNote
+from apd.domain.models import Run
+from apd.domain.models import Source
+from apd.domain.models import Theme
+from apd.domain.models import ValidationGate
+
+__all__ = [
+	"Run",
+	"Source",
+	"EvidenceExcerpt",
+	"Claim",
+	"Theme",
+	"Candidate",
+	"EvidenceLink",
+	"ValidationGate",
+	"ReviewNote",
+	"Decision",
+	"Artifact",
+]

--- a/apd/domain/models.py
+++ b/apd/domain/models.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Enum as SqlEnum
+from sqlalchemy import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from apd.app.db import Base
+
+
+def _utc_now() -> datetime:
+    return datetime.utcnow()
+
+
+class RunPhase(StrEnum):
+    VAGUE_NOTION = "vague_notion"
+    EVIDENCE_COLLECTED = "evidence_collected"
+    SUPPORTED_OPPORTUNITY = "supported_opportunity"
+    VETTED_OPPORTUNITY = "vetted_opportunity"
+    PROTOTYPE_READY = "prototype_ready"
+    BUILD_APPROVED = "build_approved"
+
+
+class ReviewStatus(StrEnum):
+    UNREVIEWED = "unreviewed"
+    ACCEPTED = "accepted"
+    WEAK = "weak"
+    DISPUTED = "disputed"
+    NEEDS_FOLLOWUP = "needs_followup"
+
+
+class DecisionValue(StrEnum):
+    ARCHIVE = "archive"
+    WATCH = "watch"
+    PUBLISH = "publish"
+    PROTOTYPE_LATER = "prototype_later"
+    BUILD_APPROVED = "build_approved"
+
+
+class EvidenceRelationship(StrEnum):
+    SUPPORTS = "supports"
+    WEAKENS = "weakens"
+    CONTRADICTS = "contradicts"
+    CONTEXT_FOR = "context_for"
+    EXAMPLE_OF = "example_of"
+
+
+class ValidationGateStatus(StrEnum):
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    SATISFIED = "satisfied"
+    WEAK = "weak"
+    FAILED = "failed"
+    WAIVED = "waived"
+
+
+class EvidenceTargetType(StrEnum):
+    CLAIM = "claim"
+    THEME = "theme"
+    CANDIDATE = "candidate"
+    VALIDATION_GATE = "validation_gate"
+
+
+class ReviewTargetType(StrEnum):
+    RUN = "run"
+    SOURCE = "source"
+    EVIDENCE_EXCERPT = "evidence_excerpt"
+    CLAIM = "claim"
+    THEME = "theme"
+    CANDIDATE = "candidate"
+    VALIDATION_GATE = "validation_gate"
+    ARTIFACT = "artifact"
+    DECISION = "decision"
+
+
+class DecisionTargetType(StrEnum):
+    RUN = "run"
+    CANDIDATE = "candidate"
+
+
+class ReviewNoteStatus(StrEnum):
+    OPEN = "open"
+    RESOLVED = "resolved"
+    WONT_FIX = "wont_fix"
+    SUPERSEDED = "superseded"
+
+
+class EvidenceStrength(StrEnum):
+    WEAK = "weak"
+    MEDIUM = "medium"
+    STRONG = "strong"
+
+
+class Run(Base):
+    __tablename__ = "runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    intent: Mapped[Optional[str]] = mapped_column(Text)
+    summary: Mapped[Optional[str]] = mapped_column(Text)
+    mode: Mapped[Optional[str]] = mapped_column(String(64))
+    phase: Mapped[RunPhase] = mapped_column(
+        SqlEnum(RunPhase, native_enum=False, validate_strings=True),
+        nullable=False,
+        default=RunPhase.VAGUE_NOTION,
+    )
+    current_decision: Mapped[Optional[DecisionValue]] = mapped_column(
+        SqlEnum(DecisionValue, native_enum=False, validate_strings=True),
+        nullable=True,
+    )
+    recommendation: Mapped[Optional[str]] = mapped_column(Text)
+    confidence: Mapped[Optional[float]] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    source_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    claim_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    theme_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    candidate_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    sources: Mapped[list[Source]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    evidence_excerpts: Mapped[list[EvidenceExcerpt]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    claims: Mapped[list[Claim]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    themes: Mapped[list[Theme]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    candidates: Mapped[list[Candidate]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    evidence_links: Mapped[list[EvidenceLink]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    validation_gates: Mapped[list[ValidationGate]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    review_notes: Mapped[list[ReviewNote]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    decisions: Mapped[list[Decision]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    artifacts: Mapped[list[Artifact]] = relationship(back_populates="run", cascade="all, delete-orphan")
+
+
+class Source(Base):
+    __tablename__ = "sources"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    title: Mapped[Optional[str]] = mapped_column(String(255))
+    source_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    url: Mapped[Optional[str]] = mapped_column(String(1024))
+    origin: Mapped[Optional[str]] = mapped_column(String(255))
+    author_or_org: Mapped[Optional[str]] = mapped_column(String(255))
+    captured_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    published_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    raw_path: Mapped[Optional[str]] = mapped_column(String(1024))
+    normalized_path: Mapped[Optional[str]] = mapped_column(String(1024))
+    reliability_notes: Mapped[Optional[str]] = mapped_column(Text)
+    summary: Mapped[Optional[str]] = mapped_column(Text)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="sources")
+    evidence_excerpts: Mapped[list[EvidenceExcerpt]] = relationship(back_populates="source", cascade="all, delete-orphan")
+    evidence_links: Mapped[list[EvidenceLink]] = relationship(back_populates="source")
+
+
+class EvidenceExcerpt(Base):
+    __tablename__ = "evidence_excerpts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    source_id: Mapped[int] = mapped_column(ForeignKey("sources.id"), nullable=False, index=True)
+    excerpt_text: Mapped[str] = mapped_column(Text, nullable=False)
+    location_reference: Mapped[Optional[str]] = mapped_column(String(255))
+    excerpt_type: Mapped[Optional[str]] = mapped_column(String(64))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="evidence_excerpts")
+    source: Mapped[Source] = relationship(back_populates="evidence_excerpts")
+    evidence_links: Mapped[list[EvidenceLink]] = relationship(back_populates="excerpt")
+
+
+class Claim(Base):
+    __tablename__ = "claims"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    statement: Mapped[str] = mapped_column(Text, nullable=False)
+    claim_type: Mapped[Optional[str]] = mapped_column(String(64))
+    review_status: Mapped[ReviewStatus] = mapped_column(
+        SqlEnum(ReviewStatus, native_enum=False, validate_strings=True),
+        nullable=False,
+        default=ReviewStatus.UNREVIEWED,
+    )
+    confidence: Mapped[Optional[float]] = mapped_column(Float)
+    created_by: Mapped[Optional[str]] = mapped_column(String(255))
+    is_agent_generated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="claims")
+
+
+class Theme(Base):
+    __tablename__ = "themes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[Optional[str]] = mapped_column(Text)
+    theme_type: Mapped[Optional[str]] = mapped_column(String(64))
+    severity: Mapped[Optional[str]] = mapped_column(String(32))
+    frequency: Mapped[Optional[str]] = mapped_column(String(32))
+    user_segment: Mapped[Optional[str]] = mapped_column(String(255))
+    workflow: Mapped[Optional[str]] = mapped_column(String(255))
+    review_status: Mapped[ReviewStatus] = mapped_column(
+        SqlEnum(ReviewStatus, native_enum=False, validate_strings=True),
+        nullable=False,
+        default=ReviewStatus.UNREVIEWED,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="themes")
+
+
+class Candidate(Base):
+    __tablename__ = "candidates"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[Optional[str]] = mapped_column(Text)
+    target_user: Mapped[Optional[str]] = mapped_column(String(255))
+    first_workflow: Mapped[Optional[str]] = mapped_column(String(255))
+    first_wedge: Mapped[Optional[str]] = mapped_column(String(255))
+    prototype_success_event: Mapped[Optional[str]] = mapped_column(Text)
+    monetization_path: Mapped[Optional[str]] = mapped_column(Text)
+    substitutes: Mapped[Optional[str]] = mapped_column(Text)
+    risks: Mapped[Optional[str]] = mapped_column(Text)
+    why_now: Mapped[Optional[str]] = mapped_column(Text)
+    why_it_might_fail: Mapped[Optional[str]] = mapped_column(Text)
+    score: Mapped[Optional[float]] = mapped_column(Float)
+    rank: Mapped[Optional[int]] = mapped_column(Integer)
+    review_status: Mapped[ReviewStatus] = mapped_column(
+        SqlEnum(ReviewStatus, native_enum=False, validate_strings=True),
+        nullable=False,
+        default=ReviewStatus.UNREVIEWED,
+    )
+    decision: Mapped[Optional[DecisionValue]] = mapped_column(
+        SqlEnum(DecisionValue, native_enum=False, validate_strings=True),
+        nullable=True,
+    )
+    is_agent_generated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="candidates")
+    validation_gates: Mapped[list[ValidationGate]] = relationship(back_populates="candidate")
+    decisions: Mapped[list[Decision]] = relationship(back_populates="candidate")
+    artifacts: Mapped[list[Artifact]] = relationship(back_populates="candidate")
+
+
+class EvidenceLink(Base):
+    __tablename__ = "evidence_links"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    source_id: Mapped[Optional[int]] = mapped_column(ForeignKey("sources.id"), index=True)
+    excerpt_id: Mapped[Optional[int]] = mapped_column(ForeignKey("evidence_excerpts.id"), index=True)
+    target_type: Mapped[EvidenceTargetType] = mapped_column(
+        SqlEnum(EvidenceTargetType, native_enum=False, validate_strings=True),
+        nullable=False,
+    )
+    target_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    relationship_type: Mapped[EvidenceRelationship] = mapped_column(
+        "relationship",
+        SqlEnum(EvidenceRelationship, native_enum=False, validate_strings=True),
+        nullable=False,
+    )
+    strength: Mapped[Optional[EvidenceStrength]] = mapped_column(
+        SqlEnum(EvidenceStrength, native_enum=False, validate_strings=True),
+        nullable=True,
+    )
+    notes: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="evidence_links")
+    source: Mapped[Optional[Source]] = relationship(back_populates="evidence_links")
+    excerpt: Mapped[Optional[EvidenceExcerpt]] = relationship(back_populates="evidence_links")
+
+
+class ValidationGate(Base):
+    __tablename__ = "validation_gates"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    candidate_id: Mapped[Optional[int]] = mapped_column(ForeignKey("candidates.id"), index=True)
+    phase: Mapped[Optional[RunPhase]] = mapped_column(
+        SqlEnum(RunPhase, native_enum=False, validate_strings=True),
+        nullable=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    status: Mapped[ValidationGateStatus] = mapped_column(
+        SqlEnum(ValidationGateStatus, native_enum=False, validate_strings=True),
+        nullable=False,
+        default=ValidationGateStatus.NOT_STARTED,
+    )
+    blocking: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    evidence_summary: Mapped[Optional[str]] = mapped_column(Text)
+    missing_evidence: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="validation_gates")
+    candidate: Mapped[Optional[Candidate]] = relationship(back_populates="validation_gates")
+
+
+class ReviewNote(Base):
+    __tablename__ = "review_notes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    target_type: Mapped[ReviewTargetType] = mapped_column(
+        SqlEnum(ReviewTargetType, native_enum=False, validate_strings=True),
+        nullable=False,
+    )
+    target_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    author: Mapped[Optional[str]] = mapped_column(String(255))
+    note: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[ReviewNoteStatus] = mapped_column(
+        SqlEnum(ReviewNoteStatus, native_enum=False, validate_strings=True),
+        nullable=False,
+        default=ReviewNoteStatus.OPEN,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="review_notes")
+
+
+class Decision(Base):
+    __tablename__ = "decisions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    candidate_id: Mapped[Optional[int]] = mapped_column(ForeignKey("candidates.id"), index=True)
+    target_type: Mapped[DecisionTargetType] = mapped_column(
+        SqlEnum(DecisionTargetType, native_enum=False, validate_strings=True),
+        nullable=False,
+    )
+    target_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    decision: Mapped[DecisionValue] = mapped_column(
+        SqlEnum(DecisionValue, native_enum=False, validate_strings=True),
+        nullable=False,
+    )
+    rationale: Mapped[Optional[str]] = mapped_column(Text)
+    decided_by: Mapped[Optional[str]] = mapped_column(String(255))
+    decided_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="decisions")
+    candidate: Mapped[Optional[Candidate]] = relationship(back_populates="decisions")
+
+
+class Artifact(Base):
+    __tablename__ = "artifacts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("runs.id"), nullable=False, index=True)
+    candidate_id: Mapped[Optional[int]] = mapped_column(ForeignKey("candidates.id"), index=True)
+    artifact_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    title: Mapped[Optional[str]] = mapped_column(String(255))
+    path: Mapped[Optional[str]] = mapped_column(String(1024))
+    url: Mapped[Optional[str]] = mapped_column(String(1024))
+    created_by: Mapped[Optional[str]] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    summary: Mapped[Optional[str]] = mapped_column(Text)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    run: Mapped[Run] = relationship(back_populates="artifacts")
+    candidate: Mapped[Optional[Candidate]] = relationship(back_populates="artifacts")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+# Ensure ORM model modules are imported so metadata is complete in test runs.
+import apd.domain.models  # noqa: F401

--- a/tests/test_domain_model_graph.py
+++ b/tests/test_domain_model_graph.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from apd.app.db import Base
+from apd.domain.models import Artifact
+from apd.domain.models import Candidate
+from apd.domain.models import Claim
+from apd.domain.models import Decision
+from apd.domain.models import DecisionTargetType
+from apd.domain.models import DecisionValue
+from apd.domain.models import EvidenceExcerpt
+from apd.domain.models import EvidenceLink
+from apd.domain.models import EvidenceRelationship
+from apd.domain.models import EvidenceTargetType
+from apd.domain.models import ReviewNote
+from apd.domain.models import ReviewStatus
+from apd.domain.models import ReviewTargetType
+from apd.domain.models import Run
+from apd.domain.models import RunPhase
+from apd.domain.models import Source
+from apd.domain.models import Theme
+from apd.domain.models import ValidationGate
+from apd.domain.models import ValidationGateStatus
+
+
+def _engine_for(tmp_path):
+    return create_engine(f"sqlite+pysqlite:///{tmp_path / 'model_graph.db'}", future=True)
+
+
+def test_minimal_research_run_graph(tmp_path) -> None:
+    engine = _engine_for(tmp_path)
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        run = Run(
+            title="Customer support handoff bottleneck",
+            intent="Understand repeated pain in support escalation workflows",
+            phase=RunPhase.EVIDENCE_COLLECTED,
+        )
+        session.add(run)
+        session.flush()
+
+        source = Source(
+            run_id=run.id,
+            source_type="url",
+            title="Community thread",
+            url="https://example.com/thread/1",
+        )
+        session.add(source)
+        session.flush()
+
+        excerpt = EvidenceExcerpt(
+            run_id=run.id,
+            source_id=source.id,
+            excerpt_text="We lose context every time support escalates to engineering.",
+            excerpt_type="complaint",
+        )
+        session.add(excerpt)
+
+        claim = Claim(
+            run_id=run.id,
+            statement="Escalation context loss creates repeated customer frustration.",
+            claim_type="pain",
+            created_by="agent",
+            is_agent_generated=True,
+        )
+        session.add(claim)
+        session.flush()
+
+        theme = Theme(
+            run_id=run.id,
+            name="Escalation context loss",
+            summary="Critical data is dropped between teams.",
+        )
+        session.add(theme)
+
+        candidate = Candidate(
+            run_id=run.id,
+            title="Support-to-engineering handoff brief",
+            summary="Generate a compact handoff packet before escalation.",
+            first_workflow="Tier-1 to engineering escalation",
+            first_wedge="Auto-compiled issue context",
+            is_agent_generated=True,
+        )
+        session.add(candidate)
+        session.flush()
+
+        link = EvidenceLink(
+            run_id=run.id,
+            source_id=source.id,
+            excerpt_id=excerpt.id,
+            target_type=EvidenceTargetType.CLAIM,
+            target_id=claim.id,
+            relationship_type=EvidenceRelationship.SUPPORTS,
+        )
+        session.add(link)
+
+        gate = ValidationGate(
+            run_id=run.id,
+            candidate_id=candidate.id,
+            phase=RunPhase.SUPPORTED_OPPORTUNITY,
+            name="Confirm buyer urgency",
+            status=ValidationGateStatus.NOT_STARTED,
+            blocking=True,
+        )
+        session.add(gate)
+
+        note = ReviewNote(
+            run_id=run.id,
+            target_type=ReviewTargetType.CLAIM,
+            target_id=claim.id,
+            author="human-reviewer",
+            note="Need at least two additional sources before accepting this claim.",
+        )
+        session.add(note)
+
+        decision = Decision(
+            run_id=run.id,
+            target_type=DecisionTargetType.RUN,
+            target_id=run.id,
+            decision=DecisionValue.WATCH,
+            rationale="Evidence is promising but still thin.",
+            decided_by="human-reviewer",
+        )
+        session.add(decision)
+
+        artifact = Artifact(
+            run_id=run.id,
+            candidate_id=candidate.id,
+            artifact_type="discovery_summary",
+            title="Escalation run summary",
+            path="artifacts/runs/demo/summary.md",
+            created_by="agent",
+        )
+        session.add(artifact)
+
+        session.commit()
+
+    with Session(engine) as session:
+        saved_run = session.scalar(select(Run).where(Run.title == "Customer support handoff bottleneck"))
+        assert saved_run is not None
+        assert len(saved_run.sources) == 1
+        assert len(saved_run.claims) == 1
+        assert len(saved_run.themes) == 1
+        assert len(saved_run.candidates) == 1
+        assert len(saved_run.validation_gates) == 1
+        assert len(saved_run.review_notes) == 1
+        assert len(saved_run.decisions) == 1
+        assert len(saved_run.artifacts) == 1
+
+        saved_claim = saved_run.claims[0]
+        saved_candidate = saved_run.candidates[0]
+        assert saved_claim.review_status == ReviewStatus.UNREVIEWED
+        assert saved_candidate.review_status == ReviewStatus.UNREVIEWED
+        assert saved_claim.is_agent_generated is True
+        assert saved_candidate.is_agent_generated is True
+
+
+def test_decision_history_is_durable(tmp_path) -> None:
+    engine = _engine_for(tmp_path)
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        run = Run(title="Decision timeline test")
+        session.add(run)
+        session.flush()
+
+        session.add(
+            Decision(
+                run_id=run.id,
+                target_type=DecisionTargetType.RUN,
+                target_id=run.id,
+                decision=DecisionValue.WATCH,
+                decided_by="reviewer",
+            )
+        )
+        session.add(
+            Decision(
+                run_id=run.id,
+                target_type=DecisionTargetType.RUN,
+                target_id=run.id,
+                decision=DecisionValue.PROTOTYPE_LATER,
+                decided_by="reviewer",
+            )
+        )
+        session.commit()
+
+    with Session(engine) as session:
+        run = session.scalar(select(Run).where(Run.title == "Decision timeline test"))
+        assert run is not None
+        assert len(run.decisions) == 2
+        assert [entry.decision for entry in run.decisions] == [
+            DecisionValue.WATCH,
+            DecisionValue.PROTOTYPE_LATER,
+        ]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+
+EXPECTED_TABLES = {
+    "runs",
+    "sources",
+    "evidence_excerpts",
+    "claims",
+    "themes",
+    "candidates",
+    "evidence_links",
+    "validation_gates",
+    "review_notes",
+    "decisions",
+    "artifacts",
+}
+
+
+def test_alembic_upgrade_from_clean_sqlite(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "migrated.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+
+    monkeypatch.setenv("APD_DATABASE_URL", db_url)
+
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", db_url)
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(db_url, future=True)
+    inspector = inspect(engine)
+    tables = set(inspector.get_table_names())
+
+    assert EXPECTED_TABLES.issubset(tables)


### PR DESCRIPTION
﻿## Summary

Implements APD milestone-2 core structured domain model and first migration on top of the issue #4 app skeleton.

This PR adds SQLAlchemy models and an initial Alembic schema for:
- Run
- Source
- EvidenceExcerpt
- Claim
- Theme
- Candidate
- EvidenceLink
- ValidationGate
- ReviewNote
- Decision
- Artifact

It keeps focus on local data model and migrations only.

Refs #5

## Scope Guardrails

- No UI/routes beyond existing skeleton
- No fixture seeding/importers/exporters/scrapers/workers
- No Postgres/Docker/deployment/auth/frontend additions
- No mutation of existing research-corpus or artifacts run directories

## What Changed

- Added SQLAlchemy enums and mapped models in `apd/domain/models.py`
- Added relationships for minimal research-run graph and evidence traceability
- Added durable `decisions` table so decision history is preserved
- Added initial Alembic revision creating all core schema tables
- Added tests for migration-from-clean DB and minimal run graph creation
- Wired model module imports into DB/Alembic metadata registration

## Files Changed

- `alembic/env.py`
- `alembic/versions/20260427_0001_initial_core_schema.py`
- `apd/app/db.py`
- `apd/domain/__init__.py`
- `apd/domain/models.py`
- `tests/conftest.py`
- `tests/test_domain_model_graph.py`
- `tests/test_migrations.py`

## Verification

```powershell
./scripts/test.ps1
python scripts/check_repo_readiness.py
$env:APD_DATABASE_URL='sqlite+pysqlite:///./.local/apd_issue5_verify.db'
if (Test-Path ./.local/apd_issue5_verify.db) { Remove-Item ./.local/apd_issue5_verify.db -Force }
uv run alembic upgrade head
uv run python -c "from sqlalchemy import create_engine, inspect; e=create_engine('sqlite+pysqlite:///./.local/apd_issue5_verify.db'); print('TABLES=' + ','.join(sorted(inspect(e).get_table_names())))"
uv run alembic downgrade base
uv run alembic upgrade head
```

Results:
- `./scripts/test.ps1`: PASS (`8 passed`)
- `python scripts/check_repo_readiness.py`: PASS (`READY Repo contains the required bootstrap files and directories.`)
- `uv run alembic upgrade head`: PASS
- Table check output: `alembic_version, artifacts, candidates, claims, decisions, evidence_excerpts, evidence_links, review_notes, runs, sources, themes, validation_gates`
- `uv run alembic downgrade base`: PASS
- `uv run alembic upgrade head` (again): PASS

## Schema Notes / Simplifications

- Implemented polymorphic links with `target_type` + `target_id` for `EvidenceLink`, `ReviewNote`, and `Decision` as allowed in `docs/data-model.md` MVP simplifications.
- Deferred explicit many-to-many join tables between claims/themes/candidates to a later issue; traceability currently flows through `EvidenceLink`.
- Added `is_agent_generated` on claims/candidates to support draft-first handling alongside `review_status=unreviewed` defaults.

## Risks / Follow-ups

- `target_type` + `target_id` polymorphic links are flexible but not fully DB-level foreign-key constrained to target tables; future hardening may add stricter integrity patterns.
- Domain service/repository layer and seed fixtures remain for later issues.
