### PR TITLE
Issue #9: Add Markdown report export from structured run data

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,19 @@ At the top of the run detail page is an "Update Run Decision" card. Select a dec
 Decision history is shown in a collapsible panel below the form.
 
 > **build_approved** requires an explicit human selection. The form labels it clearly — it is never set automatically.
+
+### Markdown report export (issue #9)
+
+Generate a local Markdown report from structured run data and record it as an Artifact:
+
+```text
+uv run python scripts/export_markdown_report.py --run-id 1
+```
+
+Behavior:
+- The export writes under `.local/exports/reports/run-<run-id>/`.
+- Filenames are timestamped (`run-<id>-report-YYYYMMDD-HHMMSS.md`) to avoid silent overwrite.
+- If a timestamp collision occurs, a version suffix is added (`-v2`, `-v3`, ...).
+- Each export creates an `Artifact` record with `artifact_type=markdown_report`.
+
+The run detail page also has an **Export Markdown Report** action that triggers the same export flow and records the output in Artifacts.

--- a/apd/services/report_export.py
+++ b/apd/services/report_export.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from apd.domain.models import Artifact, ReviewStatus, Run
+from apd.web.queries import get_run_detail
+
+
+@dataclass
+class ReportExportResult:
+    run_id: int
+    artifact_id: int
+    artifact_path: Path
+
+
+def export_run_markdown_report(db: Session, run_id: int, export_root: Optional[Path] = None) -> Optional[ReportExportResult]:
+    detail = get_run_detail(db, run_id)
+    if detail is None:
+        return None
+
+    run = detail["run"]
+    markdown = render_run_report_markdown(detail)
+
+    root = export_root or _default_export_root()
+    safe_dir = root / f"run-{run_id}"
+    safe_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = _next_report_path(safe_dir, run_id)
+    output_path.write_text(markdown, encoding="utf-8")
+
+    artifact = Artifact(
+        run_id=run_id,
+        artifact_type="markdown_report",
+        title=f"Run {run_id} Markdown Report",
+        path=str(_to_repo_relative(output_path)),
+        created_by="local_export",
+        summary="Markdown report export generated from structured run data.",
+        metadata_json={
+            "format": "markdown",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "phase": str(run.phase),
+            "decision": str(run.current_decision) if run.current_decision else None,
+        },
+    )
+    db.add(artifact)
+    db.commit()
+    db.refresh(artifact)
+
+    return ReportExportResult(run_id=run_id, artifact_id=artifact.id, artifact_path=output_path)
+
+
+def render_run_report_markdown(detail: dict) -> str:
+    run = detail["run"]
+    sources = detail["sources"]
+    claims = detail["claims"]
+    themes = detail["themes"]
+    candidates = detail["candidates"]
+    validation_gates = detail["validation_gates"]
+    review_notes = detail["review_notes"]
+    decision_history = detail.get("decision_history", [])
+    evidence_index = detail.get("evidence_index", {})
+
+    lines: list[str] = []
+
+    lines.append(f"# {run.title}")
+    lines.append("")
+    if run.intent:
+        lines.append("## Intent")
+        lines.append("")
+        lines.append(run.intent)
+        lines.append("")
+
+    lines.append("## Run State")
+    lines.append("")
+    lines.append(f"- Phase: {str(run.phase).replace('_', ' ')}")
+    lines.append(f"- Current decision: {_display_or_none(run.current_decision)}")
+    lines.append("")
+
+    if run.summary:
+        lines.append("## Summary")
+        lines.append("")
+        lines.append(run.summary)
+        lines.append("")
+
+    if run.recommendation:
+        lines.append("## Recommendation")
+        lines.append("")
+        lines.append(run.recommendation)
+        lines.append("")
+
+    if decision_history:
+        lines.append("## Decision History")
+        lines.append("")
+        for d in decision_history:
+            decided_at = d.decided_at.strftime("%Y-%m-%d %H:%M UTC") if d.decided_at else "unknown"
+            rationale = f" - rationale: {d.rationale}" if d.rationale else ""
+            lines.append(f"- {str(d.decision).replace('_', ' ')} at {decided_at}{rationale}")
+        lines.append("")
+
+    lines.append("## Sources")
+    lines.append("")
+    if not sources:
+        lines.append("- None")
+    else:
+        for s in sources:
+            reference = s.url or s.raw_path or "no reference"
+            summary = f" - {s.summary}" if s.summary else ""
+            lines.append(f"- [source#{s.id}] {s.title or 'Untitled'} ({s.source_type}) - {reference}{summary}")
+    lines.append("")
+
+    lines.append("## Claims")
+    lines.append("")
+    _append_items_with_status(lines, claims, "claim", evidence_index)
+
+    lines.append("## Themes")
+    lines.append("")
+    _append_items_with_status(lines, themes, "theme", evidence_index)
+
+    lines.append("## Candidates")
+    lines.append("")
+    if not candidates:
+        lines.append("- None")
+        lines.append("")
+    else:
+        for c in candidates:
+            status = str(c.review_status).replace("_", " ")
+            decision_part = f", decision={str(c.decision).replace('_', ' ')}" if c.decision else ""
+            lines.append(f"- [candidate#{c.id}] ({status}{decision_part}) {c.title}")
+            if c.summary:
+                lines.append(f"  - summary: {c.summary}")
+            if c.target_user:
+                lines.append(f"  - target_user: {c.target_user}")
+            if c.first_workflow:
+                lines.append(f"  - first_workflow: {c.first_workflow}")
+            if c.first_wedge:
+                lines.append(f"  - first_wedge: {c.first_wedge}")
+            if c.why_it_might_fail:
+                lines.append(f"  - why_it_might_fail: {c.why_it_might_fail}")
+            _append_evidence_refs(lines, evidence_index, "candidate", c.id)
+        lines.append("")
+
+    lines.append("## Validation Gates And Gaps")
+    lines.append("")
+    if not validation_gates:
+        lines.append("- None")
+    else:
+        for g in validation_gates:
+            phase = str(g.phase).replace("_", " ") if g.phase else "none"
+            status = str(g.status).replace("_", " ")
+            blocking = "blocking" if g.blocking else "non-blocking"
+            lines.append(f"- [gate#{g.id}] {g.name} ({status}, {blocking}, phase={phase})")
+            if g.description:
+                lines.append(f"  - description: {g.description}")
+            if g.missing_evidence:
+                lines.append(f"  - missing_evidence: {g.missing_evidence}")
+    lines.append("")
+
+    lines.append("## Review Notes")
+    lines.append("")
+    if not review_notes:
+        lines.append("- None")
+    else:
+        for n in review_notes:
+            author = n.author or "unknown"
+            target = f"{str(n.target_type)}#{n.target_id}"
+            lines.append(f"- [{str(n.status)}] {target} by {author}: {n.note}")
+    lines.append("")
+
+    lines.append("## Known Weak, Disputed, Or Needs-Followup Material")
+    lines.append("")
+    _append_flagged_material(lines, claims, themes, candidates)
+
+    next_action = _next_suggested_action(run, validation_gates)
+    if next_action:
+        lines.append("")
+        lines.append("## Next Suggested Action")
+        lines.append("")
+        lines.append(next_action)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _append_items_with_status(lines: list[str], items: list, item_type: str, evidence_index: dict) -> None:
+    if not items:
+        lines.append("- None")
+        lines.append("")
+        return
+
+    grouped = {
+        ReviewStatus.ACCEPTED.value: [],
+        ReviewStatus.WEAK.value: [],
+        ReviewStatus.DISPUTED.value: [],
+        ReviewStatus.NEEDS_FOLLOWUP.value: [],
+        ReviewStatus.UNREVIEWED.value: [],
+    }
+
+    for item in items:
+        grouped.setdefault(str(item.review_status), []).append(item)
+
+    for status_key in [
+        ReviewStatus.ACCEPTED.value,
+        ReviewStatus.WEAK.value,
+        ReviewStatus.DISPUTED.value,
+        ReviewStatus.NEEDS_FOLLOWUP.value,
+        ReviewStatus.UNREVIEWED.value,
+    ]:
+        entries = grouped.get(status_key, [])
+        lines.append(f"### {status_key.replace('_', ' ').title()}")
+        if not entries:
+            lines.append("")
+            lines.append("- None")
+            lines.append("")
+            continue
+
+        lines.append("")
+        for item in entries:
+            name = getattr(item, "statement", None) or getattr(item, "name", None) or "unnamed"
+            lines.append(f"- [{item_type}#{item.id}] {name}")
+            summary = getattr(item, "summary", None)
+            if summary:
+                lines.append(f"  - summary: {summary}")
+            _append_evidence_refs(lines, evidence_index, item_type, item.id)
+        lines.append("")
+
+
+def _append_evidence_refs(lines: list[str], evidence_index: dict, target_type: str, target_id: int) -> None:
+    refs = evidence_index.get(target_type, {}).get(target_id, [])
+    if not refs:
+        lines.append("  - evidence: none linked")
+        return
+
+    for ref in refs:
+        source_ref = f"source#{ref.get('source_id')}" if ref.get("source_id") else "source?"
+        source_title = ref.get("source_title") or source_ref
+        rel = ref.get("relationship_type") or "related"
+        strength = f", strength={ref.get('strength')}" if ref.get("strength") else ""
+        lines.append(f"  - evidence: {source_title} ({source_ref}, {rel}{strength})")
+
+
+def _append_flagged_material(lines: list[str], claims: list, themes: list, candidates: list) -> None:
+    flagged = []
+    for label, items, text_attr in [
+        ("claim", claims, "statement"),
+        ("theme", themes, "name"),
+        ("candidate", candidates, "title"),
+    ]:
+        for item in items:
+            status = str(item.review_status)
+            if status in {
+                ReviewStatus.WEAK.value,
+                ReviewStatus.DISPUTED.value,
+                ReviewStatus.NEEDS_FOLLOWUP.value,
+            }:
+                text = getattr(item, text_attr)
+                flagged.append(f"- [{label}#{item.id}] ({status.replace('_', ' ')}) {text}")
+
+    if not flagged:
+        lines.append("- None")
+        return
+
+    lines.extend(flagged)
+
+
+def _next_suggested_action(run: Run, validation_gates: list) -> Optional[str]:
+    if run.recommendation:
+        return run.recommendation
+
+    blocking_open = [
+        g for g in validation_gates
+        if g.blocking and str(g.status) in {"not_started", "in_progress", "weak", "failed"}
+    ]
+    if blocking_open:
+        return "Address blocking validation-gate gaps before advancing the run phase."
+
+    if run.current_decision:
+        decision = str(run.current_decision)
+        if decision == "watch":
+            return "Collect additional evidence and re-evaluate the strongest weak or disputed claims."
+        if decision == "publish":
+            return "Draft a publishable report based on accepted claims and clearly-labeled uncertainties."
+        if decision == "prototype_later":
+            return "Capture explicit trigger conditions for when to revisit this prototype."
+        if decision == "build_approved":
+            return "Define the first prototype slice and success event before implementation."
+        if decision == "archive":
+            return "Archive for now and document what new evidence would justify reopening."
+
+    return None
+
+
+def _display_or_none(value: object) -> str:
+    if value is None:
+        return "none"
+    return str(value).replace("_", " ")
+
+
+def _default_export_root() -> Path:
+    repo_root = Path(__file__).resolve().parents[2]
+    return repo_root / ".local" / "exports" / "reports"
+
+
+def _to_repo_relative(path: Path) -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _next_report_path(run_dir: Path, run_id: int) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    base = run_dir / f"run-{run_id}-report-{stamp}.md"
+    if not base.exists():
+        return base
+
+    suffix = 2
+    while True:
+        candidate = run_dir / f"run-{run_id}-report-{stamp}-v{suffix}.md"
+        if not candidate.exists():
+            return candidate
+        suffix += 1

