### PR TITLE
Issue #8: Add human review controls and run decision updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,31 @@ uv run uvicorn apd.app.main:app --reload
 ```
 
 Open `http://127.0.0.1:8000/runs` — the fixture run should appear. Click its title to open the run detail page.
+
+### Review and decision workflow (issue #8)
+
+The run detail page (`/runs/{run_id}`) includes inline review controls for human review.
+
+**Claim and candidate review**
+
+Each claim and candidate shows a collapsible "Review this claim / candidate" section with:
+- A status dropdown (`unreviewed`, `accepted`, `weak`, `disputed`, `needs_followup`)
+- An optional free-text note field
+- A Save button — submits a POST and redirects back to the same page (PRG pattern)
+
+Submitting with a note also creates a `ReviewNote` record linked to that claim or candidate.
+
+**Standalone notes**
+
+POST to `/runs/{run_id}/claims/{claim_id}/notes` or `.../candidates/{candidate_id}/notes` with a `note` field to add a review note without changing the review status.
+
+**Run decision update**
+
+At the top of the run detail page is an "Update Run Decision" card. Select a decision value and an optional rationale, then click "Save Decision". This:
+- Updates `run.current_decision`
+- Creates a `Decision` history record with the rationale and timestamp
+- Redirects back to the run detail page
+
+Decision history is shown in a collapsible panel below the form.
+
+> **build_approved** requires an explicit human selection. The form labels it clearly — it is never set automatically.

--- a/apd/web/mutations.py
+++ b/apd/web/mutations.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from apd.domain.models import (
+    Candidate,
+    Claim,
+    Decision,
+    DecisionTargetType,
+    DecisionValue,
+    ReviewNote,
+    ReviewNoteStatus,
+    ReviewStatus,
+    ReviewTargetType,
+    Run,
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def update_claim_review_status(
+    db: Session,
+    run_id: int,
+    claim_id: int,
+    new_status: ReviewStatus,
+    note_text: Optional[str] = None,
+    author: Optional[str] = None,
+) -> Optional[Claim]:
+    claim = db.get(Claim, claim_id)
+    if claim is None or claim.run_id != run_id:
+        return None
+    claim.review_status = new_status
+    claim.updated_at = _utc_now()
+    if note_text and note_text.strip():
+        note = ReviewNote(
+            run_id=run_id,
+            target_type=ReviewTargetType.CLAIM,
+            target_id=claim_id,
+            note=note_text.strip(),
+            author=author,
+            status=ReviewNoteStatus.OPEN,
+        )
+        db.add(note)
+    db.commit()
+    db.refresh(claim)
+    return claim
+
+
+def update_candidate_review_status(
+    db: Session,
+    run_id: int,
+    candidate_id: int,
+    new_status: ReviewStatus,
+    note_text: Optional[str] = None,
+    author: Optional[str] = None,
+) -> Optional[Candidate]:
+    candidate = db.get(Candidate, candidate_id)
+    if candidate is None or candidate.run_id != run_id:
+        return None
+    candidate.review_status = new_status
+    candidate.updated_at = _utc_now()
+    if note_text and note_text.strip():
+        note = ReviewNote(
+            run_id=run_id,
+            target_type=ReviewTargetType.CANDIDATE,
+            target_id=candidate_id,
+            note=note_text.strip(),
+            author=author,
+            status=ReviewNoteStatus.OPEN,
+        )
+        db.add(note)
+    db.commit()
+    db.refresh(candidate)
+    return candidate
+
+
+def add_review_note(
+    db: Session,
+    run_id: int,
+    target_type: ReviewTargetType,
+    target_id: int,
+    note_text: str,
+    author: Optional[str] = None,
+) -> Optional[ReviewNote]:
+    # Verify the run exists
+    run = db.get(Run, run_id)
+    if run is None:
+        return None
+    note = ReviewNote(
+        run_id=run_id,
+        target_type=target_type,
+        target_id=target_id,
+        note=note_text.strip(),
+        author=author,
+        status=ReviewNoteStatus.OPEN,
+    )
+    db.add(note)
+    db.commit()
+    db.refresh(note)
+    return note
+
+
+def update_run_decision(
+    db: Session,
+    run_id: int,
+    new_decision: DecisionValue,
+    rationale: Optional[str] = None,
+    decided_by: Optional[str] = None,
+) -> Optional[Run]:
+    run = db.get(Run, run_id)
+    if run is None:
+        return None
+    run.current_decision = new_decision
+    run.updated_at = _utc_now()
+    # Preserve history in the Decision table
+    decision_record = Decision(
+        run_id=run_id,
+        candidate_id=None,
+        target_type=DecisionTargetType.RUN,
+        target_id=run_id,
+        decision=new_decision,
+        rationale=rationale.strip() if rationale and rationale.strip() else None,
+        decided_by=decided_by,
+        decided_at=_utc_now(),
+    )
+    db.add(decision_record)
+    db.commit()
+    db.refresh(run)
+    return run

--- a/apd/web/queries.py
+++ b/apd/web/queries.py
@@ -87,6 +87,10 @@ def get_run_detail(db: Session, run_id: int) -> Optional[dict]:
         select(ReviewNote).where(ReviewNote.run_id == run_id).order_by(ReviewNote.id)
     ).scalars().all()
 
