### PR TITLE
Document APD product investigation direction

### DIFF
--- a/docs/explanation/product-research-review-model.md
+++ b/docs/explanation/product-research-review-model.md
@@ -1,0 +1,137 @@
+# Product research review model
+
+APD separates different kinds of research objects because they mean different things and should be reviewed differently.
+
+A claim is not a theme. A theme is not a candidate. A candidate is not a decision to build. Review states should reflect those differences.
+
+## Claims
+
+Claims are propositions about the world.
+
+Examples:
+
+- Small teams struggle to tune alerts after their first production deployment.
+- Managed observability substitutes win because they reduce maintenance burden.
+- Restore confidence matters more than backup creation alone.
+
+Claim review answers: do we believe this proposition enough to use it?
+
+Suggested claim dispositions:
+
+- `unreviewed`: Imported or generated, not yet evaluated by a human.
+- `accepted`: True enough, with current evidence, to use in reasoning.
+- `weak`: Plausible but under-supported.
+- `disputed`: Possibly wrong, contradicted, or misleading.
+- `dismissed`: Not useful for this run, out of scope, or too low quality.
+- `needs_followup`: Important enough to investigate further.
+
+Current implementation may not support all of these states yet. The concept should guide future changes.
+
+## Themes
+
+Themes are synthesized patterns across claims, workflows, user pains, or substitutes.
+
+Examples:
+
+- Observability burden is cumulative, not one-time.
+- Managed substitutes win when support is part of the offer.
+- Deploy simplicity beats infrastructure flexibility in the first wedge.
+
+Theme review answers: is this a useful and sufficiently supported pattern?
+
+Suggested theme dispositions:
+
+- `unreviewed`: Imported or generated, not yet evaluated.
+- `supported`: A useful synthesis supported by enough claims/evidence.
+- `weak`: Interesting but not yet supported strongly.
+- `duplicate_or_merge`: Overlaps another theme and should be merged or reframed.
+- `dismissed`: Not useful or too vague.
+- `needs_more_evidence`: Useful but needs more support before driving candidate decisions.
+
+Themes should eventually show which claims support them and which candidates they help motivate.
+
+## Candidates
+
+Candidates are product opportunities or product wedges.
+
+Examples:
+
+- Compose Ops Wrapper for single-app production.
+- Observability Autopilot for self-hosted stacks.
+- Restore Drill Assistant for self-hosted stateful apps.
+
+Candidate review does not mean accepting the candidate as true. A candidate is not a proposition; it is a possible direction.
+
+Candidate review answers: what should we do with this opportunity?
+
+Suggested candidate dispositions:
+
+- `unreviewed`: Imported or generated, not yet evaluated.
+- `reject`: Do not pursue this direction.
+- `watch`: Keep it in the corpus, but do not act yet.
+- `validate_next`: Worth focused validation work.
+- `prototype_later`: Promising, but not the immediate next build.
+- `build_approved`: Human-approved for prototype brief or build-forward work.
+
+This differs from claim review. A claim can be accepted as true; a candidate should be advanced, parked, rejected, or promoted.
+
+## Validation gates
+
+Validation gates are the checklist that moves a candidate forward.
+
+A gate names a required learning milestone, such as:
+
+- Confirm buyer urgency.
+- Prove default alert packs reduce maintenance.
+- Test willingness to pay against managed incumbents.
+
+Gate review answers: what must be learned before this candidate can advance?
+
+Suggested gate states:
+
+- `not_started`: No validation work has been done.
+- `in_progress`: Validation is underway.
+- `weak`: Some evidence exists, but not enough.
+- `passed`: The gate is sufficiently satisfied for the current stage.
+- `failed`: The gate failed and should block or redirect the candidate.
+- `not_applicable`: The gate no longer applies.
+
+## Run decisions
+
+A run decision is the disposition of the overall research run.
+
+It should answer: what should happen after reviewing this run?
+
+Suggested run decisions:
+
+- `archive`: Keep the record, but do not pursue.
+- `watch`: Keep the area under observation.
+- `publish`: Turn the reviewed run into a public or private report.
+- `prototype_later`: Preserve as a promising future prototype direction.
+- `build_approved`: Move into prototype brief or build-forward workflow.
+
+## Review as human understanding
+
+Review is valuable even before any agent follow-up exists.
+
+The user is using APD to build their own map of a product space. Review actions should make that map clearer by distinguishing accepted claims, weak claims, disputed reasoning, useful themes, and candidate priorities.
+
+## Review as agent feedback
+
+Review should also become input to future agent loops.
+
+Examples:
+
+- A disputed claim can generate a follow-up research task.
+- A weak theme can request more supporting claims or better sources.
+- A promising candidate can request validation gates and interview questions.
+- A rejected candidate can teach the agent what not to propose again.
+- An accepted claim can enter the durable corpus as reusable knowledge.
+
+This feedback loop is a core future product direction.
+
+## Design principle
+
+Do not collapse all review into one generic status.
+
+Different object types need different review semantics. The UI may use shared controls where practical, but the product meaning should remain explicit.

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -1,0 +1,86 @@
+# APD product vision
+
+APD is a product investigation and guided product-development workspace.
+
+Its job is not to be a generic research archive or a generic coding agent wrapper. Its job is to help a user move from a product research question to a structured understanding of a product space, then to a decision about what to validate, park, reject, or prototype.
+
+The central product loop is:
+
+1. A user enters a product investigation direction.
+2. An agent produces a draft research map: sources, excerpts, claims, themes, candidates, validation gates, and evidence links.
+3. APD imports that draft as unreviewed structured research.
+4. The user reviews the reasoning chain from product candidates back to evidence.
+5. The user accepts, disputes, dismisses, or requests follow-up on parts of the map.
+6. APD converts that review into next actions: follow-up research, candidate validation, prototype brief, no-go decision, or build approval.
+
+## Positioning
+
+APD should be understood as an overlay over the product-development process.
+
+The differentiation is not simply that an LLM can research or write code. The differentiation is that APD organizes the messy middle between a vague product idea and a buildable direction:
+
+- It turns research into structured, reviewable product reasoning.
+- It makes evidence traceable.
+- It separates claims about the world from synthesized themes and proposed product candidates.
+- It gives the user an explicit review surface.
+- It preserves decisions and follow-up needs.
+- It can eventually turn a validated candidate into a prototype brief or scaffolded project.
+
+## Primary user job
+
+The user starts from a question like:
+
+> I know little about this space. Help me understand what is happening, what product opportunities might exist, why those opportunities were recommended, and what I should validate next.
+
+The user is not merely reading a report. They are building an internal map of a space.
+
+APD should help them:
+
+- identify product candidates
+- understand which pains, workflows, or themes each candidate addresses
+- inspect the claims behind those themes
+- trace claims back to sources and evidence excerpts
+- separate supported claims from weak or disputed ones
+- decide which candidate deserves more validation or prototyping
+
+## Product scope
+
+APD may use general research techniques, but the product should stay oriented around product investigation.
+
+Canonical use cases include:
+
+- market pain discovery
+- product opportunity research
+- competitor and substitute analysis
+- customer complaint mining
+- prototype prioritization
+- validation planning
+- guided transition from research to prototype brief
+
+Non-primary use cases include broad academic research, generic document search, generic note-taking, or generic enterprise knowledge management. Those may be adjacent later, but they should not drive the early product shape.
+
+## Expected outputs
+
+A successful APD run should produce more than a prose report.
+
+It should produce:
+
+- candidate product opportunities
+- themes or pain patterns
+- claims about users, workflows, substitutes, risks, and willingness to pay
+- source-backed evidence links
+- validation gates that describe what must be learned before advancing
+- review state and notes from the human
+- an explicit disposition: reject, watch, validate next, prototype later, or build approved
+
+## The build-forward extension
+
+The long-term path may extend beyond research into product creation.
+
+When a candidate is sufficiently reviewed and promoted, APD can eventually generate a prototype brief, a backlog, and possibly a scaffolded GitHub repository. The expected deliverable does not need to be a production-ready business. It can be a runnable prototype or design artifact that the user can inspect, continue developing, or use as inspiration.
+
+The key is that build-forward work should be grounded in reviewed product reasoning rather than raw brainstorming.
+
+## Current constraint
+
+APD is currently local-first and single-user. It should continue to support dogfooding locally while avoiding design choices that block future hosted or multi-user versions.


### PR DESCRIPTION
## Summary

Adds initial product-direction documentation for APD's post-MVP identity as a product investigation and guided product-development workspace.

Files added:
- `docs/explanation/product-vision.md`
- `docs/explanation/product-research-review-model.md`

These docs capture the product loop and the review semantics for claims, themes, candidates, validation gates, and run decisions.

## Notes

This is documentation-only. It should be followed by implementation issues for UI hierarchy, explicit reasoning relationships, theme review, candidate promotion, and follow-up research tasks.

## Verification

Docs-only PR. Recommended local checks:
- `./scripts/test.ps1`
- `python scripts/check_repo_readiness.py`

Refs #35