--- a/apd/web/queries.py
+++ b/apd/web/queries.py
@@ -11,6 +11,7 @@ from apd.domain.models import (
     Candidate,
     Claim,
     Decision,
+    EvidenceExcerpt,
     EvidenceLink,
     ReviewNote,
     Run,
@@ -83,6 +84,13 @@ def get_run_detail(db: Session, run_id: int) -> Optional[dict]:
         select(EvidenceLink).where(EvidenceLink.run_id == run_id)
     ).scalars().all()
 
+    excerpts = {
+        ex.id: ex
+        for ex in db.execute(
+            select(EvidenceExcerpt).where(EvidenceExcerpt.run_id == run_id)
+        ).scalars().all()
+    }
+
     review_notes = db.execute(
         select(ReviewNote).where(ReviewNote.run_id == run_id).order_by(ReviewNote.id)
     ).scalars().all()
@@ -100,9 +108,12 @@ def get_run_detail(db: Session, run_id: int) -> Optional[dict]:
         key = str(link.target_type)
         evidence_index.setdefault(key, {}).setdefault(link.target_id, [])
         src = source_by_id.get(link.source_id) if link.source_id else None
+        excerpt = excerpts.get(link.excerpt_id) if link.excerpt_id else None
         evidence_index[key][link.target_id].append({
             "source_title": src.title if src else None,
             "source_id": link.source_id,
+            "excerpt_id": link.excerpt_id,
+            "excerpt_location": excerpt.location_reference if excerpt else None,
             "relationship_type": str(link.relationship_type),
             "strength": str(link.strength) if link.strength else None,
         })

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -15,6 +15,7 @@ from apd.web.mutations import (
     update_claim_review_status,
     update_run_decision,
 )