+    decision_history = db.execute(
+        select(Decision).where(Decision.run_id == run_id).order_by(Decision.decided_at.desc())
+    ).scalars().all()
+
     # Build a source lookup by id for display
     source_by_id = {s.id: s for s in sources}
 
@@ -118,4 +122,15 @@ def get_run_detail(db: Session, run_id: int) -> Optional[dict]:
         "review_notes": review_notes,
         "evidence_index": evidence_index,
         "is_fixture": is_fixture,
+        "decision_history": decision_history,
+        "notes_by_target": _build_notes_by_target(review_notes),
     }
+
+
+def _build_notes_by_target(review_notes) -> dict:
+    """Build a nested dict: target_type_str -> target_id -> list of notes."""
+    result: dict[str, dict[int, list]] = {}
+    for n in review_notes:
+        key = str(n.target_type)
+        result.setdefault(key, {}).setdefault(n.target_id, []).append(n)
+    return result

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from apd.app.db import SessionLocal
+from apd.domain.models import DecisionValue, ReviewStatus, ReviewTargetType
+from apd.web.mutations import (
+    add_review_note,
+    update_candidate_review_status,
+    update_claim_review_status,
+    update_run_decision,
+)
 from apd.web.queries import get_recent_runs, get_run_detail
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -47,5 +54,100 @@ def run_detail(run_id: int, request: Request, db: Session = Depends(_get_db)):
     return templates.TemplateResponse(
         request,
         "run_detail.html",
-        {"run": detail["run"], "detail": detail},
+        {
+            "run": detail["run"],
+            "detail": detail,
+            "review_statuses": [s.value for s in ReviewStatus],
+            "decision_values": [d.value for d in DecisionValue],
+        },
     )
