### PR TITLE
Add agent draft import schema and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,3 +299,30 @@ Current limitations:
 - The importer focuses on linking artifacts and importing sources first.
 - It does not attempt full structured import of claims, themes, candidates, validation gates, or review notes from legacy Markdown.
 - Legacy runs may appear in the UI with useful title, intent, summary, source, and artifact data even when richer structured fields are unavailable.
+
+### Agent draft import schema and command (issue #27)
+
+Import a structured agent draft package into APD:
+
+```text
+uv run python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
+```
+
+Behavior:
+- Validates package shape and required minimum content before writing to the database.
+- Imports run metadata, sources, excerpts, claims, themes, candidates, validation gates, and evidence links.
+- Treats imported material as draft/unreviewed, not accepted truth.
+- Forces imported claims, themes, and candidates to `unreviewed`.
+- Marks imported claims and candidates as agent-generated.
+- Preserves traceability by mapping external IDs in the package to imported rows and evidence links.
+- Rejects duplicate `external_draft_id` by default; use `--allow-duplicate-external-id` to intentionally import another run version.
+
+Validation and safety:
+- Malformed JSON and invalid package shape fail safely with clear `ERROR:` lines.
+- Unknown references (for example, evidence links to missing IDs) are skipped with `WARNING:` lines.
+- Imported warnings are recorded in run metadata.
+- The importer does not fetch URLs, call model APIs, or mutate legacy run directories.
+
+Package contract documentation:
+- `docs/agent-draft-import.md`
+- sample package: `apd/fixtures/examples/agent_draft_sample.json`

--- a/apd/fixtures/examples/agent_draft_sample.json
+++ b/apd/fixtures/examples/agent_draft_sample.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": "1.0",
+  "external_draft_id": "draft-20260426-recruiting-ops-r1",
+  "agent_name": "local-research-agent",
+  "generated_at": "2026-04-26T18:20:00Z",
+  "run": {
+    "title": "Agent Draft: Recruiting Ops Friction",
+    "intent": "Assess repeated friction in internal recruiting operations and shortlist wedge candidates.",
+    "summary": "Draft synthesis from structured source notes. Requires human review before acceptance.",
+    "mode": "agent_draft",
+    "phase": "evidence_collected",
+    "recommendation": "Watch and validate buyer urgency with recruiter operations leads."
+  },
+  "warnings": [
+    "Sample package uses synthetic IDs and should not be treated as accepted research."
+  ],
+  "limitations": [
+    "No direct willingness-to-pay interviews included in this draft package."
+  ],
+  "sources": [
+    {
+      "id": "src-1",
+      "title": "Hiring team forum thread on handoff delays",
+      "source_type": "forum_thread",
+      "url": "https://example.com/recruiting/handoff-delays",
+      "origin": "agent_draft",
+      "author_or_org": "Recruiting Ops Forum",
+      "captured_at": "2026-04-24T14:00:00Z",
+      "summary": "Recruiters report repeated delays when interview feedback is spread across tools."
+    },
+    {
+      "id": "src-2",
+      "title": "Recruiter interview notes",
+      "source_type": "interview_notes",
+      "origin": "agent_draft",
+      "author_or_org": "Synthetic User Interviews",
+      "captured_at": "2026-04-25T11:30:00Z",
+      "summary": "Small teams lose hours weekly reconciling conflicting candidate-status updates."
+    }
+  ],
+  "evidence_excerpts": [
+    {
+      "id": "ex-1",
+      "source_id": "src-1",
+      "excerpt_text": "Status updates are split across ATS comments and chat threads, so nobody trusts the latest state.",
+      "location_reference": "post-18",
+      "excerpt_type": "complaint"
+    },
+    {
+      "id": "ex-2",
+      "source_id": "src-2",
+      "excerpt_text": "I spend Friday afternoons just aligning interview notes and next-step ownership.",
+      "location_reference": "interview-2",
+      "excerpt_type": "workflow"
+    }
+  ],
+  "claims": [
+    {
+      "id": "claim-1",
+      "statement": "Recruiting teams face repeated coordination friction due to fragmented candidate-state updates.",
+      "claim_type": "pain",
+      "confidence": 0.67
+    }
+  ],
+  "themes": [
+    {
+      "id": "theme-1",
+      "name": "State-tracking fragmentation",
+      "summary": "Teams lack one trusted workflow for candidate progression and ownership.",
+      "theme_type": "pain_theme",
+      "severity": "high",
+      "frequency": "recurring",
+      "user_segment": "internal recruiters",
+      "workflow": "interview follow-up"
+    }
+  ],
+  "candidates": [
+    {
+      "id": "cand-1",
+      "title": "Recruiting Handoff Ledger",
+      "summary": "A narrow workflow layer that reconciles candidate-state updates and ownership transitions.",
+      "target_user": "Recruiting coordinators at small to mid-size companies",
+      "first_workflow": "Post-interview decision handoff",
+      "first_wedge": "Single state timeline with explicit owner transitions",
+      "why_it_might_fail": "Teams may resist another dashboard unless it directly saves weekly reconciliation time.",
+      "rank": 1,
+      "score": 0.72
+    }
+  ],
+  "validation_gates": [
+    {
+      "id": "gate-1",
+      "candidate_id": "cand-1",
+      "phase": "supported_opportunity",
+      "name": "Confirm buyer urgency",
+      "description": "Interview at least three recruiting operations leads who own process tooling decisions.",
+      "status": "not_started",
+      "blocking": true,
+      "missing_evidence": "No direct buyer interviews in this draft package yet."
+    }
+  ],
+  "evidence_links": [
+    {
+      "id": "link-1",
+      "source_id": "src-1",
+      "excerpt_id": "ex-1",
+      "target_type": "claim",
+      "target_id": "claim-1",
+      "relationship": "supports",
+      "strength": "medium"
+    },
+    {
+      "id": "link-2",
+      "source_id": "src-2",
+      "excerpt_id": "ex-2",
+      "target_type": "theme",
+      "target_id": "theme-1",
+      "relationship": "example_of",
+      "strength": "strong"
+    },
+    {
+      "id": "link-3",
+      "source_id": "src-2",
+      "excerpt_id": "ex-2",
+      "target_type": "candidate",
+      "target_id": "cand-1",
+      "relationship": "supports",
+      "strength": "medium"
+    },
+    {
+      "id": "link-4",
+      "source_id": "src-1",
+      "excerpt_id": "ex-1",
+      "target_type": "validation_gate",
+      "target_id": "gate-1",
+      "relationship": "context_for",
+      "strength": "weak"
+    }
+  ]
+}

