### PR TITLE
Issue #6: Add deterministic fixture run and seed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,25 @@ Then open `http://127.0.0.1:8000/health` and expect:
 ```json
 {"status":"ok"}
 ```
+
+### Seed deterministic fixture data (issue #6)
+
+Seed one synthetic fixture run for local demos/tests:
+
+```text
+uv run python scripts/seed_fixture.py
+```
+
+The command is idempotent by default and will not duplicate fixture records.
+
+To explicitly reset fixture-owned records and reseed:
+
+```text
+uv run python scripts/seed_fixture.py --reset-fixture
+```
+
+To remove fixture-owned records only, without reseeding:
+
+```text
+uv run python scripts/seed_fixture.py --reset-only
+```

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,7 @@
 [alembic]
 script_location = alembic
 prepend_sys_path = .
+path_separator = os
 sqlalchemy.url = sqlite+pysqlite:///./.local/apd.db
 
 [loggers]

--- a/apd/domain/models.py
+++ b/apd/domain/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import timezone
 from enum import StrEnum
 from typing import Optional
 
@@ -13,7 +14,7 @@ from apd.app.db import Base
 
 
 def _utc_now() -> datetime:
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 class RunPhase(StrEnum):

--- a/apd/fixtures/__init__.py
+++ b/apd/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic fixture data utilities for APD local development."""

--- a/apd/fixtures/seed.py
+++ b/apd/fixtures/seed.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from apd.domain.models import Artifact
+from apd.domain.models import Candidate
+from apd.domain.models import Claim
+from apd.domain.models import Decision
+from apd.domain.models import DecisionTargetType
+from apd.domain.models import DecisionValue
+from apd.domain.models import EvidenceExcerpt
+from apd.domain.models import EvidenceLink
+from apd.domain.models import EvidenceRelationship
+from apd.domain.models import EvidenceTargetType
+from apd.domain.models import ReviewNote
+from apd.domain.models import ReviewStatus
+from apd.domain.models import ReviewTargetType
+from apd.domain.models import Run
+from apd.domain.models import RunPhase
+from apd.domain.models import Source
+from apd.domain.models import Theme
+from apd.domain.models import ValidationGate
+from apd.domain.models import ValidationGateStatus
+
+FIXTURE_ID = "apd_demo_solo_self_hosted_v1"
+FIXTURE_TITLE = "Fixture Demo: Solo builders deploying self-hosted apps"
+FIXTURE_MODE = "fixture_demo"
+FIXTURE_INTENT = "Synthetic fixture/demo data for APD local cockpit dogfooding."
+
+
+@dataclass(frozen=True)
+class SeedResult:
+    created: bool
+    run_id: int | None
+    run_count: int
+    source_count: int
+    excerpt_count: int
+    claim_count: int
+    theme_count: int
+    candidate_count: int
+    evidence_link_count: int
+    validation_gate_count: int
+    review_note_count: int
+    decision_count: int
+    artifact_count: int
+
+
+@dataclass(frozen=True)
+class ResetResult:
+    removed_runs: int
+
+
+def _dt(year: int, month: int, day: int, hour: int, minute: int) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def _fixture_run_query():
+    return select(Run).where(Run.title == FIXTURE_TITLE, Run.mode == FIXTURE_MODE)
+
+
+def _count_for_run(session: Session, run_id: int) -> SeedResult:
+    source_count = session.scalar(select(func.count()).select_from(Source).where(Source.run_id == run_id)) or 0
+    excerpt_count = session.scalar(select(func.count()).select_from(EvidenceExcerpt).where(EvidenceExcerpt.run_id == run_id)) or 0
+    claim_count = session.scalar(select(func.count()).select_from(Claim).where(Claim.run_id == run_id)) or 0
+    theme_count = session.scalar(select(func.count()).select_from(Theme).where(Theme.run_id == run_id)) or 0
+    candidate_count = session.scalar(select(func.count()).select_from(Candidate).where(Candidate.run_id == run_id)) or 0
+    evidence_link_count = session.scalar(select(func.count()).select_from(EvidenceLink).where(EvidenceLink.run_id == run_id)) or 0
+    validation_gate_count = (
+        session.scalar(select(func.count()).select_from(ValidationGate).where(ValidationGate.run_id == run_id)) or 0
+    )
+    review_note_count = session.scalar(select(func.count()).select_from(ReviewNote).where(ReviewNote.run_id == run_id)) or 0
+    decision_count = session.scalar(select(func.count()).select_from(Decision).where(Decision.run_id == run_id)) or 0
+    artifact_count = session.scalar(select(func.count()).select_from(Artifact).where(Artifact.run_id == run_id)) or 0
+
+    return SeedResult(
+        created=False,
+        run_id=run_id,
+        run_count=1,
+        source_count=source_count,
+        excerpt_count=excerpt_count,
+        claim_count=claim_count,
+        theme_count=theme_count,
+        candidate_count=candidate_count,
+        evidence_link_count=evidence_link_count,
+        validation_gate_count=validation_gate_count,
+        review_note_count=review_note_count,
+        decision_count=decision_count,
+        artifact_count=artifact_count,
+    )
+
+
+def reset_fixture_data(session: Session) -> ResetResult:
+    fixture_runs = session.scalars(_fixture_run_query()).all()
+    removed = 0
+    for run in fixture_runs:
+        session.delete(run)
+        removed += 1
+    session.flush()
+    return ResetResult(removed_runs=removed)
+
+
+def seed_fixture_data(session: Session, *, reset_fixture: bool = False) -> SeedResult:
+    if reset_fixture:
+        reset_fixture_data(session)
+
+    existing = session.scalar(_fixture_run_query().limit(1))
+    if existing is not None:
+        return _count_for_run(session, existing.id)
+
+    run = Run(
+        title=FIXTURE_TITLE,
+        intent=FIXTURE_INTENT,
+        summary=(
+            "Synthetic fixture run that explores opportunities for solo builders shipping "
+            "self-hosted application workflows."
+        ),
+        mode=FIXTURE_MODE,
+        phase=RunPhase.SUPPORTED_OPPORTUNITY,
+        current_decision=DecisionValue.WATCH,
+        recommendation=(
+            "Prioritize narrow onboarding and update-safety workflows before broader platform expansion."
+        ),
+        confidence=0.64,
+        created_at=_dt(2026, 4, 26, 9, 0),
+        updated_at=_dt(2026, 4, 26, 9, 45),
+        metadata_json={
+            "fixture_id": FIXTURE_ID,
+            "is_fixture": True,
+            "data_origin": "synthetic_demo",
+        },
+    )
+    session.add(run)
+    session.flush()
+
+    sources = [
+        Source(
+            run_id=run.id,
+            title="Ops forum thread: midnight rollback fatigue",
+            source_type="demo_forum_thread",
+            url="https://demo.local/forum/self-hosted-rollbacks",
+            origin="fixture-demo",
+            author_or_org="Synthetic Ops Forum",
+            captured_at=_dt(2026, 4, 20, 11, 0),
+            published_at=_dt(2026, 4, 19, 21, 30),
+            reliability_notes="Synthetic fixture source for deterministic local tests.",
+            summary="Solo maintainers report repeated downtime from manual rollback runbooks.",
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Source(
+            run_id=run.id,
+            title="Indie deploy log review notes",
+            source_type="demo_interview_note",
+            url="https://demo.local/interviews/indie-deploy-log",
+            origin="fixture-demo",
+            author_or_org="Synthetic Interview Set",
+            captured_at=_dt(2026, 4, 21, 15, 15),
+            published_at=_dt(2026, 4, 21, 15, 0),
+            reliability_notes="Synthetic fixture interview abstraction.",
+            summary="Maintainers lose confidence when updates lack a safe preview and rollback checkpoint.",
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Source(
+            run_id=run.id,
+            title="Community issue list: self-hosted support load",
+            source_type="demo_issue_collection",
+            url="https://demo.local/issues/self-hosted-support",
+            origin="fixture-demo",
+            author_or_org="Synthetic Community Issues",
+            captured_at=_dt(2026, 4, 22, 8, 0),
+            published_at=_dt(2026, 4, 22, 7, 20),
+            reliability_notes="Synthetic fixture issue compilation.",
+            summary="Support burden spikes when install docs drift from deploy script behavior.",
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+    ]
+    session.add_all(sources)
+    session.flush()
+
+    excerpts = [
+        EvidenceExcerpt(
+            run_id=run.id,
+            source_id=sources[0].id,
+            excerpt_text="I cannot risk updates after 10pm because rollback is guesswork.",
+            location_reference="post-14",
+            excerpt_type="complaint",
+            created_at=_dt(2026, 4, 20, 11, 5),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceExcerpt(
+            run_id=run.id,
+            source_id=sources[0].id,
+            excerpt_text="The moment compose files diverge, recovery instructions become stale.",
+            location_reference="post-22",
+            excerpt_type="workaround",
+            created_at=_dt(2026, 4, 20, 11, 8),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceExcerpt(
+            run_id=run.id,
+            source_id=sources[1].id,
+            excerpt_text="Previewing diffed environment variables before deploy would avoid most incidents.",
+            location_reference="note-03",
+            excerpt_type="feature_request",
+            created_at=_dt(2026, 4, 21, 15, 17),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceExcerpt(
+            run_id=run.id,
+            source_id=sources[1].id,
+            excerpt_text="Most solo maintainers patch rollback scripts only after a production outage.",
+            location_reference="note-07",
+            excerpt_type="context",
+            created_at=_dt(2026, 4, 21, 15, 19),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceExcerpt(
+            run_id=run.id,
+            source_id=sources[2].id,
+            excerpt_text="Broken onboarding docs increase support tickets by day two of each release.",
+            location_reference="issue-112",
+            excerpt_type="adoption_signal",
+            created_at=_dt(2026, 4, 22, 8, 3),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceExcerpt(
+            run_id=run.id,
+            source_id=sources[2].id,
+            excerpt_text="Some teams still prefer shell scripts over control-plane tooling for transparency.",
+            location_reference="issue-129",
+            excerpt_type="counterevidence",
+            created_at=_dt(2026, 4, 22, 8, 6),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+    ]
+    session.add_all(excerpts)
+    session.flush()
+
+    claims = [
+        Claim(
+            run_id=run.id,
+            statement="Update anxiety is driven by weak rollback confidence in solo-run environments.",
+            claim_type="pain",
+            review_status=ReviewStatus.UNREVIEWED,
+            created_by="fixture-agent",
+            is_agent_generated=True,
+            confidence=0.73,
+            created_at=_dt(2026, 4, 26, 9, 5),
+            updated_at=_dt(2026, 4, 26, 9, 5),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Claim(
+            run_id=run.id,
+            statement="Pre-deploy configuration diff previews can prevent avoidable outages.",
+            claim_type="workflow",
+            review_status=ReviewStatus.ACCEPTED,
+            created_by="fixture-reviewer",
+            is_agent_generated=False,
+            confidence=0.69,
+            created_at=_dt(2026, 4, 26, 9, 10),
+            updated_at=_dt(2026, 4, 26, 9, 12),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Claim(
+            run_id=run.id,
+            statement="Documentation drift is a recurring support burden after each release.",
+            claim_type="risk",
+            review_status=ReviewStatus.WEAK,
+            created_by="fixture-agent",
+            is_agent_generated=True,
+            confidence=0.52,
+            created_at=_dt(2026, 4, 26, 9, 15),
+            updated_at=_dt(2026, 4, 26, 9, 16),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Claim(
+            run_id=run.id,
+            statement="Operators need a narrow first workflow, not a full control-plane replacement.",
+            claim_type="market_gap",
+            review_status=ReviewStatus.ACCEPTED,
+            created_by="fixture-reviewer",
+            is_agent_generated=False,
+            confidence=0.71,
+            created_at=_dt(2026, 4, 26, 9, 18),
+            updated_at=_dt(2026, 4, 26, 9, 20),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Claim(
+            run_id=run.id,
+            statement="Some users may reject tooling that obscures plain compose workflows.",
+            claim_type="counterevidence",
+            review_status=ReviewStatus.DISPUTED,
+            created_by="fixture-reviewer",
+            is_agent_generated=False,
+            confidence=0.48,
+            created_at=_dt(2026, 4, 26, 9, 22),
+            updated_at=_dt(2026, 4, 26, 9, 24),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+    ]
+    session.add_all(claims)
+    session.flush()
+
+    themes = [
+        Theme(
+            run_id=run.id,
+            name="Rollback confidence gap",
+            summary="Solo operators need predictable rollback checkpoints before applying updates.",
+            theme_type="pain_theme",
+            review_status=ReviewStatus.ACCEPTED,
+            created_at=_dt(2026, 4, 26, 9, 25),
+            updated_at=_dt(2026, 4, 26, 9, 25),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Theme(
+            run_id=run.id,
+            name="Documentation drift burden",
+            summary="Install and update docs diverge from actual release steps, increasing support load.",
+            theme_type="workflow_theme",
+            review_status=ReviewStatus.UNREVIEWED,
+            created_at=_dt(2026, 4, 26, 9, 26),
+            updated_at=_dt(2026, 4, 26, 9, 26),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+    ]
+    session.add_all(themes)
+    session.flush()
+
+    candidates = [
+        Candidate(
+            run_id=run.id,
+            title="Release Guardrails Assistant",
+            summary="A narrow pre-deploy checklist and rollback checkpoint generator for solo maintainers.",
+            target_user="Solo maintainers of self-hosted apps",
+            first_workflow="Pre-release update preparation",
+            first_wedge="Rollback plan snapshot plus config diff preview",
+            prototype_success_event="Maintainer completes update with no manual rollback guesswork.",
+            monetization_path="Monthly subscription for advanced guardrail templates",
+            risks="Could be viewed as redundant with shell script discipline",
+            review_status=ReviewStatus.UNREVIEWED,
+            is_agent_generated=True,
+            score=0.78,
+            rank=1,
+            created_at=_dt(2026, 4, 26, 9, 28),
+            updated_at=_dt(2026, 4, 26, 9, 28),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        Candidate(
+            run_id=run.id,
+            title="Self-Hosted Docs Drift Monitor",
+            summary="Detect release-note and setup-doc mismatches before users hit onboarding issues.",
+            target_user="Solo founders shipping frequent self-hosted releases",
+            first_workflow="Release documentation validation",
+            first_wedge="Checklist report highlighting docs-vs-config drift",
+            prototype_success_event="Support tickets caused by stale setup docs drop after release.",
+            monetization_path="Lower-cost tier tied to release frequency",
+            risks="May require deeper integration than early adopters want",
+            review_status=ReviewStatus.UNREVIEWED,
+            is_agent_generated=True,
+            score=0.66,
+            rank=2,
+            created_at=_dt(2026, 4, 26, 9, 30),
+            updated_at=_dt(2026, 4, 26, 9, 30),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+    ]
+    session.add_all(candidates)
+    session.flush()
+
+    validation_gates = [
+        ValidationGate(
+            run_id=run.id,
+            candidate_id=candidates[0].id,
+            phase=RunPhase.SUPPORTED_OPPORTUNITY,
+            name="Confirm willingness to pay",
+            description="Interview at least three operators who have experienced failed rollbacks.",
+            status=ValidationGateStatus.NOT_STARTED,
+            blocking=True,
+            missing_evidence="No direct willingness-to-pay evidence in fixture set yet.",
+            created_at=_dt(2026, 4, 26, 9, 33),
+            updated_at=_dt(2026, 4, 26, 9, 33),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        ValidationGate(
+            run_id=run.id,
+            candidate_id=candidates[1].id,
+            phase=RunPhase.SUPPORTED_OPPORTUNITY,
+            name="Validate docs drift frequency",
+            description="Collect repeated examples across at least five release cycles.",
+            status=ValidationGateStatus.WEAK,
+            blocking=False,
+            evidence_summary="Some weak evidence exists, but breadth is low.",
+            created_at=_dt(2026, 4, 26, 9, 34),
+            updated_at=_dt(2026, 4, 26, 9, 34),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+    ]
+    session.add_all(validation_gates)
+    session.flush()
+
+    session.add(
+        ReviewNote(
+            run_id=run.id,
+            target_type=ReviewTargetType.CLAIM,
+            target_id=claims[2].id,
+            author="fixture-reviewer",
+            note="Treat this as weak until cross-community corroboration exists.",
+            created_at=_dt(2026, 4, 26, 9, 36),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        )
+    )
+
+    session.add(
+        Decision(
+            run_id=run.id,
+            target_type=DecisionTargetType.RUN,
+            target_id=run.id,
+            decision=DecisionValue.WATCH,
+            rationale="Opportunity looks promising but requires stronger buyer and payment evidence.",
+            decided_by="fixture-reviewer",
+            decided_at=_dt(2026, 4, 26, 9, 40),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        )
+    )
+
+    session.add(
+        Artifact(
+            run_id=run.id,
+            candidate_id=candidates[0].id,
+            artifact_type="discovery_summary",
+            title="Fixture run summary",
+            path="fixtures/demo/solo-self-hosted-summary.md",
+            created_by="fixture-agent",
+            created_at=_dt(2026, 4, 26, 9, 42),
+            summary="Synthetic summary artifact for local app demos and screenshots.",
+            metadata_json={"fixture_id": FIXTURE_ID, "synthetic": True},
+        )
+    )
+
+    evidence_links = [
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[0].id,
+            excerpt_id=excerpts[0].id,
+            target_type=EvidenceTargetType.CLAIM,
+            target_id=claims[0].id,
+            relationship_type=EvidenceRelationship.SUPPORTS,
+            notes="Rollback anxiety directly supports core pain claim.",
+            created_at=_dt(2026, 4, 26, 9, 31),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[1].id,
+            excerpt_id=excerpts[2].id,
+            target_type=EvidenceTargetType.CLAIM,
+            target_id=claims[1].id,
+            relationship_type=EvidenceRelationship.SUPPORTS,
+            created_at=_dt(2026, 4, 26, 9, 31),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[2].id,
+            excerpt_id=excerpts[4].id,
+            target_type=EvidenceTargetType.CLAIM,
+            target_id=claims[2].id,
+            relationship_type=EvidenceRelationship.SUPPORTS,
+            created_at=_dt(2026, 4, 26, 9, 31),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[2].id,
+            excerpt_id=excerpts[5].id,
+            target_type=EvidenceTargetType.CLAIM,
+            target_id=claims[4].id,
+            relationship_type=EvidenceRelationship.SUPPORTS,
+            created_at=_dt(2026, 4, 26, 9, 31),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[0].id,
+            excerpt_id=excerpts[1].id,
+            target_type=EvidenceTargetType.THEME,
+            target_id=themes[0].id,
+            relationship_type=EvidenceRelationship.EXAMPLE_OF,
+            created_at=_dt(2026, 4, 26, 9, 32),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[2].id,
+            excerpt_id=excerpts[4].id,
+            target_type=EvidenceTargetType.THEME,
+            target_id=themes[1].id,
+            relationship_type=EvidenceRelationship.EXAMPLE_OF,
+            created_at=_dt(2026, 4, 26, 9, 32),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[1].id,
+            excerpt_id=excerpts[2].id,
+            target_type=EvidenceTargetType.CANDIDATE,
+            target_id=candidates[0].id,
+            relationship_type=EvidenceRelationship.SUPPORTS,
+            created_at=_dt(2026, 4, 26, 9, 32),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[2].id,
+            excerpt_id=excerpts[4].id,
+            target_type=EvidenceTargetType.CANDIDATE,
+            target_id=candidates[1].id,
+            relationship_type=EvidenceRelationship.SUPPORTS,
+            created_at=_dt(2026, 4, 26, 9, 32),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+        EvidenceLink(
+            run_id=run.id,
+            source_id=sources[1].id,
+            excerpt_id=excerpts[3].id,
+            target_type=EvidenceTargetType.VALIDATION_GATE,
+            target_id=validation_gates[0].id,
+            relationship_type=EvidenceRelationship.CONTEXT_FOR,
+            created_at=_dt(2026, 4, 26, 9, 32),
+            metadata_json={"fixture_id": FIXTURE_ID},
+        ),
+    ]
+    session.add_all(evidence_links)
+
+    run.source_count = len(sources)
+    run.claim_count = len(claims)
+    run.theme_count = len(themes)
+    run.candidate_count = len(candidates)
+    run.updated_at = _dt(2026, 4, 26, 9, 45)
+
+    session.flush()
+
+    counts = _count_for_run(session, run.id)
+    return SeedResult(
+        created=True,
+        run_id=counts.run_id,
+        run_count=counts.run_count,
+        source_count=counts.source_count,
+        excerpt_count=counts.excerpt_count,
+        claim_count=counts.claim_count,
+        theme_count=counts.theme_count,
+        candidate_count=counts.candidate_count,
+        evidence_link_count=counts.evidence_link_count,
+        validation_gate_count=counts.validation_gate_count,
+        review_note_count=counts.review_note_count,
+        decision_count=counts.decision_count,
+        artifact_count=counts.artifact_count,
+    )

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,6 +71,18 @@ To inspect and optionally clean empty leftover run folders:
 python scripts/clean_empty_run_dirs.py --dry-run
 ```
 
+To seed deterministic APD fixture/demo data into the configured local database:
+
+```text
+python scripts/seed_fixture.py
+```
+
+To explicitly reset fixture-owned data and reseed:
+
+```text
+python scripts/seed_fixture.py --reset-fixture
+```
+
 The cleanup utility is intentionally conservative:
 
 - it removes only truly empty nested run directories

--- a/scripts/seed_fixture.py
+++ b/scripts/seed_fixture.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+
+from apd.app.db import SessionLocal
+from apd.fixtures.seed import FIXTURE_ID
+from apd.fixtures.seed import reset_fixture_data
+from apd.fixtures.seed import seed_fixture_data
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed deterministic APD fixture data into the local database.")
+    parser.add_argument(
+        "--reset-fixture",
+        action="store_true",
+        help="Delete existing fixture-owned records first, then reseed fixture data.",
+    )
+    parser.add_argument(
+        "--reset-only",
+        action="store_true",
+        help="Delete fixture-owned records and exit without reseeding.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+
+    with SessionLocal() as session:
+        if args.reset_only:
+            reset_result = reset_fixture_data(session)
+            session.commit()
+            print(f"fixture_id={FIXTURE_ID} removed_runs={reset_result.removed_runs}")
+            return 0
+
+        seed_result = seed_fixture_data(session, reset_fixture=args.reset_fixture)
+        session.commit()
+
+    print(
+        " ".join(
+            [
+                f"fixture_id={FIXTURE_ID}",
+                f"created={seed_result.created}",
+                f"run_id={seed_result.run_id}",
+                f"runs={seed_result.run_count}",
+                f"sources={seed_result.source_count}",
+                f"excerpts={seed_result.excerpt_count}",
+                f"claims={seed_result.claim_count}",
+                f"themes={seed_result.theme_count}",
+                f"candidates={seed_result.candidate_count}",
+                f"evidence_links={seed_result.evidence_link_count}",
+                f"validation_gates={seed_result.validation_gate_count}",
+                f"review_notes={seed_result.review_note_count}",
+                f"decisions={seed_result.decision_count}",
+                f"artifacts={seed_result.artifact_count}",
+            ]
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alembic_config.py
+++ b/tests/test_alembic_config.py
@@ -7,6 +7,7 @@ def test_alembic_config_is_sane() -> None:
     cfg = Config("alembic.ini")
 
     assert cfg.get_main_option("script_location") == "alembic"
+    assert cfg.get_main_option("path_separator") == "os"
     assert cfg.get_main_option("sqlalchemy.url").startswith("sqlite")
     assert Path("alembic/env.py").is_file()
     assert Path("alembic/versions").is_dir()

--- a/tests/test_fixture_seed.py
+++ b/tests/test_fixture_seed.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from apd.app.db import Base
+from apd.domain.models import Artifact
+from apd.domain.models import Candidate
+from apd.domain.models import Claim
+from apd.domain.models import Decision
+from apd.domain.models import EvidenceExcerpt
+from apd.domain.models import EvidenceLink
+from apd.domain.models import ReviewNote
+from apd.domain.models import Run
+from apd.domain.models import Source
+from apd.domain.models import Theme
+from apd.domain.models import ValidationGate
+from apd.fixtures.seed import seed_fixture_data
+
+
+def _count(session: Session, model) -> int:
+    return session.scalar(select(func.count()).select_from(model)) or 0
+
+
+def test_fixture_seed_creates_expected_graph(tmp_path) -> None:
+    engine = create_engine(f"sqlite+pysqlite:///{tmp_path / 'fixture_seed.db'}", future=True)
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        result = seed_fixture_data(session)
+        session.commit()
+
+        assert result.created is True
+        assert result.run_count == 1
+        assert result.source_count >= 3
+        assert result.excerpt_count >= 6
+        assert result.claim_count >= 5
+        assert result.theme_count >= 2
+        assert result.candidate_count >= 2
+        assert result.evidence_link_count >= 1
+        assert result.validation_gate_count >= 1
+        assert result.decision_count >= 1
+        assert result.artifact_count >= 1
+
+        assert _count(session, Run) == 1
+        assert _count(session, Source) >= 3
+        assert _count(session, EvidenceExcerpt) >= 6
+        assert _count(session, Claim) >= 5
+        assert _count(session, Theme) >= 2
+        assert _count(session, Candidate) >= 2
+        assert _count(session, EvidenceLink) >= 1
+        assert _count(session, ValidationGate) >= 1
+        assert _count(session, ReviewNote) >= 1
+        assert _count(session, Decision) >= 1
+        assert _count(session, Artifact) >= 1
+
+
+def test_fixture_seed_is_idempotent_and_resettable(tmp_path) -> None:
+    engine = create_engine(f"sqlite+pysqlite:///{tmp_path / 'fixture_idempotent.db'}", future=True)
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        first = seed_fixture_data(session)
+        session.commit()
+
+        second = seed_fixture_data(session)
+        session.commit()
+
+        assert first.created is True
+        assert second.created is False
+        assert second.run_count == 1
+        assert _count(session, Run) == 1
+
+        third = seed_fixture_data(session, reset_fixture=True)
+        session.commit()
+
+        assert third.created is True
+        assert _count(session, Run) == 1
+        assert _count(session, Source) == third.source_count
+        assert _count(session, EvidenceExcerpt) == third.excerpt_count
+        assert _count(session, Claim) == third.claim_count
+
+
+def test_fixture_reset_does_not_delete_user_runs(tmp_path) -> None:
+    engine = create_engine(f"sqlite+pysqlite:///{tmp_path / 'fixture_reset_scope.db'}", future=True)
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        seed_fixture_data(session)
+        session.add(Run(title="User-created local run", mode="manual"))
+        session.commit()
+
+        reseed = seed_fixture_data(session, reset_fixture=True)
+        session.commit()
+
+        assert reseed.created is True
+        assert _count(session, Run) == 2
+        user_run = session.scalar(select(Run).where(Run.title == "User-created local run"))
+        assert user_run is not None


### PR DESCRIPTION
﻿## Summary

Adds deterministic APD fixture/demo data and a safe local seed command for issue #6.

Also fixes two warnings found during issue #5 verification:
- Replaced deprecated `datetime.utcnow()` usage with timezone-aware UTC timestamps.
- Added `path_separator = os` in Alembic config.

Refs #6

## What Changed

- Added deterministic fixture module with one bounded demo run:
  - Topic: product opportunities around solo builders deploying self-hosted apps
  - Synthetic/demo records are explicitly labeled in metadata and source notes
- Added seed command (`scripts/seed_fixture.py`) that:
  - seeds fixture data into configured `APD_DATABASE_URL` (or default local SQLite)
  - is idempotent by default (repeat runs do not duplicate fixture records)
  - supports explicit fixture-only reset (`--reset-fixture`) and fixture-only removal (`--reset-only`)
- Added tests for fixture seeding and reset safety
- Updated docs for fixture seed usage
- Fixed warning sources in models and Alembic config

## Files Changed

- `alembic.ini`
- `apd/domain/models.py`
- `apd/fixtures/__init__.py`
- `apd/fixtures/seed.py`
- `scripts/README.md`
- `scripts/seed_fixture.py`
- `README.md`
- `tests/test_alembic_config.py`
- `tests/test_fixture_seed.py`

## Verification

```powershell
./scripts/test.ps1
python scripts/check_repo_readiness.py
$env:APD_DATABASE_URL='sqlite+pysqlite:///./.local/apd_issue6_verify.db'
if (Test-Path ./.local/apd_issue6_verify.db) { Remove-Item ./.local/apd_issue6_verify.db -Force }
uv run alembic upgrade head
uv run python scripts/seed_fixture.py
uv run python -c "from sqlalchemy import create_engine, select, func; from sqlalchemy.orm import Session; from apd.domain.models import Run,Source,EvidenceExcerpt,Claim,Theme,Candidate,EvidenceLink,ValidationGate,ReviewNote,Decision,Artifact,ReviewStatus; e=create_engine('sqlite+pysqlite:///./.local/apd_issue6_verify.db', future=True); s=Session(e); print('RUNS=' + str(s.scalar(select(func.count()).select_from(Run)))); print('SOURCES=' + str(s.scalar(select(func.count()).select_from(Source)))); print('EXCERPTS=' + str(s.scalar(select(func.count()).select_from(EvidenceExcerpt)))); print('CLAIMS=' + str(s.scalar(select(func.count()).select_from(Claim)))); print('THEMES=' + str(s.scalar(select(func.count()).select_from(Theme)))); print('CANDIDATES=' + str(s.scalar(select(func.count()).select_from(Candidate)))); print('EVIDENCE_LINKS=' + str(s.scalar(select(func.count()).select_from(EvidenceLink)))); print('VALIDATION_GATES=' + str(s.scalar(select(func.count()).select_from(ValidationGate)))); print('REVIEW_NOTES=' + str(s.scalar(select(func.count()).select_from(ReviewNote)))); print('DECISIONS=' + str(s.scalar(select(func.count()).select_from(Decision)))); print('ARTIFACTS=' + str(s.scalar(select(func.count()).select_from(Artifact)))); print('WEAK_OR_DISPUTED_CLAIMS=' + str(s.scalar(select(func.count()).select_from(Claim).where(Claim.review_status.in_([ReviewStatus.WEAK, ReviewStatus.DISPUTED]))))); s.close()"
uv run python scripts/seed_fixture.py
uv run python -c "from sqlalchemy import create_engine, select, func; from sqlalchemy.orm import Session; from apd.domain.models import Run,Source,EvidenceExcerpt,Claim,Theme,Candidate,EvidenceLink,ValidationGate,ReviewNote,Decision,Artifact; e=create_engine('sqlite+pysqlite:///./.local/apd_issue6_verify.db', future=True); s=Session(e); print('POST_RESEED_COUNTS=' + ','.join([str(s.scalar(select(func.count()).select_from(m))) for m in [Run,Source,EvidenceExcerpt,Claim,Theme,Candidate,EvidenceLink,ValidationGate,ReviewNote,Decision,Artifact]])); s.close()"
```

Results:
- `./scripts/test.ps1`: PASS (`11 passed`)
- `python scripts/check_repo_readiness.py`: PASS (`READY`)
- `uv run alembic upgrade head`: PASS on clean DB
- First seed: `created=True` with counts
  - runs=1, sources=3, excerpts=6, claims=5, themes=2, candidates=2, evidence_links=9, validation_gates=2, review_notes=1, decisions=1, artifacts=1
  - weak/disputed claims: 2
- Second seed: `created=False` and no count changes
  - post-reseed counts: `1,3,6,5,2,2,9,2,1,1,1`

## Warning Fix Status

- `datetime.utcnow()` deprecation warning: fixed by using timezone-aware UTC timestamps (`datetime.now(timezone.utc)`) in model defaults.
- Alembic `path_separator` warning: fixed by adding `path_separator = os` in `alembic.ini`.
- No remaining warnings were observed in the issue #6 verification commands.

## Scope Notes

- No UI, scraping, import/export pipeline, background workers, Postgres, Docker, deployment, or auth added.
- No mutation of existing `research-corpus/` or `artifacts/` run directories.
- Seed reset operations are explicit and fixture-scoped only.
