### PR TITLE
Issue #7: Add recent-runs and run-detail web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,28 @@ To remove fixture-owned records only, without reseeding:
 ```text
 uv run python scripts/seed_fixture.py --reset-only
 ```
+
+### View the local web UI (issue #7)
+
+After seeding fixture data, start the app and open the browser UI:
+
+```text
+uv run uvicorn apd.app.main:app --reload
+```
+
+Then open `http://127.0.0.1:8000/runs` in a browser.
+
+- `/runs` — recent-runs list. Shows each run's title, phase, decision, recommendation, source/claim/theme/candidate counts, and a link to its detail page. Fixture runs are labeled.
+- `/runs/{run_id}` — run detail page. Shows run intent, summary, recommendation, phase, decision, sources, claims (with review status), themes, candidates, validation gates, artifacts, and evidence traceability.
+- `/` — redirects to `/runs`.
+
+To seed and view the fixture run against a throwaway database:
+
+```text
+$env:APD_DATABASE_URL = "sqlite+pysqlite:///./.local/apd_demo.db"
+uv run alembic upgrade head
+uv run python scripts/seed_fixture.py
+uv run uvicorn apd.app.main:app --reload
+```
+
+Open `http://127.0.0.1:8000/runs` — the fixture run should appear. Click its title to open the run detail page.

--- a/apd/app/main.py
+++ b/apd/app/main.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from pathlib import Path
 
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from apd.web.routes import router as web_router
+
+_STATIC_DIR = Path(__file__).parent.parent / "web" / "static"
 
 app = FastAPI(title="APD Local App")
+app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+app.include_router(web_router)
 
 
 @app.get("/health")