--- a/apd/services/agent_draft_import.py
+++ b/apd/services/agent_draft_import.py
@@ -1,0 +1,589 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from apd.domain.models import (
+    Candidate,
+    Claim,
+    EvidenceExcerpt,
+    EvidenceLink,
+    EvidenceRelationship,
+    EvidenceStrength,
+    EvidenceTargetType,
+    ReviewStatus,
+    Run,
+    RunPhase,
+    Source,
+    Theme,
+    ValidationGate,
+    ValidationGateStatus,
+)
+
+
+class AgentDraftImportError(Exception):
+    """Base exception for agent draft import failures."""
+
+
+class AgentDraftValidationError(AgentDraftImportError):
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+class DuplicateExternalDraftIdError(AgentDraftImportError):
+    def __init__(self, external_draft_id: str, run_id: int):
+        self.external_draft_id = external_draft_id
+        self.run_id = run_id
+        super().__init__(
+            f"external_draft_id '{external_draft_id}' already imported as run {run_id}"
+        )
+
+
+class RunDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: Optional[str] = Field(default=None, min_length=1)
+    intent: Optional[str] = Field(default=None, min_length=1)
+    summary: Optional[str] = None
+    mode: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    phase: Optional[RunPhase] = None
+    recommendation: Optional[str] = None
+
+
+class SourceDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    title: Optional[str] = None
+    source_type: str = Field(min_length=1, max_length=64)
+    url: Optional[str] = None
+    origin: Optional[str] = None
+    author_or_org: Optional[str] = None
+    captured_at: Optional[datetime] = None
+    published_at: Optional[datetime] = None
+    raw_path: Optional[str] = None
+    normalized_path: Optional[str] = None
+    reliability_notes: Optional[str] = None
+    summary: Optional[str] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
+class EvidenceExcerptDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    source_id: str = Field(min_length=1)
+    excerpt_text: str = Field(min_length=1)
+    location_reference: Optional[str] = None
+    excerpt_type: Optional[str] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
+class ClaimDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    statement: str = Field(min_length=1)
+    claim_type: Optional[str] = None
+    confidence: Optional[float] = None
+    created_by: Optional[str] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
+class ThemeDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    summary: Optional[str] = None
+    theme_type: Optional[str] = None
+    severity: Optional[str] = None
+    frequency: Optional[str] = None
+    user_segment: Optional[str] = None
+    workflow: Optional[str] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
+class CandidateDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    summary: Optional[str] = None
+    target_user: Optional[str] = None
+    first_workflow: Optional[str] = None
+    first_wedge: Optional[str] = None
+    prototype_success_event: Optional[str] = None
+    monetization_path: Optional[str] = None
+    substitutes: Optional[str] = None
+    risks: Optional[str] = None
+    why_now: Optional[str] = None
+    why_it_might_fail: Optional[str] = None
+    score: Optional[float] = None
+    rank: Optional[int] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
+class ValidationGateDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    candidate_id: Optional[str] = None
+    phase: Optional[RunPhase] = None
+    name: str = Field(min_length=1)
+    description: Optional[str] = None
+    status: Optional[ValidationGateStatus] = None
+    blocking: bool = True
+    evidence_summary: Optional[str] = None
+    missing_evidence: Optional[str] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
+class EvidenceLinkDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    source_id: Optional[str] = None
+    excerpt_id: Optional[str] = None
+    target_type: EvidenceTargetType
+    target_id: str = Field(min_length=1)
+    relationship: EvidenceRelationship
+    strength: Optional[EvidenceStrength] = None
+    notes: Optional[str] = None
+    metadata_json: Optional[dict[str, Any]] = None
+
+
+class AgentDraftPackage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default="1.0", min_length=1)
+    external_draft_id: Optional[str] = Field(default=None, min_length=1)
+    agent_name: Optional[str] = None
+    generated_at: Optional[datetime] = None
+    run: RunDraft
+    warnings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+    sources: list[SourceDraft] = Field(default_factory=list)
+    evidence_excerpts: list[EvidenceExcerptDraft] = Field(default_factory=list)
+    claims: list[ClaimDraft] = Field(default_factory=list)
+    themes: list[ThemeDraft] = Field(default_factory=list)
+    candidates: list[CandidateDraft] = Field(default_factory=list)
+    validation_gates: list[ValidationGateDraft] = Field(default_factory=list)
+    evidence_links: list[EvidenceLinkDraft] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_minimum_content(self) -> "AgentDraftPackage":
+        if not (self.run.title or self.run.intent):
+            raise ValueError("run.title or run.intent is required")
+
+        if not (self.sources or self.claims or self.candidates):
+            raise ValueError("at least one source or one claim or one candidate is required")
+
+        _validate_unique_ids("sources", self.sources)
+        _validate_unique_ids("evidence_excerpts", self.evidence_excerpts)
+        _validate_unique_ids("claims", self.claims)
+        _validate_unique_ids("themes", self.themes)
+        _validate_unique_ids("candidates", self.candidates)
+        _validate_unique_ids("validation_gates", self.validation_gates)
+        _validate_unique_ids("evidence_links", self.evidence_links)
+        return self
+
+
+@dataclass
+class AgentDraftImportResult:
+    run_db_id: int
+    external_draft_id: Optional[str]
+    created_run: bool
+    imported_source_count: int
+    imported_excerpt_count: int
+    imported_claim_count: int
+    imported_theme_count: int
+    imported_candidate_count: int
+    imported_validation_gate_count: int
+    imported_evidence_link_count: int
+    warnings: list[str]
+
+
+def load_agent_draft_package(path: Path) -> AgentDraftPackage:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AgentDraftValidationError([f"could not read draft package: {exc}"]) from exc
+
+    try:
+        raw_data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise AgentDraftValidationError([f"invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"]) from exc
+
+    try:
+        return AgentDraftPackage.model_validate(raw_data)
+    except ValidationError as exc:
+        errors: list[str] = []
+        for err in exc.errors():
+            location = ".".join(str(part) for part in err.get("loc", []))
+            message = err.get("msg", "validation error")
+            errors.append(f"{location}: {message}" if location else message)
+        raise AgentDraftValidationError(errors) from exc
+
+
+def import_agent_draft_file(
+    db: Session,
+    path: Path,
+    *,
+    allow_duplicate_external_id: bool = False,
+) -> AgentDraftImportResult:
+    package = load_agent_draft_package(path)
+    return import_agent_draft_package(
+        db,
+        package,
+        package_path=path,
+        allow_duplicate_external_id=allow_duplicate_external_id,
+    )
+
+
+def import_agent_draft_package(
+    db: Session,
+    package: AgentDraftPackage,
+    *,
+    package_path: Optional[Path] = None,
+    allow_duplicate_external_id: bool = False,
+) -> AgentDraftImportResult:
+    if package.external_draft_id and not allow_duplicate_external_id:
+        existing = _find_existing_external_draft_run(db, package.external_draft_id)
+        if existing is not None:
+            raise DuplicateExternalDraftIdError(package.external_draft_id, existing.id)
+
+    warnings = list(package.warnings)
+
+    run = Run(
+        title=package.run.title or _title_from_intent_or_external(package.run.intent, package.external_draft_id),
+        intent=package.run.intent,
+        summary=package.run.summary,
+        mode=package.run.mode or "agent_draft_import",
+        phase=package.run.phase or _default_phase(package),
+        recommendation=package.run.recommendation,
+        metadata_json={
+            "agent_draft": {
+                "schema_version": package.schema_version,
+                "external_draft_id": package.external_draft_id,
+                "agent_name": package.agent_name,
+                "generated_at": package.generated_at.isoformat() if package.generated_at else None,
+                "limitations": package.limitations,
+                "imported_at": datetime.now(timezone.utc).isoformat(),
+                "package_path": _repo_relative_or_abs(package_path),
+            }
+        },
+    )
+    db.add(run)
+    db.flush()
+
+    source_ids: dict[str, int] = {}
+    excerpt_ids: dict[str, int] = {}
+    claim_ids: dict[str, int] = {}
+    theme_ids: dict[str, int] = {}
+    candidate_ids: dict[str, int] = {}
+    validation_gate_ids: dict[str, int] = {}
+
+    for source in package.sources:
+        source_row = Source(
+            run_id=run.id,
+            title=source.title,
+            source_type=source.source_type,
+            url=source.url,
+            origin=source.origin or "agent_draft_import",
+            author_or_org=source.author_or_org,
+            captured_at=source.captured_at,
+            published_at=source.published_at,
+            raw_path=source.raw_path,
+            normalized_path=source.normalized_path,
+            reliability_notes=source.reliability_notes,
+            summary=source.summary,
+            metadata_json={
+                **(source.metadata_json or {}),
+                "agent_draft_id": source.id,
+                "agent_generated": True,
+            },
+        )
+        db.add(source_row)
+        db.flush()
+        source_ids[source.id] = source_row.id
+
+    for excerpt in package.evidence_excerpts:
+        source_id = source_ids.get(excerpt.source_id)
+        if source_id is None:
+            warnings.append(
+                f"skipped excerpt '{excerpt.id}': unknown source_id '{excerpt.source_id}'"
+            )
+            continue
+
+        excerpt_row = EvidenceExcerpt(
+            run_id=run.id,
+            source_id=source_id,
+            excerpt_text=excerpt.excerpt_text,
+            location_reference=excerpt.location_reference,
+            excerpt_type=excerpt.excerpt_type,
+            metadata_json={
+                **(excerpt.metadata_json or {}),
+                "agent_draft_id": excerpt.id,
+                "agent_generated": True,
+            },
+        )
+        db.add(excerpt_row)
+        db.flush()
+        excerpt_ids[excerpt.id] = excerpt_row.id
+
+    for claim in package.claims:
+        claim_row = Claim(
+            run_id=run.id,
+            statement=claim.statement,
+            claim_type=claim.claim_type,
+            review_status=ReviewStatus.UNREVIEWED,
+            confidence=claim.confidence,
+            created_by=claim.created_by or package.agent_name or "agent_draft_import",
+            is_agent_generated=True,
+            metadata_json={
+                **(claim.metadata_json or {}),
+                "agent_draft_id": claim.id,
+                "agent_generated": True,
+            },
+        )
+        db.add(claim_row)
+        db.flush()
+        claim_ids[claim.id] = claim_row.id
+
+    for theme in package.themes:
+        theme_row = Theme(
+            run_id=run.id,
+            name=theme.name,
+            summary=theme.summary,
+            theme_type=theme.theme_type,
+            severity=theme.severity,
+            frequency=theme.frequency,
+            user_segment=theme.user_segment,
+            workflow=theme.workflow,
+            review_status=ReviewStatus.UNREVIEWED,
+            metadata_json={
+                **(theme.metadata_json or {}),
+                "agent_draft_id": theme.id,
+                "agent_generated": True,
+            },
+        )
+        db.add(theme_row)
+        db.flush()
+        theme_ids[theme.id] = theme_row.id
+
+    for candidate in package.candidates:
+        candidate_row = Candidate(
+            run_id=run.id,
+            title=candidate.title,
+            summary=candidate.summary,
+            target_user=candidate.target_user,
+            first_workflow=candidate.first_workflow,
+            first_wedge=candidate.first_wedge,
+            prototype_success_event=candidate.prototype_success_event,
+            monetization_path=candidate.monetization_path,
+            substitutes=candidate.substitutes,
+            risks=candidate.risks,
+            why_now=candidate.why_now,
+            why_it_might_fail=candidate.why_it_might_fail,
+            score=candidate.score,
+            rank=candidate.rank,
+            review_status=ReviewStatus.UNREVIEWED,
+            is_agent_generated=True,
+            metadata_json={
+                **(candidate.metadata_json or {}),
+                "agent_draft_id": candidate.id,
+                "agent_generated": True,
+            },
+        )
+        db.add(candidate_row)
+        db.flush()
+        candidate_ids[candidate.id] = candidate_row.id
+
+    for gate in package.validation_gates:
+        candidate_id = None
+        if gate.candidate_id:
+            candidate_id = candidate_ids.get(gate.candidate_id)
+            if candidate_id is None:
+                warnings.append(
+                    f"validation_gate '{gate.id}' references unknown candidate_id '{gate.candidate_id}'; candidate link omitted"
+                )
+
+        gate_row = ValidationGate(
+            run_id=run.id,
+            candidate_id=candidate_id,
+            phase=gate.phase,
+            name=gate.name,
+            description=gate.description,
+            status=gate.status or ValidationGateStatus.NOT_STARTED,
+            blocking=gate.blocking,
+            evidence_summary=gate.evidence_summary,
+            missing_evidence=gate.missing_evidence,
+            metadata_json={
+                **(gate.metadata_json or {}),
+                "agent_draft_id": gate.id,
+                "agent_generated": True,
+            },
+        )
+        db.add(gate_row)
+        db.flush()
+        validation_gate_ids[gate.id] = gate_row.id
+
+    for link in package.evidence_links:
+        target_id = _map_target_id(
+            link.target_type,
+            link.target_id,
+            claim_ids,
+            theme_ids,
+            candidate_ids,
+            validation_gate_ids,
+        )
+        if target_id is None:
+            warnings.append(
+                f"skipped evidence_link '{link.id}': unknown {link.target_type.value} target_id '{link.target_id}'"
+            )
+            continue
+
+        source_id = None
+        if link.source_id is not None:
+            source_id = source_ids.get(link.source_id)
+            if source_id is None:
+                warnings.append(
+                    f"skipped evidence_link '{link.id}': unknown source_id '{link.source_id}'"
+                )
+                continue
+
+        excerpt_id = None
+        if link.excerpt_id is not None:
+            excerpt_id = excerpt_ids.get(link.excerpt_id)
+            if excerpt_id is None:
+                warnings.append(
+                    f"skipped evidence_link '{link.id}': unknown excerpt_id '{link.excerpt_id}'"
+                )
+                continue
+
+        link_row = EvidenceLink(
+            run_id=run.id,
+            source_id=source_id,
+            excerpt_id=excerpt_id,
+            target_type=link.target_type,
+            target_id=target_id,
+            relationship_type=link.relationship,
+            strength=link.strength,
+            notes=link.notes,
+            metadata_json={
+                **(link.metadata_json or {}),
+                "agent_draft_id": link.id,
+                "agent_generated": True,
+                "source_external_id": link.source_id,
+                "excerpt_external_id": link.excerpt_id,
+                "target_external_id": link.target_id,
+            },
+        )
+        db.add(link_row)
+
+    db.flush()
+
+    run.source_count = _count_rows_for_run(db, Source, run.id)
+    run.claim_count = _count_rows_for_run(db, Claim, run.id)
+    run.theme_count = _count_rows_for_run(db, Theme, run.id)
+    run.candidate_count = _count_rows_for_run(db, Candidate, run.id)
+    run.updated_at = datetime.now(timezone.utc)
+    run.metadata_json = {
+        **(run.metadata_json or {}),
+        "agent_draft": {
+            **((run.metadata_json or {}).get("agent_draft") or {}),
+            "import_warnings": warnings,
+        },
+    }
+
+    db.commit()
+    db.refresh(run)
+
+    return AgentDraftImportResult(
+        run_db_id=run.id,
+        external_draft_id=package.external_draft_id,
+        created_run=True,
+        imported_source_count=run.source_count,
+        imported_excerpt_count=_count_rows_for_run(db, EvidenceExcerpt, run.id),
+        imported_claim_count=run.claim_count,
+        imported_theme_count=run.theme_count,
+        imported_candidate_count=run.candidate_count,
+        imported_validation_gate_count=_count_rows_for_run(db, ValidationGate, run.id),
+        imported_evidence_link_count=_count_rows_for_run(db, EvidenceLink, run.id),
+        warnings=warnings,
+    )
+
+
+def _validate_unique_ids(name: str, items: list[Any]) -> None:
+    seen: set[str] = set()
+    for item in items:
+        item_id = item.id
+        if item_id in seen:
+            raise ValueError(f"duplicate {name} id: {item_id}")
+        seen.add(item_id)
+
+
+def _find_existing_external_draft_run(db: Session, external_draft_id: str) -> Optional[Run]:
+    runs = db.execute(select(Run)).scalars().all()
+    for run in runs:
+        metadata = run.metadata_json or {}
+        draft_meta = metadata.get("agent_draft") if isinstance(metadata, dict) else None
+        if isinstance(draft_meta, dict) and draft_meta.get("external_draft_id") == external_draft_id:
+            return run
+    return None
+
+
+def _title_from_intent_or_external(intent: Optional[str], external_draft_id: Optional[str]) -> str:
+    if intent:
+        return intent[:255]
+    if external_draft_id:
+        return f"Agent Draft {external_draft_id}"[:255]
+    return "Imported Agent Draft"
+
+
+def _default_phase(package: AgentDraftPackage) -> RunPhase:
+    if package.sources:
+        return RunPhase.EVIDENCE_COLLECTED
+    return RunPhase.VAGUE_NOTION
+
+
+def _map_target_id(
+    target_type: EvidenceTargetType,
+    external_target_id: str,
+    claim_ids: dict[str, int],
+    theme_ids: dict[str, int],
+    candidate_ids: dict[str, int],
+    validation_gate_ids: dict[str, int],
+) -> Optional[int]:
+    if target_type == EvidenceTargetType.CLAIM:
+        return claim_ids.get(external_target_id)
+    if target_type == EvidenceTargetType.THEME:
+        return theme_ids.get(external_target_id)
+    if target_type == EvidenceTargetType.CANDIDATE:
+        return candidate_ids.get(external_target_id)
+    if target_type == EvidenceTargetType.VALIDATION_GATE:
+        return validation_gate_ids.get(external_target_id)
+    return None
+
+
+def _count_rows_for_run(db: Session, model: Any, run_id: int) -> int:
+    return db.scalar(select(func.count()).select_from(model).where(model.run_id == run_id)) or 0
+
+
+def _repo_relative_or_abs(path: Optional[Path]) -> Optional[str]:
+    if path is None:
+        return None
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()