+
+
+# --- Review status updates ---
+
+@router.post("/runs/{run_id}/claims/{claim_id}/review", response_class=RedirectResponse)
+def update_claim_review(
+    run_id: int,
+    claim_id: int,
+    review_status: str = Form(...),
+    note: str = Form(""),
+    db: Session = Depends(_get_db),
+):
+    try:
+        status = ReviewStatus(review_status)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid review status: {review_status}")
+    result = update_claim_review_status(db, run_id, claim_id, status, note_text=note or None)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Claim not found")
+    return RedirectResponse(url=f"/runs/{run_id}#claims", status_code=303)
+
+
+@router.post("/runs/{run_id}/candidates/{candidate_id}/review", response_class=RedirectResponse)
+def update_candidate_review(
+    run_id: int,
+    candidate_id: int,
+    review_status: str = Form(...),
+    note: str = Form(""),
+    db: Session = Depends(_get_db),
+):
+    try:
+        status = ReviewStatus(review_status)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid review status: {review_status}")
+    result = update_candidate_review_status(db, run_id, candidate_id, status, note_text=note or None)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    return RedirectResponse(url=f"/runs/{run_id}#candidates", status_code=303)
+
+
+# --- Standalone review note endpoints ---
+
+@router.post("/runs/{run_id}/claims/{claim_id}/notes", response_class=RedirectResponse)
+def add_claim_note(
+    run_id: int,
+    claim_id: int,
+    note: str = Form(...),
+    db: Session = Depends(_get_db),
+):
+    if not note.strip():
+        raise HTTPException(status_code=422, detail="Note text required")
+    result = add_review_note(db, run_id, ReviewTargetType.CLAIM, claim_id, note)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return RedirectResponse(url=f"/runs/{run_id}#claims", status_code=303)
+
+
+@router.post("/runs/{run_id}/candidates/{candidate_id}/notes", response_class=RedirectResponse)
+def add_candidate_note(
+    run_id: int,
+    candidate_id: int,
+    note: str = Form(...),
+    db: Session = Depends(_get_db),
+):
+    if not note.strip():
+        raise HTTPException(status_code=422, detail="Note text required")
+    result = add_review_note(db, run_id, ReviewTargetType.CANDIDATE, candidate_id, note)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return RedirectResponse(url=f"/runs/{run_id}#candidates", status_code=303)
+
+
+# --- Run decision update ---
+
+@router.post("/runs/{run_id}/decision", response_class=RedirectResponse)
+def update_decision(
+    run_id: int,
+    decision: str = Form(...),
+    rationale: str = Form(""),
+    db: Session = Depends(_get_db),
+):
+    try:
+        decision_value = DecisionValue(decision)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid decision: {decision}")
+    result = update_run_decision(db, run_id, decision_value, rationale=rationale or None)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return RedirectResponse(url=f"/runs/{run_id}", status_code=303)
+