--- a/apd/web/queries.py
+++ b/apd/web/queries.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from apd.domain.models import (
+    Artifact,
+    Candidate,
+    Claim,
+    Decision,
+    EvidenceLink,
+    ReviewNote,
+    Run,
+    Source,
+    Theme,
+    ValidationGate,
+)
+
+
+@dataclass
+class RunSummary:
+    run: Run
+    source_count: int
+    claim_count: int
+    theme_count: int
+    candidate_count: int
+
+
+def get_recent_runs(db: Session, limit: int = 50) -> list[RunSummary]:
+    stmt = (
+        select(Run)
+        .order_by(Run.updated_at.desc())
+        .limit(limit)
+    )
+    runs = db.execute(stmt).scalars().all()
+    result = []
+    for run in runs:
+        result.append(
+            RunSummary(
+                run=run,
+                source_count=run.source_count,
+                claim_count=run.claim_count,
+                theme_count=run.theme_count,
+                candidate_count=run.candidate_count,
+            )
+        )
+    return result
+
+
+def get_run_detail(db: Session, run_id: int) -> Optional[dict]:
+    run = db.get(Run, run_id)
+    if run is None:
+        return None
+
+    sources = db.execute(
+        select(Source).where(Source.run_id == run_id).order_by(Source.id)
+    ).scalars().all()
+
+    claims = db.execute(
+        select(Claim).where(Claim.run_id == run_id).order_by(Claim.id)
+    ).scalars().all()
+
+    themes = db.execute(
+        select(Theme).where(Theme.run_id == run_id).order_by(Theme.id)
+    ).scalars().all()
+
+    candidates = db.execute(
+        select(Candidate).where(Candidate.run_id == run_id).order_by(Candidate.rank.asc().nullslast(), Candidate.id)
+    ).scalars().all()
+
+    validation_gates = db.execute(
+        select(ValidationGate).where(ValidationGate.run_id == run_id).order_by(ValidationGate.id)
+    ).scalars().all()
+
+    artifacts = db.execute(
+        select(Artifact).where(Artifact.run_id == run_id).order_by(Artifact.id)
+    ).scalars().all()
+
+    evidence_links = db.execute(
+        select(EvidenceLink).where(EvidenceLink.run_id == run_id)
+    ).scalars().all()
+
+    review_notes = db.execute(
+        select(ReviewNote).where(ReviewNote.run_id == run_id).order_by(ReviewNote.id)
+    ).scalars().all()
+
+    # Build a source lookup by id for display
+    source_by_id = {s.id: s for s in sources}
+
+    # Build evidence link index: target_type -> target_id -> list of (source_title, rel_type)
+    evidence_index: dict[str, dict[int, list[dict]]] = {}
+    for link in evidence_links:
+        key = str(link.target_type)
+        evidence_index.setdefault(key, {}).setdefault(link.target_id, [])
+        src = source_by_id.get(link.source_id) if link.source_id else None
+        evidence_index[key][link.target_id].append({
+            "source_title": src.title if src else None,
+            "source_id": link.source_id,
+            "relationship_type": str(link.relationship_type),
+            "strength": str(link.strength) if link.strength else None,
+        })
+
+    is_fixture = bool(
+        run.metadata_json and run.metadata_json.get("is_fixture")
+    )
+
+    return {
+        "run": run,
+        "sources": sources,
+        "claims": claims,
+        "themes": themes,
+        "candidates": candidates,
+        "validation_gates": validation_gates,
+        "artifacts": artifacts,
+        "review_notes": review_notes,
+        "evidence_index": evidence_index,
+        "is_fixture": is_fixture,
+    }

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from apd.app.db import SessionLocal
+from apd.web.queries import get_recent_runs, get_run_detail
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+router = APIRouter()
+
+
+def _get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/", response_class=RedirectResponse, include_in_schema=False)
+def index():
+    return RedirectResponse(url="/runs")
+
+
+@router.get("/runs", response_class=HTMLResponse)
+def recent_runs(request: Request, db: Session = Depends(_get_db)):
+    runs = get_recent_runs(db)
+    return templates.TemplateResponse(
+        request,
+        "runs_list.html",
+        {"runs": runs},
+    )
+
+
+@router.get("/runs/{run_id}", response_class=HTMLResponse)
+def run_detail(run_id: int, request: Request, db: Session = Depends(_get_db)):
+    detail = get_run_detail(db, run_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return templates.TemplateResponse(
+        request,
+        "run_detail.html",
+        {"run": detail["run"], "detail": detail},
+    )

--- a/apd/web/static/style.css
+++ b/apd/web/static/style.css
@@ -1,0 +1,267 @@
+/* APD Local — minimal functional stylesheet */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #1a1a1a;
+  background: #f7f7f7;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  background: #1e293b;
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  height: 48px;
+}
+
+.nav-brand {
+  color: #e2e8f0;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.nav-brand:hover { color: #fff; }
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  color: #94a3b8;
+  font-size: 0.8rem;
+}
+
+/* breadcrumb */
+.breadcrumb {
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+  color: #64748b;
+}
+.breadcrumb a { color: #3b82f6; text-decoration: none; }
+.breadcrumb a:hover { text-decoration: underline; }
+
+/* page header */
+.page-header { margin-bottom: 1.5rem; }
+.page-header h1 { margin: 0 0 0.25rem; font-size: 1.5rem; }
+
+/* run header */
+.run-header { margin-bottom: 1rem; }
+.run-header h1 { margin: 0 0 0.25rem; font-size: 1.4rem; display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+.run-meta { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; margin-top: 0.5rem; }
+
+.run-intent { margin: 0.25rem 0 0; color: #475569; font-size: 0.9rem; }
+
+/* cards */
+.card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+.card h2 {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* tables */
+.runs-table, .detail-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.runs-table th, .detail-table th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: #f1f5f9;
+  border-bottom: 1px solid #e2e8f0;
+  font-weight: 600;
+  color: #475569;
+  white-space: nowrap;
+}
+.runs-table td, .detail-table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: top;
+}
+.runs-table tr:last-child td, .detail-table tr:last-child td { border-bottom: none; }
+.runs-table tr:hover td, .detail-table tr:hover td { background: #f8fafc; }
+.runs-table a { color: #1d4ed8; text-decoration: none; font-weight: 500; }
+.runs-table a:hover { text-decoration: underline; }
+
+td.count, th.count { text-align: center; }
+.summary-cell { max-width: 260px; color: #475569; }
+.timestamp { color: #94a3b8; white-space: nowrap; font-size: 0.8rem; }
+.recommendation { max-width: 200px; color: #475569; font-size: 0.8rem; }
+
+/* badges */
+.badge {
+  display: inline-block;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  background: #e2e8f0;
+  color: #475569;
+}
+.badge-fixture { background: #fef9c3; color: #854d0e; border: 1px solid #fde68a; }
+.count-badge {
+  font-size: 0.75rem;
+  font-weight: normal;
+  color: #94a3b8;
+  background: #f1f5f9;
+  border-radius: 10px;
+  padding: 0.1em 0.5em;
+}
+.rank-badge { background: #e0f2fe; color: #0369a1; font-size: 0.75rem; padding: 0.1em 0.4em; border-radius: 4px; }
+
+/* phase */
+.phase {
+  display: inline-block;
+  padding: 0.15em 0.6em;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #dbeafe;
+  color: #1e40af;
+}
+.phase-vague_notion { background: #f1f5f9; color: #475569; }
+.phase-evidence_collected { background: #dbeafe; color: #1e40af; }
+.phase-supported_opportunity { background: #d1fae5; color: #065f46; }
+.phase-vetted_opportunity { background: #a7f3d0; color: #047857; }
+.phase-prototype_ready { background: #fef3c7; color: #92400e; }
+.phase-build_approved { background: #dcfce7; color: #166534; }
+
+/* decision */
+.decision {
+  display: inline-block;
+  padding: 0.15em 0.6em;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: #f1f5f9;
+  color: #475569;
+}
+.decision-archive { background: #f1f5f9; color: #6b7280; }
+.decision-watch { background: #fef3c7; color: #92400e; }
+.decision-publish { background: #dbeafe; color: #1e40af; }
+.decision-prototype_later { background: #ede9fe; color: #4c1d95; }
+.decision-build_approved { background: #dcfce7; color: #166534; }
+
+/* review status badges */
+.status-badge {
+  display: inline-block;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+.status-unreviewed { background: #f1f5f9; color: #64748b; }
+.status-accepted { background: #d1fae5; color: #065f46; }
+.status-weak { background: #fef3c7; color: #92400e; }
+.status-disputed { background: #fee2e2; color: #b91c1c; }
+.status-needs_followup { background: #fce7f3; color: #9d174d; }
+
+/* row highlight for status */
+tr.status-weak td { background: #fffbeb; }
+tr.status-disputed td { background: #fff1f2; }
+tr.status-needs_followup td { background: #fdf4ff; }
+
+/* validation gate badges */
+.gate-badge {
+  display: inline-block;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: #f1f5f9;
+  color: #64748b;
+}
+.gate-not_started { background: #f1f5f9; color: #64748b; }
+.gate-in_progress { background: #dbeafe; color: #1e40af; }
+.gate-satisfied { background: #d1fae5; color: #065f46; }
+.gate-weak { background: #fef3c7; color: #92400e; }
+.gate-failed { background: #fee2e2; color: #b91c1c; }
+.gate-waived { background: #f3f4f6; color: #6b7280; text-decoration: line-through; }
+
+tr.gate-not_started td { /* no highlight */ }
+tr.gate-failed td { background: #fff1f2; }
+tr.gate-weak td { background: #fffbeb; }
+
+/* evidence */
+.evidence-cell { font-size: 0.8rem; }
+.evidence-link {
+  display: inline-block;
+  margin: 0.1em 0.2em 0.1em 0;
+  padding: 0.1em 0.4em;
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #0369a1;
+}
+.rel-type { font-size: 0.65rem; color: #94a3b8; margin-left: 0.25em; }
+.evidence-links-row { margin-top: 0.5rem; font-size: 0.8rem; }
+.evidence-links-row .label { font-weight: 600; margin-right: 0.25rem; color: #64748b; }
+
+/* candidates */
+.candidate-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  background: #fafafa;
+}
+.candidate-card.status-weak { border-left: 4px solid #fbbf24; }
+.candidate-card.status-disputed { border-left: 4px solid #f87171; }
+.candidate-card.status-accepted { border-left: 4px solid #34d399; }
+.candidate-card.status-needs_followup { border-left: 4px solid #e879f9; }
+
+.candidate-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+.candidate-header strong { font-size: 0.95rem; }
+
+.candidate-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+}
+.candidate-details div { display: flex; flex-direction: column; }
+.candidate-details dt { font-weight: 600; color: #64748b; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.candidate-details dd { margin: 0; color: #374151; }
+
+/* review notes */
+.review-notes-list { list-style: none; padding: 0; margin: 0; }
+.review-notes-list li { padding: 0.6rem 0.75rem; border-bottom: 1px solid #f1f5f9; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: baseline; }
+.review-notes-list li:last-child { border-bottom: none; }
+.note-target { font-size: 0.75rem; color: #64748b; font-weight: 600; }
+.note-status { font-size: 0.7rem; padding: 0.1em 0.4em; border-radius: 4px; background: #f1f5f9; color: #64748b; }
+.note-resolved .note-status { background: #d1fae5; color: #065f46; }
+.review-notes-list li p { margin: 0.25rem 0 0; width: 100%; font-size: 0.85rem; }
+
+/* empty state */
+.empty-state { padding: 2rem; text-align: center; color: #64748b; }
+.empty-state code { background: #f1f5f9; padding: 0.2em 0.4em; border-radius: 4px; }
+
+.muted { color: #94a3b8; }

--- a/apd/web/templates/base.html
+++ b/apd/web/templates/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}APD{% endblock %}</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="/runs" class="nav-brand">APD Research Cockpit</a>
+    </nav>
+  </header>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+  <footer>
+    <p>APD Local &mdash; Autonomous Product Development</p>
+  </footer>
+</body>
+</html>

--- a/apd/web/templates/run_detail.html
+++ b/apd/web/templates/run_detail.html
@@ -1,0 +1,247 @@
+{% extends "base.html" %}
+{% block title %}{{ run.title }} — APD{% endblock %}
+{% block content %}
+
+<div class="breadcrumb">
+  <a href="/runs">Recent Runs</a> &rsaquo; {{ run.title }}
+</div>
+
+<section class="run-header">
+  <h1>
+    {{ run.title }}
+    {% if detail.is_fixture %}<span class="badge badge-fixture">fixture / demo data</span>{% endif %}
+  </h1>
+  {% if run.intent and run.intent != run.title %}
+  <p class="run-intent">{{ run.intent }}</p>
+  {% endif %}
+
+  <div class="run-meta">
+    <span class="phase phase-{{ run.phase }}">Phase: {{ run.phase.replace("_", " ") }}</span>
+    {% if run.current_decision %}
+    <span class="decision decision-{{ run.current_decision }}">Decision: {{ run.current_decision.replace("_", " ") }}</span>
+    {% else %}
+    <span class="muted">No decision yet</span>
+    {% endif %}
+    <span class="muted">Updated: {{ run.updated_at.strftime("%Y-%m-%d %H:%M UTC") if run.updated_at else "—" }}</span>
+  </div>
+</section>
+
+{% if run.summary %}
+<section class="card">
+  <h2>Summary</h2>
+  <p>{{ run.summary }}</p>
+</section>
+{% endif %}
+
+{% if run.recommendation %}
+<section class="card">
+  <h2>Recommendation</h2>
+  <p>{{ run.recommendation }}</p>
+</section>
+{% endif %}
+
+{# Sources #}
+<section class="card" id="sources">
+  <h2>Sources <span class="count-badge">{{ detail.sources | length }}</span></h2>
+  {% if detail.sources %}
+  <table class="detail-table">
+    <thead>
+      <tr><th>#</th><th>Title</th><th>Type</th><th>URL / Reference</th><th>Summary</th></tr>
+    </thead>
+    <tbody>
+      {% for s in detail.sources %}
+      <tr>
+        <td class="count">{{ loop.index }}</td>
+        <td>{{ s.title or "Untitled" }}</td>
+        <td><span class="badge">{{ s.source_type }}</span></td>
+        <td>
+          {% if s.url %}<a href="{{ s.url }}" target="_blank" rel="noopener">{{ s.url | truncate(60) }}</a>
+          {% elif s.raw_path %}{{ s.raw_path }}
+          {% else %}<span class="muted">—</span>{% endif %}
+        </td>
+        <td class="summary-cell">{{ s.summary or "" }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No sources.</p>
+  {% endif %}
+</section>
+
+{# Claims #}
+<section class="card" id="claims">
+  <h2>Claims <span class="count-badge">{{ detail.claims | length }}</span></h2>
+  {% if detail.claims %}
+  <table class="detail-table">
+    <thead>
+      <tr><th>#</th><th>Statement</th><th>Type</th><th>Status</th><th>Agent?</th><th>Evidence</th></tr>
+    </thead>
+    <tbody>
+      {% for c in detail.claims %}
+      {% set elinks = detail.evidence_index.get("claim", {}).get(c.id, []) %}
+      <tr class="status-{{ c.review_status }}">
+        <td class="count">{{ loop.index }}</td>
+        <td>{{ c.statement }}</td>
+        <td>{{ c.claim_type or "—" }}</td>
+        <td><span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span></td>
+        <td>{{ "yes" if c.is_agent_generated else "no" }}</td>
+        <td class="evidence-cell">
+          {% if elinks %}
+          {% for el in elinks %}
+          <span class="evidence-link" title="{{ el.relationship_type }}{% if el.strength %} ({{ el.strength }}){% endif %}">
+            {% if el.source_title %}{{ el.source_title | truncate(40) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
+            <span class="rel-type">{{ el.relationship_type }}</span>
+          </span>
+          {% endfor %}
+          {% else %}<span class="muted">none</span>{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No claims.</p>
+  {% endif %}
+</section>
+
+{# Themes #}
+<section class="card" id="themes">
+  <h2>Themes <span class="count-badge">{{ detail.themes | length }}</span></h2>
+  {% if detail.themes %}
+  <table class="detail-table">
+    <thead>
+      <tr><th>#</th><th>Name</th><th>Summary</th><th>Status</th><th>Segment</th><th>Workflow</th></tr>
+    </thead>
+    <tbody>
+      {% for t in detail.themes %}
+      <tr class="status-{{ t.review_status }}">
+        <td class="count">{{ loop.index }}</td>
+        <td>{{ t.name }}</td>
+        <td class="summary-cell">{{ t.summary or "—" }}</td>
+        <td><span class="status-badge status-{{ t.review_status }}">{{ t.review_status.replace("_", " ") }}</span></td>
+        <td>{{ t.user_segment or "—" }}</td>
+        <td>{{ t.workflow or "—" }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No themes.</p>
+  {% endif %}
+</section>
+
+{# Candidates #}
+<section class="card" id="candidates">
+  <h2>Candidates <span class="count-badge">{{ detail.candidates | length }}</span></h2>
+  {% if detail.candidates %}
+  {% for c in detail.candidates %}
+  {% set elinks = detail.evidence_index.get("candidate", {}).get(c.id, []) %}
+  <div class="candidate-card status-{{ c.review_status }}">
+    <div class="candidate-header">
+      <strong>{{ c.title }}</strong>
+      <span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span>
+      {% if c.decision %}<span class="decision decision-{{ c.decision }}">{{ c.decision.replace("_", " ") }}</span>{% endif %}
+      {% if c.rank %}<span class="rank-badge">rank {{ c.rank }}</span>{% endif %}
+    </div>
+    {% if c.summary %}<p>{{ c.summary }}</p>{% endif %}
+    <dl class="candidate-details">
+      {% if c.target_user %}<div><dt>Target user</dt><dd>{{ c.target_user }}</dd></div>{% endif %}
+      {% if c.first_workflow %}<div><dt>First workflow</dt><dd>{{ c.first_workflow }}</dd></div>{% endif %}
+      {% if c.first_wedge %}<div><dt>First wedge</dt><dd>{{ c.first_wedge }}</dd></div>{% endif %}
+      {% if c.monetization_path %}<div><dt>Monetization</dt><dd>{{ c.monetization_path }}</dd></div>{% endif %}
+      {% if c.substitutes %}<div><dt>Substitutes</dt><dd>{{ c.substitutes }}</dd></div>{% endif %}
+      {% if c.risks %}<div><dt>Risks</dt><dd>{{ c.risks }}</dd></div>{% endif %}
+      {% if c.why_now %}<div><dt>Why now</dt><dd>{{ c.why_now }}</dd></div>{% endif %}
+      {% if c.why_it_might_fail %}<div><dt>Why it might fail</dt><dd>{{ c.why_it_might_fail }}</dd></div>{% endif %}
+    </dl>
+    {% if elinks %}
+    <div class="evidence-links-row">
+      <span class="label">Evidence:</span>
+      {% for el in elinks %}
+      <span class="evidence-link" title="{{ el.relationship_type }}{% if el.strength %} ({{ el.strength }}){% endif %}">
+        {% if el.source_title %}{{ el.source_title | truncate(40) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
+        <span class="rel-type">{{ el.relationship_type }}</span>
+      </span>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+  {% endfor %}
+  {% else %}
+  <p class="muted">No candidates.</p>
+  {% endif %}
+</section>
+
+{# Validation Gates #}
+<section class="card" id="validation-gates">
+  <h2>Validation Gates <span class="count-badge">{{ detail.validation_gates | length }}</span></h2>
+  {% if detail.validation_gates %}
+  <table class="detail-table">
+    <thead>
+      <tr><th>#</th><th>Name</th><th>Phase</th><th>Status</th><th>Blocking</th><th>Description</th><th>Missing Evidence</th></tr>
+    </thead>
+    <tbody>
+      {% for g in detail.validation_gates %}
+      <tr class="gate-{{ g.status }}">
+        <td class="count">{{ loop.index }}</td>
+        <td>{{ g.name }}</td>
+        <td>{{ g.phase.replace("_", " ") if g.phase else "—" }}</td>
+        <td><span class="gate-badge gate-{{ g.status }}">{{ g.status.replace("_", " ") }}</span></td>
+        <td>{{ "yes" if g.blocking else "no" }}</td>
+        <td class="summary-cell">{{ g.description or "—" }}</td>
+        <td class="summary-cell">{{ g.missing_evidence or "—" }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No validation gates.</p>
+  {% endif %}
+</section>
+
+{# Artifacts #}
+{% if detail.artifacts %}
+<section class="card" id="artifacts">
+  <h2>Artifacts <span class="count-badge">{{ detail.artifacts | length }}</span></h2>
+  <table class="detail-table">
+    <thead>
+      <tr><th>#</th><th>Title</th><th>Type</th><th>Path / URL</th><th>Summary</th></tr>
+    </thead>
+    <tbody>
+      {% for a in detail.artifacts %}
+      <tr>
+        <td class="count">{{ loop.index }}</td>
+        <td>{{ a.title or "Untitled" }}</td>
+        <td><span class="badge">{{ a.artifact_type }}</span></td>
+        <td>
+          {% if a.url %}<a href="{{ a.url }}" target="_blank" rel="noopener">{{ a.url | truncate(60) }}</a>
+          {% elif a.path %}{{ a.path }}
+          {% else %}<span class="muted">—</span>{% endif %}
+        </td>
+        <td class="summary-cell">{{ a.summary or "—" }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+
+{# Review Notes #}
+{% if detail.review_notes %}
+<section class="card" id="review-notes">
+  <h2>Review Notes <span class="count-badge">{{ detail.review_notes | length }}</span></h2>
+  <ul class="review-notes-list">
+    {% for n in detail.review_notes %}
+    <li class="note-{{ n.status }}">
+      <span class="note-target">{{ n.target_type.replace("_", " ") }} #{{ n.target_id }}</span>
+      {% if n.author %}<span class="muted">by {{ n.author }}</span>{% endif %}
+      <span class="note-status note-{{ n.status }}">{{ n.status }}</span>
+      <p>{{ n.note }}</p>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+
+{% endblock %}

--- a/apd/web/templates/runs_list.html
+++ b/apd/web/templates/runs_list.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block title %}Recent Runs — APD{% endblock %}
+{% block content %}
+<section class="page-header">
+  <h1>Recent Runs</h1>
+</section>
+
+{% if runs %}
+<table class="runs-table">
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Phase</th>
+      <th>Decision</th>
+      <th>Recommendation</th>
+      <th>Sources</th>
+      <th>Claims</th>
+      <th>Themes</th>
+      <th>Candidates</th>
+      <th>Updated</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in runs %}
+    {% set run = item.run %}
+    <tr>
+      <td>
+        <a href="/runs/{{ run.id }}">{{ run.title }}</a>
+        {% if run.intent and run.intent != run.title %}
+        <p class="run-intent">{{ run.intent }}</p>
+        {% endif %}
+        {% if run.metadata_json and run.metadata_json.get("is_fixture") %}
+        <span class="badge badge-fixture">fixture</span>
+        {% endif %}
+      </td>
+      <td><span class="phase phase-{{ run.phase }}">{{ run.phase.replace("_", " ") }}</span></td>
+      <td>
+        {% if run.current_decision %}
+        <span class="decision decision-{{ run.current_decision }}">{{ run.current_decision.replace("_", " ") }}</span>
+        {% else %}
+        <span class="muted">—</span>
+        {% endif %}
+      </td>
+      <td class="recommendation">
+        {% if run.recommendation %}
+        {{ run.recommendation | truncate(120) }}
+        {% else %}
+        <span class="muted">—</span>
+        {% endif %}
+      </td>
+      <td class="count">{{ item.source_count }}</td>
+      <td class="count">{{ item.claim_count }}</td>
+      <td class="count">{{ item.theme_count }}</td>
+      <td class="count">{{ item.candidate_count }}</td>
+      <td class="timestamp">{{ run.updated_at.strftime("%Y-%m-%d") if run.updated_at else "—" }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No runs found.</p>
+  <p class="muted">Run <code>uv run python scripts/seed_fixture.py</code> to load fixture data.</p>
+</div>
+{% endif %}
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.115,<1",
+  "jinja2>=3.1,<4",
   "sqlalchemy>=2.0,<3",
   "alembic>=1.13,<2",
   "uvicorn[standard]>=0.30,<1",

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from apd.app.db import Base
+from apd.fixtures.seed import seed_fixture_data
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """Return a TestClient wired to an isolated in-memory-style SQLite DB with fixture data."""
+    db_path = tmp_path / "test_ui.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+
+    # Patch the engine and SessionLocal in the modules that use them
+    from sqlalchemy.orm import sessionmaker
+    from fastapi.staticfiles import StaticFiles
+
+    test_engine = create_engine(db_url, future=True, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(test_engine)
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, autocommit=False, future=True)
+
+    # Seed fixture data
+    with TestSession() as session:
+        seed_fixture_data(session)
+        session.commit()
+
+    # Patch the DB dependency used by web routes
+    import apd.web.routes as web_routes
+    import apd.app.db as app_db
+
+    monkeypatch.setattr(app_db, "engine", test_engine)
+    monkeypatch.setattr(app_db, "SessionLocal", TestSession)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_root_redirects_to_runs(client):
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code in (301, 302, 307, 308)
+    assert resp.headers["location"].endswith("/runs")
+
+
+def test_recent_runs_page_loads(client):
+    resp = client.get("/runs")
+    assert resp.status_code == 200
+    body = resp.text
+    # The fixture run title should appear
+    assert "Solo builders" in body or "self-hosted" in body or "Fixture Demo" in body
+
+
+def test_recent_runs_page_shows_run_columns(client):
+    resp = client.get("/runs")
+    assert resp.status_code == 200
+    body = resp.text
+    # Should show phase, counts and a link to run detail
+    assert "/runs/1" in body or 'href="/runs/' in body
+
+
+def test_recent_runs_page_shows_fixture_badge(client):
+    resp = client.get("/runs")
+    assert resp.status_code == 200
+    assert "fixture" in resp.text
+
+
+def test_run_detail_page_loads(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+
+
+def test_run_detail_shows_run_title(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Solo builders" in body or "self-hosted" in body or "Fixture Demo" in body
+
+
+def test_run_detail_shows_sources_section(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    assert "Sources" in resp.text
+
+
+def test_run_detail_shows_claims_section(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    assert "Claims" in resp.text
+
+
+def test_run_detail_shows_themes_section(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    assert "Themes" in resp.text
+
+
+def test_run_detail_shows_candidates_section(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    assert "Candidates" in resp.text
+
+
+def test_run_detail_shows_validation_gates_section(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    assert "Validation Gates" in resp.text
+
+
+def test_run_detail_shows_review_statuses(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    body = resp.text
+    # Fixture data has unreviewed, weak, or disputed claims/candidates
+    assert any(s in body for s in ["unreviewed", "weak", "disputed", "accepted", "needs followup"])
+
+
+def test_run_detail_404_for_missing_run(client):
+    resp = client.get("/runs/99999")
+    assert resp.status_code == 404
+
+
+def test_health_still_works(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "fastapi" },
+    { name = "jinja2" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -69,6 +70,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13,<2" },
     { name = "fastapi", specifier = ">=0.115,<1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<1" },
+    { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
@@ -242,6 +244,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
﻿## Summary

Adds the first local browser UI for APD: a recent-runs page and a run-detail page backed by the SQLite database and fixture data.

Refs #7

## What Changed

- `apd/web/routes.py` — FastAPI router with `/` (redirect), `/runs`, and `/runs/{run_id}` routes
- `apd/web/queries.py` — DB query helpers for run list and run detail, including evidence link indexing
- `apd/web/templates/base.html` — base HTML layout
- `apd/web/templates/runs_list.html` — recent-runs page with title, phase, decision, recommendation, counts, fixture badge, and detail link
- `apd/web/templates/run_detail.html` — run detail page with sources, claims (with review status), themes, candidates, validation gates, artifacts, review notes, evidence traceability, and fixture badge
- `apd/web/static/style.css` — minimal functional CSS with phase/decision/status color coding
- `apd/app/main.py` — includes web router, mounts `/static`
- `pyproject.toml` — adds `jinja2>=3.1,<4` dependency
- `tests/test_web_ui.py` — 14 tests covering redirect, recent-runs, run-detail, review statuses, 404, and health
- `README.md` — docs for viewing the UI and seeding against a throwaway DB

No React, no build tooling, no auth, no deployment, no background workers. Server-rendered Jinja2 templates only.

## Files Changed

- `README.md`
- `apd/app/main.py`
- `apd/web/queries.py`
- `apd/web/routes.py`
- `apd/web/static/style.css`
- `apd/web/templates/base.html`
- `apd/web/templates/run_detail.html`
- `apd/web/templates/runs_list.html`
- `pyproject.toml`
- `tests/test_web_ui.py`
- `uv.lock`

## Verification

```powershell
./scripts/test.ps1                    # 25 passed
python scripts/check_repo_readiness.py  # READY
```

### Manual browser verification (throwaway DB)

```powershell
$env:APD_DATABASE_URL = "sqlite+pysqlite:///./.local/apd_issue7_verify.db"
if (Test-Path ./.local/apd_issue7_verify.db) { Remove-Item ./.local/apd_issue7_verify.db -Force }
uv run alembic upgrade head
uv run python scripts/seed_fixture.py
uv run uvicorn apd.app.main:app --port 8765 --reload
```

Results observed:

- `GET /runs` → HTTP 200. Page shows fixture run "Fixture Demo: Solo builders deploying self-hosted apps", phase badge, fixture badge, source/claim/theme/candidate counts, link to `/runs/1`.
- `GET /runs/1` → HTTP 200. Run detail page shows: Sources (3), Claims (5 with `unreviewed`/`weak`/`disputed` status badges), Themes (2), Candidates (2 with status and evidence traceability), Validation Gates (2 with `not_started`/`weak` badges), Artifacts (1), Review Notes (1), phase/decision/fixture badge, run summary and recommendation.
- `GET /` → HTTP 307 redirect to `/runs`.
- `GET /runs/99999` → HTTP 404.
- `GET /health` → HTTP 200, `{"status":"ok"}`.

## Reviewer Focus

- Template rendering and route wiring (`apd/web/routes.py`, `apd/web/queries.py`)
- Evidence index in `get_run_detail` — evidence links are grouped by `(target_type, target_id)` for display
- Test fixture in `tests/test_web_ui.py` — uses `app.dependency_overrides` to inject isolated test DB

## Deployment Notes

No deployment changes. No secrets. No external network required.

## Scope Notes

- No review/decision mutation controls (owned by issue #8).
- No pagination (not needed at local fixture scale).
- No source/evidence detail sub-pages (owned by future issues per MVP contract).