--- a/apd/services/report_export.py
+++ b/apd/services/report_export.py
@@ -158,6 +158,7 @@ def render_run_report_markdown(detail: dict) -> str:
                 lines.append(f"  - description: {g.description}")
             if g.missing_evidence:
                 lines.append(f"  - missing_evidence: {g.missing_evidence}")
+            _append_evidence_refs(lines, evidence_index, "validation_gate", g.id)
     lines.append("")
 
     lines.append("## Review Notes")

--- a/apd/web/templates/run_detail.html
+++ b/apd/web/templates/run_detail.html
@@ -174,10 +174,11 @@
   {% if detail.themes %}
   <table class="detail-table">
     <thead>
-      <tr><th>#</th><th>Name</th><th>Summary</th><th>Status</th><th>Segment</th><th>Workflow</th></tr>
+      <tr><th>#</th><th>Name</th><th>Summary</th><th>Status</th><th>Segment</th><th>Workflow</th><th>Evidence</th></tr>
     </thead>
     <tbody>
       {% for t in detail.themes %}
+      {% set tlinks = detail.evidence_index.get("theme", {}).get(t.id, []) %}
       <tr class="status-{{ t.review_status }}">
         <td class="count">{{ loop.index }}</td>
         <td>{{ t.name }}</td>