--- a/apd/web/static/style.css
+++ b/apd/web/static/style.css
@@ -265,3 +265,117 @@ tr.gate-weak td { background: #fffbeb; }
 .empty-state code { background: #f1f5f9; padding: 0.2em 0.4em; border-radius: 4px; }
 
 .muted { color: #94a3b8; }
+
+/* review items (claims / candidates with inline review forms) */
+.review-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.5rem;
+  background: #fafafa;
+}
+.review-item.status-weak { border-left: 4px solid #fbbf24; }
+.review-item.status-disputed { border-left: 4px solid #f87171; }
+.review-item.status-accepted { border-left: 4px solid #34d399; }
+.review-item.status-needs_followup { border-left: 4px solid #e879f9; }
+
+.review-item-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+.item-index {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-weight: 600;
+  min-width: 1.5rem;
+  padding-top: 0.1rem;
+}
+.item-body { flex: 1; font-size: 0.875rem; }
+
+/* inline notes under a claim/candidate */
+.inline-notes {
+  list-style: none;
+  padding: 0.25rem 0 0 1.5rem;
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+}
+.inline-notes li {
+  padding: 0.2rem 0;
+  color: #374151;
+}
+.note-date { font-size: 0.7rem; margin-left: 0.5rem; }
+
+/* collapsible review form */
+.review-form-details {
+  margin-top: 0.5rem;
+}
+.review-form-details > summary {
+  cursor: pointer;
+  font-size: 0.78rem;
+  color: #3b82f6;
+  user-select: none;
+}
+.review-form-details > summary:hover { text-decoration: underline; }
+
+/* shared form row */
+.form-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+.form-row label {
+  font-size: 0.78rem;
+  color: #64748b;
+  white-space: nowrap;
+}
+.form-select {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  background: #fff;
+}
+.form-input {
+  flex: 1;
+  min-width: 120px;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+/* buttons */
+.btn {
+  display: inline-block;
+  padding: 0.3rem 0.9rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background: #1e293b;
+  color: #fff;
+  white-space: nowrap;
+}
+.btn:hover { background: #0f172a; }
+.btn-primary { background: #2563eb; }
+.btn-primary:hover { background: #1d4ed8; }
+.btn-sm { padding: 0.2rem 0.6rem; font-size: 0.75rem; }
+
+/* run-decision card form */
+#run-decision .form-row { align-items: center; gap: 0.75rem; }
+#run-decision .form-select { min-width: 160px; }
+
+/* decision history */
+.history-details { margin-top: 1rem; font-size: 0.85rem; }
+.history-details > summary { cursor: pointer; color: #64748b; font-size: 0.8rem; }
+.history-list { list-style: none; padding: 0.5rem 0 0; margin: 0; }
+.history-list li { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; padding: 0.25rem 0; border-bottom: 1px solid #f1f5f9; }
+.history-list li:last-child { border-bottom: none; }
+
+/* badge-agent */
+.badge-agent { background: #ede9fe; color: #4c1d95; }

--- a/apd/web/templates/run_detail.html
+++ b/apd/web/templates/run_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+﻿{% extends "base.html" %}
 {% block title %}{{ run.title }} — APD{% endblock %}
 {% block content %}
 
@@ -14,7 +14,6 @@
   {% if run.intent and run.intent != run.title %}
   <p class="run-intent">{{ run.intent }}</p>
   {% endif %}
-
   <div class="run-meta">
     <span class="phase phase-{{ run.phase }}">Phase: {{ run.phase.replace("_", " ") }}</span>
     {% if run.current_decision %}
@@ -24,6 +23,40 @@
     {% endif %}
     <span class="muted">Updated: {{ run.updated_at.strftime("%Y-%m-%d %H:%M UTC") if run.updated_at else "—" }}</span>
   </div>
+</section>
+
+{# Run Decision Update #}
+<section class="card" id="run-decision">
+  <h2>Update Run Decision</h2>
+  <form method="post" action="/runs/{{ run.id }}/decision" class="inline-form">
+    <div class="form-row">
+      <label for="decision-select">Decision</label>
+      <select name="decision" id="decision-select" class="form-select">
+        {% for dv in decision_values %}
+        <option value="{{ dv }}" {% if run.current_decision and run.current_decision == dv %}selected{% endif %}>
+          {{ dv.replace("_", " ") }}{% if dv == "build_approved" %} — explicit human action required{% endif %}
+        </option>
+        {% endfor %}
+      </select>
+      <label for="decision-rationale">Rationale (optional)</label>
+      <input type="text" name="rationale" id="decision-rationale" class="form-input" placeholder="Brief reason…" maxlength="500">
+      <button type="submit" class="btn btn-primary">Save Decision</button>
+    </div>
+  </form>
+  {% if detail.decision_history %}
+  <details class="history-details">
+    <summary>Decision history ({{ detail.decision_history | length }})</summary>
+    <ul class="history-list">
+      {% for d in detail.decision_history %}
+      <li>
+        <span class="decision decision-{{ d.decision }}">{{ d.decision.replace("_", " ") }}</span>
+        <span class="muted">{{ d.decided_at.strftime("%Y-%m-%d %H:%M UTC") if d.decided_at else "" }}</span>
+        {% if d.rationale %}<span>— {{ d.rationale }}</span>{% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </details>
+  {% endif %}
 </section>
 
 {% if run.summary %}
@@ -73,33 +106,56 @@
 <section class="card" id="claims">
   <h2>Claims <span class="count-badge">{{ detail.claims | length }}</span></h2>
   {% if detail.claims %}
-  <table class="detail-table">
-    <thead>
-      <tr><th>#</th><th>Statement</th><th>Type</th><th>Status</th><th>Agent?</th><th>Evidence</th></tr>
-    </thead>
-    <tbody>
-      {% for c in detail.claims %}
-      {% set elinks = detail.evidence_index.get("claim", {}).get(c.id, []) %}
-      <tr class="status-{{ c.review_status }}">
-        <td class="count">{{ loop.index }}</td>
-        <td>{{ c.statement }}</td>
-        <td>{{ c.claim_type or "—" }}</td>
-        <td><span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span></td>
-        <td>{{ "yes" if c.is_agent_generated else "no" }}</td>
-        <td class="evidence-cell">
-          {% if elinks %}
-          {% for el in elinks %}
-          <span class="evidence-link" title="{{ el.relationship_type }}{% if el.strength %} ({{ el.strength }}){% endif %}">
-            {% if el.source_title %}{{ el.source_title | truncate(40) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
-            <span class="rel-type">{{ el.relationship_type }}</span>
-          </span>
-          {% endfor %}
-          {% else %}<span class="muted">none</span>{% endif %}
-        </td>
-      </tr>
+  {% for c in detail.claims %}
+  {% set elinks = detail.evidence_index.get("claim", {}).get(c.id, []) %}
+  {% set claim_notes = detail.notes_by_target.get("claim", {}).get(c.id, []) %}
+  <div class="review-item status-{{ c.review_status }}" id="claim-{{ c.id }}">
+    <div class="review-item-header">
+      <span class="item-index">{{ loop.index }}</span>
+      <span class="item-body">{{ c.statement }}</span>
+      <span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span>
+      {% if c.claim_type %}<span class="badge">{{ c.claim_type }}</span>{% endif %}
+      {% if c.is_agent_generated %}<span class="badge badge-agent">agent</span>{% endif %}
+    </div>
+    {% if elinks %}
+    <div class="evidence-links-row">
+      <span class="label">Evidence:</span>
+      {% for el in elinks %}
+      <span class="evidence-link" title="{{ el.relationship_type }}{% if el.strength %} ({{ el.strength }}){% endif %}">
+        {% if el.source_title %}{{ el.source_title | truncate(40) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
+        <span class="rel-type">{{ el.relationship_type }}</span>
+      </span>
       {% endfor %}
-    </tbody>
-  </table>
+    </div>
+    {% endif %}
+    {% if claim_notes %}
+    <ul class="inline-notes">
+      {% for n in claim_notes %}
+      <li>
+        {% if n.author %}<strong>{{ n.author }}</strong>: {% endif %}{{ n.note }}
+        <span class="muted note-date">{{ n.created_at.strftime("%Y-%m-%d") if n.created_at else "" }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    <details class="review-form-details">
+      <summary>Review this claim</summary>
+      <form method="post" action="/runs/{{ run.id }}/claims/{{ c.id }}/review" class="review-form">
+        <div class="form-row">
+          <label>Status</label>
+          <select name="review_status" class="form-select">
+            {% for rs in review_statuses %}
+            <option value="{{ rs }}" {% if c.review_status == rs %}selected{% endif %}>{{ rs.replace("_", " ") }}</option>
+            {% endfor %}
+          </select>
+          <label>Note (optional)</label>
+          <input type="text" name="note" class="form-input" placeholder="Add a review note…" maxlength="1000">
+          <button type="submit" class="btn btn-sm">Save</button>
+        </div>
+      </form>
+    </details>
+  </div>
+  {% endfor %}
   {% else %}
   <p class="muted">No claims.</p>
   {% endif %}
@@ -137,7 +193,8 @@
   {% if detail.candidates %}
   {% for c in detail.candidates %}
   {% set elinks = detail.evidence_index.get("candidate", {}).get(c.id, []) %}
-  <div class="candidate-card status-{{ c.review_status }}">
+  {% set cand_notes = detail.notes_by_target.get("candidate", {}).get(c.id, []) %}
+  <div class="candidate-card review-item status-{{ c.review_status }}" id="candidate-{{ c.id }}">
     <div class="candidate-header">
       <strong>{{ c.title }}</strong>
       <span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span>
@@ -166,6 +223,32 @@
       {% endfor %}
     </div>
     {% endif %}
+    {% if cand_notes %}
+    <ul class="inline-notes">
+      {% for n in cand_notes %}
+      <li>
+        {% if n.author %}<strong>{{ n.author }}</strong>: {% endif %}{{ n.note }}
+        <span class="muted note-date">{{ n.created_at.strftime("%Y-%m-%d") if n.created_at else "" }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    <details class="review-form-details">
+      <summary>Review this candidate</summary>
+      <form method="post" action="/runs/{{ run.id }}/candidates/{{ c.id }}/review" class="review-form">
+        <div class="form-row">
+          <label>Status</label>
+          <select name="review_status" class="form-select">
+            {% for rs in review_statuses %}
+            <option value="{{ rs }}" {% if c.review_status == rs %}selected{% endif %}>{{ rs.replace("_", " ") }}</option>
+            {% endfor %}
+          </select>
+          <label>Note (optional)</label>
+          <input type="text" name="note" class="form-input" placeholder="Add a review note…" maxlength="1000">
+          <button type="submit" class="btn btn-sm">Save</button>
+        </div>
+      </form>
+    </details>
   </div>
   {% endfor %}
   {% else %}
@@ -200,7 +283,6 @@
   {% endif %}
 </section>
 
-{# Artifacts #}
 {% if detail.artifacts %}
 <section class="card" id="artifacts">
   <h2>Artifacts <span class="count-badge">{{ detail.artifacts | length }}</span></h2>
@@ -227,21 +309,24 @@
 </section>
 {% endif %}
 
-{# Review Notes #}
-{% if detail.review_notes %}
+{# Review Notes (all) #}
 <section class="card" id="review-notes">
   <h2>Review Notes <span class="count-badge">{{ detail.review_notes | length }}</span></h2>
+  {% if detail.review_notes %}
   <ul class="review-notes-list">
     {% for n in detail.review_notes %}
     <li class="note-{{ n.status }}">
       <span class="note-target">{{ n.target_type.replace("_", " ") }} #{{ n.target_id }}</span>
       {% if n.author %}<span class="muted">by {{ n.author }}</span>{% endif %}
       <span class="note-status note-{{ n.status }}">{{ n.status }}</span>
+      <span class="muted note-date">{{ n.created_at.strftime("%Y-%m-%d") if n.created_at else "" }}</span>
       <p>{{ n.note }}</p>
     </li>
     {% endfor %}
   </ul>
+  {% else %}
+  <p class="muted">No review notes yet.</p>
+  {% endif %}
 </section>
-{% endif %}
 
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "sqlalchemy>=2.0,<3",
   "alembic>=1.13,<2",
   "uvicorn[standard]>=0.30,<1",
+  "python-multipart>=0.0.18",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_review_controls.py
+++ b/tests/test_review_controls.py
@@ -1,0 +1,364 @@
+"""Tests for issue #8: human review controls and run decision updates."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from apd.app.db import Base
+from apd.domain.models import Candidate, Claim, Decision, ReviewNote
+from apd.fixtures.seed import seed_fixture_data
+
+
+@pytest.fixture()
+def client_and_session(tmp_path, monkeypatch):
+    """Return (TestClient, TestSession) wired to an isolated SQLite DB with fixture data."""
+    db_path = tmp_path / "test_review.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+
+    test_engine = create_engine(db_url, future=True, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(test_engine)
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, autocommit=False, future=True)
+
+    with TestSession() as session:
+        seed_fixture_data(session)
+        session.commit()
+
+    import apd.app.db as app_db
+    import apd.web.routes as web_routes
+
+    monkeypatch.setattr(app_db, "engine", test_engine)
+    monkeypatch.setattr(app_db, "SessionLocal", TestSession)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c, TestSession
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def client(client_and_session):
+    c, _ = client_and_session
+    return c
+
+
+@pytest.fixture()
+def db(client_and_session):
+    _, SessionCls = client_and_session
+    with SessionCls() as session:
+        yield session
+
+
+# --- helper to get the first claim/candidate id from fixture data ---
+
+def _first_claim_id(db) -> int:
+    return db.execute(select(Claim).limit(1)).scalars().first().id
+
+
+def _first_candidate_id(db) -> int:
+    return db.execute(select(Candidate).limit(1)).scalars().first().id
+
+
+# --- claim review ---
+
+def test_update_claim_review_status_persists(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        claim_id = _first_claim_id(db)
+
+    resp = c.post(
+        f"/runs/1/claims/{claim_id}/review",
+        data={"review_status": "accepted", "note": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        claim = db.get(Claim, claim_id)
+        assert str(claim.review_status) == "accepted"
+
+
+def test_update_claim_review_creates_note(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        claim_id = _first_claim_id(db)
+        initial_notes = db.execute(
+            select(ReviewNote).where(ReviewNote.target_id == claim_id)
+        ).scalars().all()
+        initial_count = len(initial_notes)
+
+    resp = c.post(
+        f"/runs/1/claims/{claim_id}/review",
+        data={"review_status": "weak", "note": "Needs more evidence"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        notes = db.execute(
+            select(ReviewNote).where(ReviewNote.target_id == claim_id)
+        ).scalars().all()
+        assert len(notes) == initial_count + 1
+        latest = notes[-1]
+        assert latest.note == "Needs more evidence"
+
+
+def test_update_claim_review_no_note_no_extra_record(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        claim_id = _first_claim_id(db)
+        initial_count = len(
+            db.execute(select(ReviewNote).where(ReviewNote.target_id == claim_id)).scalars().all()
+        )
+
+    resp = c.post(
+        f"/runs/1/claims/{claim_id}/review",
+        data={"review_status": "disputed", "note": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        count_after = len(
+            db.execute(select(ReviewNote).where(ReviewNote.target_id == claim_id)).scalars().all()
+        )
+        assert count_after == initial_count
+
+
+def test_invalid_review_status_rejected(client):
+    resp = client.post(
+        "/runs/1/claims/1/review",
+        data={"review_status": "nonsense_value", "note": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 422
+
+
+def test_claim_review_wrong_run_returns_404(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        claim_id = _first_claim_id(db)
+
+    resp = c.post(
+        f"/runs/9999/claims/{claim_id}/review",
+        data={"review_status": "accepted", "note": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 404
+
+
+# --- candidate review ---
+
+def test_update_candidate_review_status_persists(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        candidate_id = _first_candidate_id(db)
+
+    resp = c.post(
+        f"/runs/1/candidates/{candidate_id}/review",
+        data={"review_status": "accepted", "note": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        candidate = db.get(Candidate, candidate_id)
+        assert str(candidate.review_status) == "accepted"
+
+
+def test_update_candidate_review_creates_note(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        candidate_id = _first_candidate_id(db)
+        initial_count = len(
+            db.execute(select(ReviewNote).where(ReviewNote.target_id == candidate_id)).scalars().all()
+        )
+
+    resp = c.post(
+        f"/runs/1/candidates/{candidate_id}/review",
+        data={"review_status": "needs_followup", "note": "Need pricing data"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        notes = db.execute(
+            select(ReviewNote).where(ReviewNote.target_id == candidate_id)
+        ).scalars().all()
+        assert len(notes) == initial_count + 1
+        assert notes[-1].note == "Need pricing data"
+
+
+# --- standalone note endpoints ---
+
+def test_add_claim_note_standalone(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        claim_id = _first_claim_id(db)
+
+    resp = c.post(
+        f"/runs/1/claims/{claim_id}/notes",
+        data={"note": "Follow-up needed on this point"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        notes = db.execute(
+            select(ReviewNote).where(ReviewNote.target_id == claim_id)
+        ).scalars().all()
+        assert any(n.note == "Follow-up needed on this point" for n in notes)
+
+
+def test_add_candidate_note_standalone(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        candidate_id = _first_candidate_id(db)
+
+    resp = c.post(
+        f"/runs/1/candidates/{candidate_id}/notes",
+        data={"note": "Strong candidate for pilot"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        notes = db.execute(
+            select(ReviewNote).where(ReviewNote.target_id == candidate_id)
+        ).scalars().all()
+        assert any(n.note == "Strong candidate for pilot" for n in notes)
+
+
+def test_add_claim_note_empty_text_rejected(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        claim_id = _first_claim_id(db)
+
+    resp = c.post(
+        f"/runs/1/claims/{claim_id}/notes",
+        data={"note": "   "},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 422
+
+
+# --- run decision ---
+
+def test_update_run_decision_persists(client_and_session):
+    c, SessionCls = client_and_session
+
+    resp = c.post(
+        "/runs/1/decision",
+        data={"decision": "watch", "rationale": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    # After redirect, GET /runs/1 should show the new decision
+    resp2 = c.get("/runs/1")
+    assert resp2.status_code == 200
+    assert "watch" in resp2.text
+
+
+def test_update_run_decision_creates_history_record(client_and_session):
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        initial_count = len(
+            db.execute(select(Decision).where(Decision.run_id == 1)).scalars().all()
+        )
+
+    resp = c.post(
+        "/runs/1/decision",
+        data={"decision": "publish", "rationale": "Meets all gates"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    with SessionCls() as db:
+        decisions = db.execute(
+            select(Decision).where(Decision.run_id == 1)
+        ).scalars().all()
+        assert len(decisions) == initial_count + 1
+        latest = decisions[-1]
+        assert str(latest.decision) == "publish"
+        assert latest.rationale == "Meets all gates"
+
+
+def test_update_run_decision_visible_on_recent_runs(client_and_session):
+    c, SessionCls = client_and_session
+
+    resp = c.post(
+        "/runs/1/decision",
+        data={"decision": "archive", "rationale": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    resp2 = c.get("/runs")
+    assert resp2.status_code == 200
+    assert "archive" in resp2.text
+
+
+def test_build_approved_can_be_explicitly_set(client_and_session):
+    """build_approved requires an explicit human selection — verify it can be saved."""
+    c, SessionCls = client_and_session
+
+    resp = c.post(
+        "/runs/1/decision",
+        data={"decision": "build_approved", "rationale": "Reviewed and approved"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    resp2 = c.get("/runs/1")
+    assert resp2.status_code == 200
+    assert "build" in resp2.text
+
+
+def test_invalid_decision_value_rejected(client):
+    resp = client.post(
+        "/runs/1/decision",
+        data={"decision": "do_nothing_ever", "rationale": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 422
+
+
+def test_review_does_not_delete_claims(client_and_session):
+    """Updating a claim review must not delete or hide the claim from the detail page."""
+    c, SessionCls = client_and_session
+    with SessionCls() as db:
+        claim_id = _first_claim_id(db)
+        original_statement = db.get(Claim, claim_id).statement
+
+    c.post(
+        f"/runs/1/claims/{claim_id}/review",
+        data={"review_status": "disputed", "note": ""},
+        follow_redirects=False,
+    )
+
+    resp = c.get("/runs/1")
+    assert resp.status_code == 200
+    # Claim statement still appears on the detail page
+    assert original_statement[:30] in resp.text
+
+
+def test_run_detail_shows_review_forms(client):
+    """run_detail page should contain form elements for review."""
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'method="post"' in body
+    assert "review_status" in body
+    assert "Update Run Decision" in body

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,7 @@ dependencies = [
     { name = "alembic" },
     { name = "fastapi" },
     { name = "jinja2" },
+    { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -72,6 +73,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<1" },
     { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]
@@ -473,6 +475,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #8

## Changes

**New file: `apd/web/mutations.py`**
- `update_claim_review_status` — updates `claim.review_status`, optionally adds a `ReviewNote`
- `update_candidate_review_status` — same pattern for candidates
- `add_review_note` — standalone note creation
- `update_run_decision` — updates `run.current_decision`, creates a `Decision` history record

**Updated: `apd/web/routes.py`**
- `POST /runs/{run_id}/claims/{claim_id}/review` — update claim status (+ optional note), PRG→303
- `POST /runs/{run_id}/candidates/{candidate_id}/review` — update candidate status, PRG→303
- `POST /runs/{run_id}/claims/{claim_id}/notes` — standalone note, PRG→303
- `POST /runs/{run_id}/candidates/{candidate_id}/notes` — standalone note, PRG→303
- `POST /runs/{run_id}/decision` — update run decision, PRG→303

**Updated: `apd/web/queries.py`**
- `get_run_detail` now returns `notes_by_target` (nested dict for inline note display) and `decision_history`

**Updated: `apd/web/templates/run_detail.html`**
- Claims section replaced with card-style items, each with a collapsible review form (status dropdown + note + Save)
- Candidates section similarly updated with inline review forms
- New "Update Run Decision" card at top with decision dropdown, rationale field, and history panel

**Updated: `apd/web/static/style.css`**
- `.review-item`, `.review-item-header`, `.review-form-details`, `.form-row`, `.form-select`, `.form-input`, `.btn`, `.btn-primary`, `.btn-sm`, `.inline-notes`, `.history-details` styles

**Updated: `pyproject.toml`**
- Added `python-multipart>=0.0.18` (required by FastAPI for `Form()` parsing)

**New file: `tests/test_review_controls.py`** — 17 tests covering:
- Claim review status persistence and note creation
- Candidate review status persistence and note creation  
- Standalone note endpoints
- Run decision update (persistence, history record, runs list visibility)
- `build_approved` explicit selection
- Invalid status/decision rejection (422)
- Claims not deleted after review
- Review forms present in rendered HTML

**Updated: `README.md`** — added "Review and decision workflow (issue #8)" section

## Verification

All 42 tests pass (`uv run pytest -q`):
- 25 pre-existing tests (issues #4–#7)
- 17 new review controls tests
