### PR TITLE
Document post-MVP roadmap and open questions

### DIFF
--- a/docs/planning/open-questions.md
+++ b/docs/planning/open-questions.md
@@ -1,0 +1,205 @@
+# Open product questions
+
+This document records choices APD should not resolve accidentally.
+
+The current direction is product investigation and guided product development. These questions should be revisited as the app is dogfooded.
+
+## Product scope
+
+### Should APD remain product-investigation-specific?
+
+Current leaning: yes.
+
+APD may use general research techniques, but the early product should stay focused on product opportunities, validation, and prototype readiness.
+
+Open question:
+
+- At what point, if any, should APD broaden into a general research deep-dive platform?
+
+Risk:
+
+- Broadening too early could make the workflow generic and less useful.
+
+## Corpus and accepted knowledge
+
+### What enters the accepted corpus?
+
+Possible options:
+
+- only accepted claims
+- accepted claims plus supported themes
+- accepted claims, supported themes, and promoted candidates
+- every imported object with review status attached
+
+Current leaning:
+
+- Store everything, but visually and operationally distinguish draft, weak, disputed, dismissed, and accepted knowledge.
+
+Open questions:
+
+- Should dismissed claims remain searchable?
+- Should disputed claims be hidden by default or surfaced as warnings?
+- How should accepted claims be revised if later evidence weakens them?
+
+## Candidate promotion
+
+### What does it mean to promote a candidate?
+
+A candidate is not a statement of fact. Promoting a candidate means choosing what action to take with that opportunity.
+
+Candidate states may include reject, watch, validate_next, prototype_later, and build_approved.
+
+Open questions:
+
+- Should candidate promotion automatically change the run decision?
+- Can multiple candidates in one run be promoted?
+- Should build_approved require all blocking validation gates to pass, or only require explicit human override?
+- Should APD support side-by-side candidate comparison before promotion?
+
+## Review feedback and follow-up research
+
+### What should happen when a user disputes a claim?
+
+Possible next actions:
+
+- record only the user's understanding
+- generate a follow-up research task
+- ask an agent to find confirming and disconfirming evidence
+- prevent the claim from supporting themes or candidates until resolved
+
+Current leaning:
+
+- Record the review first, then use it to generate optional follow-up tasks.
+
+Open questions:
+
+- Which review states should automatically suggest follow-up tasks?
+- Should follow-up tasks be run-scoped or corpus-scoped?
+- How should APD represent a revised claim after follow-up research?
+
+## Themes
+
+### Are themes durable knowledge objects?
+
+Themes summarize patterns. They may be run-local, or they may become durable corpus concepts.
+
+Open questions:
+
+- Should similar themes across runs be merged?
+- Who decides whether two themes are the same?
+- Should a theme be allowed to support multiple candidates across runs?
+
+## Reasoning relationships
+
+### How explicit should the reasoning graph be?
+
+The current evidence model links evidence to claims, themes, candidates, and validation gates. The product workflow also needs relationships such as candidate-addresses-theme and theme-supported-by-claim.
+
+Open questions:
+
+- Should these be first-class relationship records?
+- Should the draft import schema require them?
+- Should APD infer relationships from shared evidence links, or only display explicit links?
+
+Current leaning:
+
+- Add explicit relationships, but keep evidence links as the bottom-layer traceability model.
+
+## Agent execution boundary
+
+### Should APD run the model, or only coordinate external agents?
+
+Near-term workflow:
+
+- APD creates a research brief and generated prompt.
+- The user runs an external agent manually.
+- The user imports or pastes the returned draft package.
+
+Future options:
+
+- APD calls a configured model provider directly.
+- APD coordinates a local agent runner.
+- APD remains a review/import workspace and never owns model execution.
+
+Open questions:
+
+- What is the first model provider worth integrating?
+- Should users bring their own API keys?
+- How should APD enforce source permissions before it has real multi-user auth?
+
+## Source access and integrations
+
+### How much data should an agent be able to access?
+
+Current principle:
+
+- Agents should only access explicitly selected sources for a run.
+
+Open questions:
+
+- Are source packs enough, or does each run need a detailed source permission plan?
+- How should APD handle private data in later hosted versions?
+- Should derived claims from private sources be marked as private?
+- What should happen when a source is deleted or disconnected?
+
+## Build-forward output
+
+### What should APD produce after build approval?
+
+Possible outputs:
+
+- prototype brief
+- requirements and non-goals
+- validation plan
+- GitHub issue drafts
+- generated repository scaffold
+- runnable local prototype
+
+Current leaning:
+
+- Start with prototype brief and issue drafts before full repository generation.
+
+Open questions:
+
+- How complete should a generated prototype be?
+- Should APD create repositories directly, or only produce a build package?
+- How should repo-rails be used for generated project setup?
+- What counts as success for a prototype generated from APD?
+
+## Hosted or multi-user future
+
+### What must change for APD to become a hosted product?
+
+Likely requirements:
+
+- users
+- workspaces
+- workspace memberships
+- provider connections
+- data-source connections
+- credential handling
+- data isolation
+- deletion and purge policy
+- private/public export controls
+
+Open questions:
+
+- Is hosted APD a real product direction or only a future option?
+- Should local-first usage remain the primary path?
+- How should users audit what an agent saw and produced?
+
+## Product success signal
+
+### What would prove APD is useful?
+
+Possible signals:
+
+- User can understand a new product space faster than with a normal LLM report.
+- User can trace every candidate recommendation back to claims and evidence.
+- User can turn review feedback into better follow-up research.
+- User can promote a candidate into a prototype brief with less ambiguity.
+- User returns to the corpus to reuse prior accepted claims or themes.
+
+Open question:
+
+- Which of these should be the main dogfood metric for the next milestone?