@@ -185,6 +186,18 @@
         <td><span class="status-badge status-{{ t.review_status }}">{{ t.review_status.replace("_", " ") }}</span></td>
         <td>{{ t.user_segment or "—" }}</td>
         <td>{{ t.workflow or "—" }}</td>
+        <td>
+          {% if tlinks %}
+            {% for el in tlinks %}
+            <div>
+              {% if el.source_title %}{{ el.source_title | truncate(36) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
+              <span class="rel-type">{{ el.relationship_type }}</span>
+            </div>
+            {% endfor %}
+          {% else %}
+          <span class="muted">none</span>
+          {% endif %}
+        </td>
       </tr>
       {% endfor %}
     </tbody>
@@ -206,6 +219,7 @@
       <strong>{{ c.title }}</strong>
       <span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span>
       {% if c.decision %}<span class="decision decision-{{ c.decision }}">{{ c.decision.replace("_", " ") }}</span>{% endif %}
+      {% if c.is_agent_generated %}<span class="badge badge-agent">agent</span>{% endif %}
       {% if c.rank %}<span class="rank-badge">rank {{ c.rank }}</span>{% endif %}
     </div>
     {% if c.summary %}<p>{{ c.summary }}</p>{% endif %}
@@ -269,10 +283,11 @@
   {% if detail.validation_gates %}
   <table class="detail-table">
     <thead>
-      <tr><th>#</th><th>Name</th><th>Phase</th><th>Status</th><th>Blocking</th><th>Description</th><th>Missing Evidence</th></tr>
+      <tr><th>#</th><th>Name</th><th>Phase</th><th>Status</th><th>Blocking</th><th>Description</th><th>Missing Evidence</th><th>Evidence</th></tr>
     </thead>
     <tbody>
       {% for g in detail.validation_gates %}
+      {% set glinks = detail.evidence_index.get("validation_gate", {}).get(g.id, []) %}
       <tr class="gate-{{ g.status }}">
         <td class="count">{{ loop.index }}</td>
         <td>{{ g.name }}</td>
@@ -281,6 +296,18 @@
         <td>{{ "yes" if g.blocking else "no" }}</td>
         <td class="summary-cell">{{ g.description or "—" }}</td>
         <td class="summary-cell">{{ g.missing_evidence or "—" }}</td>
+        <td>
+          {% if glinks %}
+            {% for el in glinks %}
+            <div>
+              {% if el.source_title %}{{ el.source_title | truncate(36) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
+              <span class="rel-type">{{ el.relationship_type }}</span>
+            </div>
+            {% endfor %}
+          {% else %}
+          <span class="muted">none</span>
+          {% endif %}
+        </td>
       </tr>
       {% endfor %}
     </tbody>

--- a/docs/agent-draft-import.md
+++ b/docs/agent-draft-import.md
@@ -1,0 +1,180 @@
+# Agent Draft Import Format
+
+Issue: #27
+
+This document defines the APD draft import package contract for research-agent output.
+
+## Purpose
+
+An agent draft package is the handoff format between a research agent and APD.
+
+APD imports this package as draft/unreviewed research so humans can review and decide what to accept.
+
+Imported draft data is not accepted truth by default.
+
+## Command
+
+```text
+uv run python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
+```
+
+Optional duplicate override:
+
+```text
+uv run python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json --allow-duplicate-external-id
+```
+
+## Re-import behavior
+
+- Default behavior: reject duplicate `external_draft_id` imports.
+- If a package has an `external_draft_id` already imported, the command fails safely.
+- Use `--allow-duplicate-external-id` to intentionally import the same external draft ID again as a new run.
+- If `external_draft_id` is omitted, each import creates a new run.
+
+## Minimum required content
+
+A package must include:
+
+- `run` object
+- at least one of:
+  - `sources`
+  - `claims`
+  - `candidates`
+- plus `run.title` or `run.intent`
+
+## Draft package JSON shape
+
+```json
+{
+  "schema_version": "1.0",
+  "external_draft_id": "draft-optional-id",
+  "agent_name": "optional-agent-name",
+  "generated_at": "2026-04-26T18:20:00Z",
+  "run": {
+    "title": "optional-title",
+    "intent": "optional-intent",
+    "summary": "optional-summary",
+    "mode": "optional-mode",
+    "phase": "optional-run-phase",
+    "recommendation": "optional-draft-recommendation"
+  },
+  "warnings": ["optional warning strings"],
+  "limitations": ["optional limitation strings"],
+  "sources": [
+    {
+      "id": "src-1",
+      "title": "optional",
+      "source_type": "required",
+      "url": "optional",
+      "origin": "optional",
+      "author_or_org": "optional",
+      "captured_at": "optional datetime",
+      "published_at": "optional datetime",
+      "raw_path": "optional",
+      "normalized_path": "optional",
+      "reliability_notes": "optional",
+      "summary": "optional",
+      "metadata_json": {}
+    }
+  ],
+  "evidence_excerpts": [
+    {
+      "id": "ex-1",
+      "source_id": "src-1",
+      "excerpt_text": "required",
+      "location_reference": "optional",
+      "excerpt_type": "optional",
+      "metadata_json": {}
+    }
+  ],
+  "claims": [
+    {
+      "id": "claim-1",
+      "statement": "required",
+      "claim_type": "optional",
+      "confidence": 0.7,
+      "created_by": "optional",
+      "metadata_json": {}
+    }
+  ],
+  "themes": [
+    {
+      "id": "theme-1",
+      "name": "required",
+      "summary": "optional",
+      "theme_type": "optional",
+      "severity": "optional",
+      "frequency": "optional",
+      "user_segment": "optional",
+      "workflow": "optional",
+      "metadata_json": {}
+    }
+  ],
+  "candidates": [
+    {
+      "id": "cand-1",
+      "title": "required",
+      "summary": "optional",
+      "target_user": "optional",
+      "first_workflow": "optional",
+      "first_wedge": "optional",
+      "prototype_success_event": "optional",
+      "monetization_path": "optional",
+      "substitutes": "optional",
+      "risks": "optional",
+      "why_now": "optional",
+      "why_it_might_fail": "optional",
+      "score": 0.6,
+      "rank": 1,
+      "metadata_json": {}
+    }
+  ],
+  "validation_gates": [
+    {
+      "id": "gate-1",
+      "candidate_id": "optional candidate id",
+      "phase": "optional run phase",
+      "name": "required",
+      "description": "optional",
+      "status": "optional validation gate status",
+      "blocking": true,
+      "evidence_summary": "optional",
+      "missing_evidence": "optional",
+      "metadata_json": {}
+    }
+  ],
+  "evidence_links": [
+    {
+      "id": "link-1",
+      "source_id": "optional source id",
+      "excerpt_id": "optional excerpt id",
+      "target_type": "claim|theme|candidate|validation_gate",
+      "target_id": "required external object id",
+      "relationship": "supports|weakens|contradicts|context_for|example_of",
+      "strength": "weak|medium|strong",
+      "notes": "optional",
+      "metadata_json": {}
+    }
+  ]
+}
+```
+
+## Import semantics
+
+- Claims are imported with `review_status=unreviewed` and `is_agent_generated=true`.
+- Candidates are imported with `review_status=unreviewed` and `is_agent_generated=true`.
+- Themes are imported with `review_status=unreviewed` and metadata marker `agent_generated=true`.
+- Validation gates are imported without forcing accepted/satisfied status.
+- Evidence links map by external IDs in the package and preserve traceability.
+
+## Failure and warning behavior
+
+- Malformed JSON or schema violations fail with clear validation errors.
+- Unknown references in excerpts, gates, or evidence links are skipped with warning lines.
+- Import warnings are recorded in run metadata under `metadata_json.agent_draft.import_warnings`.
+
+## Sample package
+
+A committed example package is available at:
+
+- `apd/fixtures/examples/agent_draft_sample.json`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,6 +91,20 @@ python scripts/import_legacy_run.py --run-id 20260422-kickoff-smoke-r1
 
 The legacy import script is read-only against `research-corpus/runs/<run-id>/` and `artifacts/runs/<run-id>/`. It creates database records and warnings only; it does not rewrite manifests or Markdown files.
 
+To import a structured agent draft package as draft/unreviewed run data:
+
+```text
+python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
+```
+
+By default, duplicate `external_draft_id` values are rejected. To intentionally import another run version for the same external draft ID:
+
+```text
+python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json --allow-duplicate-external-id
+```
+
+See `docs/agent-draft-import.md` for the package JSON shape and semantics.
+
 The cleanup utility is intentionally conservative:
 
 - it removes only truly empty nested run directories

--- a/scripts/import_agent_draft.py
+++ b/scripts/import_agent_draft.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from apd.app.db import SessionLocal
+from apd.services.agent_draft_import import (
+    AgentDraftValidationError,
+    DuplicateExternalDraftIdError,
+    import_agent_draft_file,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Import an APD agent draft package JSON file as draft/unreviewed research. "
+            "This command does not fetch URLs or call external model APIs."
+        )
+    )
+    parser.add_argument("--path", required=True, help="Path to an agent draft package JSON file")
+    parser.add_argument(
+        "--allow-duplicate-external-id",
+        action="store_true",
+        help="Allow importing when external_draft_id has already been imported. By default duplicates are rejected.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    draft_path = Path(args.path)
+
+    with SessionLocal() as session:
+        try:
+            result = import_agent_draft_file(
+                session,
+                draft_path,
+                allow_duplicate_external_id=args.allow_duplicate_external_id,
+            )
+        except AgentDraftValidationError as exc:
+            print(f"path={draft_path.as_posix()} imported=false reason=validation_error errors={len(exc.errors)}")
+            for error in exc.errors:
+                print(f"ERROR: {error}")
+            return 2
+        except DuplicateExternalDraftIdError as exc:
+            print(
+                " ".join(
+                    [
+                        f"path={draft_path.as_posix()}",
+                        "imported=false",
+                        "reason=duplicate_external_draft_id",
+                        f"external_draft_id={exc.external_draft_id}",
+                        f"existing_run_id={exc.run_id}",
+                    ]
+                )
+            )
+            return 3
+
+    print(
+        " ".join(
+            [
+                f"path={draft_path.as_posix()}",
+                "imported=true",
+                f"run_db_id={result.run_db_id}",
+                f"external_draft_id={result.external_draft_id or 'none'}",
+                f"imported_sources={result.imported_source_count}",
+                f"imported_excerpts={result.imported_excerpt_count}",
+                f"imported_claims={result.imported_claim_count}",
+                f"imported_themes={result.imported_theme_count}",
+                f"imported_candidates={result.imported_candidate_count}",
+                f"imported_validation_gates={result.imported_validation_gate_count}",
+                f"imported_evidence_links={result.imported_evidence_link_count}",
+                f"warnings={len(result.warnings)}",
+            ]
+        )
+    )
+    for warning in result.warnings:
+        print(f"WARNING: {warning}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_draft_import.py
+++ b/tests/test_agent_draft_import.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from apd.app.db import Base
+from apd.domain.models import Candidate, Claim, EvidenceLink, ReviewStatus, Run, Theme, ValidationGate
+from apd.services.agent_draft_import import (
+    AgentDraftValidationError,
+    DuplicateExternalDraftIdError,
+    import_agent_draft_file,
+)
+from apd.services.report_export import export_run_markdown_report
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _sample_package(external_draft_id: str = "draft-abc") -> dict:
+    return {
+        "schema_version": "1.0",
+        "external_draft_id": external_draft_id,
+        "agent_name": "test-agent",
+        "run": {
+            "title": "Draft Import Test Run",
+            "intent": "Validate agent draft import path",
+            "summary": "Draft data for tests",
+            "mode": "agent_draft",
+            "phase": "evidence_collected",
+            "recommendation": "Watch"
+        },
+        "sources": [
+            {
+                "id": "src-1",
+                "title": "Source One",
+                "source_type": "note",
+                "summary": "Source summary"
+            }
+        ],
+        "evidence_excerpts": [
+            {
+                "id": "ex-1",
+                "source_id": "src-1",
+                "excerpt_text": "This is supporting evidence.",
+                "location_reference": "note-1"
+            }
+        ],
+        "claims": [
+            {
+                "id": "claim-1",
+                "statement": "Teams lose time to fragmented recruiting updates.",
+                "claim_type": "pain"
+            }
+        ],
+        "themes": [
+            {
+                "id": "theme-1",
+                "name": "Fragmented workflows",
+                "summary": "Coordination is spread across tools"
+            }
+        ],
+        "candidates": [
+            {
+                "id": "cand-1",
+                "title": "Recruiting Sync Ledger",
+                "summary": "One workflow for candidate state",
+                "target_user": "Recruiters",
+                "first_workflow": "Interview handoff",
+                "first_wedge": "Single source of truth"
+            }
+        ],
+        "validation_gates": [
+            {
+                "id": "gate-1",
+                "candidate_id": "cand-1",
+                "name": "Validate buyer urgency",
+                "description": "Interview three buyer-side operators",
+                "status": "not_started",
+                "missing_evidence": "No direct buyer interviews yet"
+            }
+        ],
+        "evidence_links": [
+            {
+                "id": "link-claim",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "target_type": "claim",
+                "target_id": "claim-1",
+                "relationship": "supports",
+                "strength": "medium"
+            },
+            {
+                "id": "link-theme",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "target_type": "theme",
+                "target_id": "theme-1",
+                "relationship": "example_of"
+            },
+            {
+                "id": "link-candidate",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "target_type": "candidate",
+                "target_id": "cand-1",
+                "relationship": "supports"
+            },
+            {
+                "id": "link-gate",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "target_type": "validation_gate",
+                "target_id": "gate-1",
+                "relationship": "context_for"
+            }
+        ]
+    }
+
+
+@pytest.fixture()
+def session_factory(tmp_path):
+    db_path = tmp_path / "test_agent_draft.db"
+    engine = create_engine(
+        f"sqlite+pysqlite:///{db_path}",
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def test_import_agent_draft_success(session_factory, tmp_path):
+    draft_path = tmp_path / "draft.json"
+    _write_json(draft_path, _sample_package())
+
+    with session_factory() as session:
+        result = import_agent_draft_file(session, draft_path)
+        run = session.get(Run, result.run_db_id)
+
+        assert run is not None
+        assert run.source_count == 1
+        assert run.claim_count == 1
+        assert run.theme_count == 1
+        assert run.candidate_count == 1
+
+        claims = session.execute(select(Claim).where(Claim.run_id == run.id)).scalars().all()
+        themes = session.execute(select(Theme).where(Theme.run_id == run.id)).scalars().all()
+        candidates = session.execute(select(Candidate).where(Candidate.run_id == run.id)).scalars().all()
+
+        assert claims[0].review_status == ReviewStatus.UNREVIEWED
+        assert claims[0].is_agent_generated is True
+        assert themes[0].review_status == ReviewStatus.UNREVIEWED
+        assert candidates[0].review_status == ReviewStatus.UNREVIEWED
+        assert candidates[0].is_agent_generated is True
+
+        links = session.execute(select(EvidenceLink).where(EvidenceLink.run_id == run.id)).scalars().all()
+        assert len(links) == 4
+        assert {str(link.target_type) for link in links} == {
+            "claim",
+            "theme",
+            "candidate",
+            "validation_gate",
+        }
+
+
+def test_import_agent_draft_rejects_malformed_package(session_factory, tmp_path):
+    invalid_path = tmp_path / "invalid.json"
+    _write_json(
+        invalid_path,
+        {
+            "schema_version": "1.0",
+            "run": {
+                "summary": "Missing title and intent"
+            },
+            "sources": [],
+            "claims": [],
+            "candidates": [],
+        },
+    )
+
+    with session_factory() as session:
+        with pytest.raises(AgentDraftValidationError) as exc_info:
+            import_agent_draft_file(session, invalid_path)
+
+    error_text = "\n".join(exc_info.value.errors)
+    assert "run.title or run.intent is required" in error_text
+
+
+def test_import_agent_draft_duplicate_external_id_behavior(session_factory, tmp_path):
+    draft_path = tmp_path / "draft.json"
+    _write_json(draft_path, _sample_package(external_draft_id="duplicate-id"))
+
+    with session_factory() as session:
+        first = import_agent_draft_file(session, draft_path)
+        assert first.run_db_id > 0
+
+        with pytest.raises(DuplicateExternalDraftIdError):
+            import_agent_draft_file(session, draft_path)
+
+        second = import_agent_draft_file(
+            session,
+            draft_path,
+            allow_duplicate_external_id=True,
+        )
+        assert second.run_db_id != first.run_db_id
+
+
+def test_imported_draft_visible_in_ui_and_report(session_factory, tmp_path, monkeypatch):
+    draft_path = tmp_path / "draft.json"
+    _write_json(draft_path, _sample_package(external_draft_id="ui-path"))
+
+    with session_factory() as session:
+        result = import_agent_draft_file(session, draft_path)
+        db_run_id = result.run_db_id
+
+    import apd.app.db as app_db
+    import apd.web.routes as web_routes
+
+    monkeypatch.setattr(app_db, "SessionLocal", session_factory)
+
+    def _override_get_db():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+    with TestClient(app, raise_server_exceptions=True) as client:
+        runs_page = client.get("/runs")
+        assert runs_page.status_code == 200
+        assert "Draft Import Test Run" in runs_page.text
+
+        detail_page = client.get(f"/runs/{db_run_id}")
+        assert detail_page.status_code == 200
+        assert "Source One" in detail_page.text
+        assert "Fragmented workflows" in detail_page.text
+        assert "Recruiting Sync Ledger" in detail_page.text
+        assert "Validate buyer urgency" in detail_page.text
+        assert "supports" in detail_page.text
+        assert "context_for" in detail_page.text
+
+    app.dependency_overrides.clear()
+
+    with session_factory() as session:
+        export = export_run_markdown_report(session, db_run_id, export_root=tmp_path / "exports")
+        assert export is not None
+        report = export.artifact_path.read_text(encoding="utf-8")
+        assert "Draft Import Test Run" in report
+        assert "## Sources" in report
+        assert "## Claims" in report
+        assert "## Themes" in report
+        assert "## Candidates" in report
+        assert "## Validation Gates And Gaps" in report
+        assert "supports" in report


### PR DESCRIPTION
﻿## Summary

Adds agent-draft import schema + importer command, sample fixture, docs, tests, and report/run-detail surfacing of imported draft metadata.

Closes #27

## Chosen re-import behavior

- Default: reject duplicate `external_draft_id` imports (safe failure).
- Opt-in override: `--allow-duplicate-external-id` permits intentional re-import as a new run.

## Exact files changed

- README.md
- scripts/README.md
- apd/services/agent_draft_import.py
- scripts/import_agent_draft.py
- apd/fixtures/examples/agent_draft_sample.json
- docs/agent-draft-import.md
- tests/test_agent_draft_import.py
- apd/web/templates/run_detail.html
- apd/services/report_export.py

## Verification

```text
uv run pytest -q tests/test_agent_draft_import.py
....                                                                     [100%]

uv run python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
path=apd/fixtures/examples/agent_draft_sample.json imported=true run_db_id=1 external_draft_id=draft-20260426-recruiting-ops-r1 imported_sources=2 imported_excerpts=2 imported_claims=1 imported_themes=1 imported_candidates=1 imported_validation_gates=1 imported_evidence_links=4 warnings=1
WARNING: Sample package uses synthetic IDs and should not be treated as accepted research.

uv run python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
path=apd/fixtures/examples/agent_draft_sample.json imported=false reason=duplicate_external_draft_id external_draft_id=draft-20260426-recruiting-ops-r1 existing_run_id=1
(exit code 1 expected for duplicate check)
```

## Manual verification package path

`apd/fixtures/examples/agent_draft_sample.json`

## Imported run ID from manual verification

`run_id=1`