+from apd.services.report_export import export_run_markdown_report
 from apd.web.queries import get_recent_runs, get_run_detail
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -150,4 +151,14 @@ def update_decision(
     if result is None:
         raise HTTPException(status_code=404, detail="Run not found")
     return RedirectResponse(url=f"/runs/{run_id}", status_code=303)
+
+
+# --- Run markdown export ---
+
+@router.post("/runs/{run_id}/export-report", response_class=RedirectResponse)
+def export_report(run_id: int, db: Session = Depends(_get_db)):
+    result = export_run_markdown_report(db, run_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return RedirectResponse(url=f"/runs/{run_id}#artifacts", status_code=303)
 

--- a/apd/web/templates/run_detail.html
+++ b/apd/web/templates/run_detail.html
@@ -57,6 +57,13 @@
     </ul>
   </details>
   {% endif %}
+
+  <form method="post" action="/runs/{{ run.id }}/export-report" class="inline-form">
+    <div class="form-row">
+      <button type="submit" class="btn">Export Markdown Report</button>
+      <span class="muted">Creates a timestamped local report and records it as an artifact.</span>
+    </div>
+  </form>
 </section>
 
 {% if run.summary %}

--- a/scripts/export_markdown_report.py
+++ b/scripts/export_markdown_report.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+
+from apd.app.db import SessionLocal
+from apd.services.report_export import export_run_markdown_report
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export a run as a local Markdown report and record it as an Artifact. "
+            "Exports are timestamped to avoid silent overwrite."
+        )
+    )
+    parser.add_argument("--run-id", type=int, required=True, help="Run ID to export")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+
+    with SessionLocal() as session:
+        result = export_run_markdown_report(session, args.run_id)
+
+    if result is None:
+        print(f"run_id={args.run_id} exported=false reason=not_found")
+        return 1
+
+    print(
+        " ".join(
+            [
+                f"run_id={result.run_id}",
+                "exported=true",
+                f"artifact_id={result.artifact_id}",
+                f"path={result.artifact_path.as_posix()}",
+            ]
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_markdown_report_export.py
+++ b/tests/test_markdown_report_export.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from apd.app.db import Base
+from apd.domain.models import Artifact
+from apd.fixtures.seed import seed_fixture_data
+from apd.services.report_export import export_run_markdown_report, render_run_report_markdown
+from apd.web.queries import get_run_detail
+
+
+@pytest.fixture()
+def session_factory(tmp_path):
+    db_path = tmp_path / "test_export.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+
+    engine = create_engine(db_url, future=True, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    SessionCls = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+    with SessionCls() as session:
+        seed_fixture_data(session)
+        session.commit()
+
+    return SessionCls
+
+
+@pytest.fixture()
+def db(session_factory):
+    with session_factory() as session:
+        yield session
+
+
+def test_render_fixture_report_includes_required_sections(db):
+    detail = get_run_detail(db, 1)
+    assert detail is not None
+
+    report = render_run_report_markdown(detail)
+
+    assert "# Fixture Demo: Solo builders deploying self-hosted apps" in report
+    assert "## Intent" in report
+    assert "## Summary" in report
+    assert "## Recommendation" in report
+    assert "## Run State" in report
+    assert "## Decision History" in report
+    assert "## Sources" in report
+    assert "## Claims" in report
+    assert "### Accepted" in report
+    assert "### Weak" in report
+    assert "### Disputed" in report
+    assert "### Unreviewed" in report
+    assert "## Themes" in report
+    assert "## Candidates" in report
+    assert "## Validation Gates And Gaps" in report
+    assert "## Review Notes" in report
+    assert "## Known Weak, Disputed, Or Needs-Followup Material" in report
+    assert "evidence:" in report
+    assert "source#" in report
+
+
+def test_export_creates_file_and_artifact(db, tmp_path):
+    export_root = tmp_path / "exports"
+
+    result = export_run_markdown_report(db, 1, export_root=export_root)
+    assert result is not None
+    assert result.artifact_path.exists()
+    assert result.artifact_path.suffix == ".md"
+
+    artifact = db.get(Artifact, result.artifact_id)
+    assert artifact is not None
+    assert artifact.run_id == 1
+    assert artifact.artifact_type == "markdown_report"
+    assert artifact.path is not None
+    assert "run-1-report-" in artifact.path
+
+    body = result.artifact_path.read_text(encoding="utf-8")
+    assert "## Sources" in body
+    assert "## Claims" in body
+    assert "## Themes" in body
+    assert "## Candidates" in body
+    assert "## Validation Gates And Gaps" in body
+
+
+def test_repeated_export_does_not_silently_clobber(db, tmp_path):
+    export_root = tmp_path / "exports"
+
+    first = export_run_markdown_report(db, 1, export_root=export_root)
+    second = export_run_markdown_report(db, 1, export_root=export_root)
+
+    assert first is not None
+    assert second is not None
+    assert first.artifact_path != second.artifact_path
+    assert first.artifact_path.exists()
+    assert second.artifact_path.exists()
+
+    exported_artifacts = db.execute(
+        select(Artifact).where(Artifact.run_id == 1, Artifact.artifact_type == "markdown_report")
+    ).scalars().all()
+    assert len(exported_artifacts) == 2
+
+
+@pytest.fixture()
+def client_and_session(session_factory, monkeypatch, tmp_path):
+    import apd.app.db as app_db
+    import apd.services.report_export as report_export_service
+    import apd.web.routes as web_routes
+
+    export_root = tmp_path / "route_exports"
+
+    monkeypatch.setattr(app_db, "SessionLocal", session_factory)
+
+    def _override_get_db():
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    original_export = report_export_service.export_run_markdown_report
+
+    def _export_with_tmp_root(db, run_id):
+        return original_export(db, run_id, export_root=export_root)
+
+    monkeypatch.setattr(web_routes, "export_run_markdown_report", _export_with_tmp_root)
+
+    from apd.app.main import app
+
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c, session_factory
+    app.dependency_overrides.clear()
+
+
+def test_export_report_route_creates_artifact_and_redirects(client_and_session):
+    client, SessionCls = client_and_session
+
+    response = client.post("/runs/1/export-report", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].endswith("/runs/1#artifacts")
+
+    with SessionCls() as session:
+        exported_artifacts = session.execute(
+            select(Artifact).where(Artifact.run_id == 1, Artifact.artifact_type == "markdown_report")
+        ).scalars().all()
+        assert len(exported_artifacts) == 1
+        path = exported_artifacts[0].path
+        assert path is not None
+        candidate = Path(path)
+        if candidate.is_absolute():
+            resolved = candidate
+        else:
+            resolved = Path(__file__).resolve().parents[1] / candidate
+        assert resolved.exists()


### PR DESCRIPTION
﻿## Summary

Adds local Markdown report export for a structured APD run.

This PR adds:
- a Markdown report rendering/export service driven from structured database data
- a local export command for a run
- a run-detail UI action to export a report locally
- Artifact record creation for generated reports
- safe timestamped file output under an app-managed local export path
- tests covering fixture-run report generation and non-clobber repeated export behavior
- README documentation for the export flow

Refs #9

## Files Changed

- README.md
- apd/services/report_export.py
- apd/web/queries.py
- apd/web/routes.py
- apd/web/templates/run_detail.html
- scripts/export_markdown_report.py
- tests/test_markdown_report_export.py

## Verification

```text
uv run pytest -q tests/test_markdown_report_export.py
.... [100%]

uv run pytest -q tests/test_web_ui.py tests/test_review_controls.py
............................... [100%]

./scripts/test.ps1
.............................................. [100%]

python scripts/check_repo_readiness.py
READY  Repo contains the required bootstrap files and directories.
```

## Manual Verification

Throwaway DB setup:

```text
$env:APD_DATABASE_URL = "sqlite+pysqlite:///./.local/apd_issue9_verify.db"
if (Test-Path ./.local/apd_issue9_verify.db) { Remove-Item ./.local/apd_issue9_verify.db -Force }
uv run alembic upgrade head
uv run python scripts/seed_fixture.py
uv run python scripts/export_markdown_report.py --run-id 1
uv run python scripts/export_markdown_report.py --run-id 1
```

Results:
- First export path: `C:/Users/jjmgo/coding_projects/autonomous-product-development/.local/exports/reports/run-1/run-1-report-20260427-021516.md`
- Second export path: `C:/Users/jjmgo/coding_projects/autonomous-product-development/.local/exports/reports/run-1/run-1-report-20260427-021518.md`
- `markdown_report` Artifact count for run 1 after repeated export: `2`
- Both exported files existed on disk.
- Latest generated report was readable and included title, intent, summary, recommendation, decision history, sources, claims, themes, candidates, validation gates, review notes, and evidence/source references.

Repeated export behavior:
- Repeated export creates a distinct timestamped file.
- Existing reports are not silently overwritten.

## Deployment Notes

No deployment changes.
No external publishing.
No generated local reports or SQLite files are committed.

## Reviewer Focus

- Markdown report completeness and labeling of accepted vs weak/disputed/unreviewed material
- Artifact persistence for exports
- Safe timestamped local file output
- Route and command integration for local export
- Repeated export non-clobber behavior