--- a/docs/planning/post-mvp-roadmap.md
+++ b/docs/planning/post-mvp-roadmap.md
@@ -1,0 +1,144 @@
+# Post-MVP roadmap
+
+This roadmap starts from the current local APD cockpit: a single-user app that can import structured agent drafts, display runs, support human review, record decisions, export reports, and link legacy artifacts.
+
+The next phase is to turn that cockpit into a product investigation workflow.
+
+## North star
+
+APD should help a user move from a product research question to a reviewed product opportunity and then, when appropriate, to a prototype brief or scaffolded project.
+
+The product loop is:
+
+1. Create a research direction.
+2. Generate or import an agent draft.
+3. Review the candidate-centered reasoning chain.
+4. Accept, dispute, dismiss, or request follow-up on claims and themes.
+5. Promote, park, or reject candidates.
+6. Generate follow-up research tasks or a prototype brief.
+7. Preserve reviewed knowledge in the corpus.
+
+## Phase 1: Make the dogfood loop ergonomic
+
+Goal: reduce friction between research question, agent output, and APD review.
+
+Relevant issues:
+
+- #31 Add research brief creation UI and generated agent prompt
+- #32 Add browser-based agent draft import flow
+- #34 Add agent draft validation and repair workflow
+
+Expected result:
+
+A user can create a research brief in APD, copy a generated prompt to an external agent, paste the returned draft JSON back into APD, repair/validate it when needed, and immediately review the imported run.
+
+This is still not a fully automated agent runner. It is the minimum product-like workflow before APD starts calling models itself.
+
+## Phase 2: Make run review candidate-centered
+
+Goal: make APD feel like a product investigation cockpit rather than a structured report viewer.
+
+Relevant issues:
+
+- #35 Improve run detail UI for product-research review workflow
+- #38 Add explicit reasoning relationship model
+- #39 Add theme review surface and semantics
+- #40 Refine candidate review and promotion workflow
+
+Expected result:
+
+The user starts with product candidates, then drills down into validation gates, themes, claims, and evidence. The review actions fit the object being reviewed: claims are accepted/disputed/dismissed; themes are supported/weak/merged; candidates are rejected, watched, validated, prototyped later, or approved for build-forward work.
+
+## Phase 3: Turn review into next actions
+
+Goal: make human review feed the next research or product-development loop.
+
+Relevant issues:
+
+- #41 Generate follow-up research tasks from review feedback
+- future issue: generate validation brief from candidate gates
+- future issue: generate prototype brief from promoted candidate
+
+Expected result:
+
+A disputed claim can become a follow-up research task. A weak theme can request more evidence. A candidate marked validate_next can produce validation questions, source requests, or interview prompts. A candidate marked prototype_later or build_approved can produce a prototype brief.
+
+## Phase 4: Make the corpus first-class
+
+Goal: make accumulated research inspectable and reusable across runs.
+
+Relevant issues:
+
+- #22 Add corpus browser as first-class product surface
+- future issue: define accepted knowledge layer
+- future issue: search across runs and reviewed knowledge
+- future issue: show related runs, recurring themes, and repeated candidates
+
+Expected result:
+
+APD is no longer only a run viewer. It becomes a workspace where sources, claims, themes, candidates, review states, decisions, and artifacts can be inspected across runs.
+
+Accepted or supported knowledge should be visually distinct from unreviewed draft output.
+
+## Phase 5: Add research contexts and source ingestion
+
+Goal: let users prime research runs with selected data sources.
+
+Relevant issues:
+
+- #23 Add source pack model for reusable research contexts
+- #24 Add public URL source ingestion
+- #28 Add research brief and run config model
+- future issue: uploaded-file source ingestion
+- future issue: GitHub repository or issue source ingestion
+
+Expected result:
+
+A user can define a source pack, create a research brief, and tell an external or future internal agent what sources are allowed for a run. Source access should be explicit and scoped, not global.
+
+## Phase 6: Prepare for model/provider integrations
+
+Goal: avoid hardcoding APD to one AI provider or runtime.
+
+Relevant issues:
+
+- #25 Add model provider abstraction design and local stubs
+- #33 Add future local agent runner design and stub
+- #26 Design workspace and user boundary for future multi-user APD
+
+Expected result:
+
+APD has clear boundaries for model providers, source access, and user/workspace ownership. It remains local-first now, but does not paint itself into a corner if a hosted or multi-user version becomes useful.
+
+## Phase 7: Build-forward workflow
+
+Goal: turn a promoted product candidate into useful product-building artifacts.
+
+Future issues should cover:
+
+- prototype brief export
+- requirements and non-goals generation
+- GitHub issue draft export
+- scaffolded repository generation
+- repo-rails integration for generated projects
+- handoff from APD research run to a build project
+
+Expected result:
+
+When a candidate is sufficiently reviewed and promoted, APD can create a build package. The package may include a prototype brief, requirements, backlog, issue drafts, and possibly a runnable scaffolded repository.
+
+The goal is not to guarantee a production app. The goal is to produce a grounded, inspectable, runnable starting point.
+
+## Recommended near-term order
+
+1. #34 Agent draft validation and repair workflow
+2. #31 Research brief creation UI
+3. #32 Browser-based draft import flow
+4. #35 Candidate-centered run detail UI
+5. #38 Explicit reasoning relationships
+6. #39 Theme review
+7. #40 Candidate promotion
+8. #41 Follow-up research tasks
+9. #22 Corpus browser
+
+This order keeps the dogfood loop usable while moving the product toward the reviewed product-investigation workflow.


### PR DESCRIPTION
## Summary

Closes #37.

Adds the remaining planning docs for APD's post-MVP direction:

- `docs/planning/post-mvp-roadmap.md`
- `docs/planning/open-questions.md`

The roadmap connects the current local MVP to the product-investigation workflow: ergonomic dogfooding, candidate-centered review, review-to-follow-up loops, corpus work, source contexts, provider boundaries, and build-forward handoff.

The open questions doc records strategic choices APD should not resolve accidentally, including corpus semantics, candidate promotion, source permissions, agent execution boundaries, and build-forward output.

## Verification

Docs-only PR. Recommended local checks:

- `./scripts/test.ps1`
- `python scripts/check_repo_readiness.py`

## Notes

No app behavior, schema, UI, or generated local state changed.