### PR TITLE
Add agent draft validation and repair workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,16 @@ Current limitations:
 Import a structured agent draft package into APD:
 
 ```text
+uv run python scripts/validate_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
 uv run python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
+```
+
+Optional repair-oriented commands:
+
+```text
+uv run python scripts/validate_agent_draft.py --path .local/drafts/dogfood-product-research.json --repair-hints
+uv run python scripts/validate_agent_draft.py --path .local/drafts/dogfood-product-research.json --repair-prompt
+uv run python scripts/normalize_agent_draft.py --path .local/drafts/input.json --out .local/drafts/input.normalized.json
 ```
 
 Behavior:
@@ -318,6 +327,8 @@ Behavior:
 - Rejects duplicate `external_draft_id` by default; use `--allow-duplicate-external-id` to intentionally import another run version.
 
 Validation and safety:
+- `validate_agent_draft.py` is read-only and does not write to the database.
+- `normalize_agent_draft.py` only writes to the explicit output path you provide and still requires strict validation before import.
 - Malformed JSON and invalid package shape fail safely with clear `ERROR:` lines.
 - Unknown references (for example, evidence links to missing IDs) are skipped with `WARNING:` lines.
 - Imported warnings are recorded in run metadata.

--- a/apd/services/agent_draft_validation.py
+++ b/apd/services/agent_draft_validation.py
@@ -1,0 +1,499 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from apd.domain.models import EvidenceRelationship, EvidenceTargetType, RunPhase
+from apd.services.agent_draft_import import AgentDraftPackage
+
+
+FIELD_ALIASES: dict[str, dict[str, str]] = {
+    "sources": {
+        "type": "source_type",
+        "accessed_at": "captured_at",
+    },
+    "evidence_excerpts": {
+        "text": "excerpt_text",
+        "locator": "location_reference",
+    },
+    "claims": {
+        "claim": "statement",
+    },
+    "themes": {
+        "theme": "name",
+    },
+    "candidates": {
+        "name": "title",
+        "description": "summary",
+    },
+}
+
+LEGACY_GATE_PHASE_MAP = {
+    "problem_validation": RunPhase.SUPPORTED_OPPORTUNITY.value,
+    "solution_validation": RunPhase.VETTED_OPPORTUNITY.value,
+    "commercial_validation": RunPhase.VETTED_OPPORTUNITY.value,
+}
+
+LEGACY_EVIDENCE_TARGET_FIELDS = {
+    "claim_id": EvidenceTargetType.CLAIM.value,
+    "theme_id": EvidenceTargetType.THEME.value,
+    "candidate_id": EvidenceTargetType.CANDIDATE.value,
+    "gate_id": EvidenceTargetType.VALIDATION_GATE.value,
+}
+
+ALLOWED_GATE_PHASES = [phase.value for phase in RunPhase]
+ALLOWED_EVIDENCE_RELATIONSHIPS = [relationship.value for relationship in EvidenceRelationship]
+
+OBJECT_ALLOWED_FIELDS: dict[str, set[str]] = {
+    "run": {"title", "intent", "summary", "mode", "phase", "recommendation"},
+    "sources": {
+        "id",
+        "title",
+        "source_type",
+        "url",
+        "origin",
+        "author_or_org",
+        "captured_at",
+        "published_at",
+        "raw_path",
+        "normalized_path",
+        "reliability_notes",
+        "summary",
+        "metadata_json",
+    },
+    "evidence_excerpts": {
+        "id",
+        "source_id",
+        "excerpt_text",
+        "location_reference",
+        "excerpt_type",
+        "metadata_json",
+    },
+    "claims": {
+        "id",
+        "statement",
+        "claim_type",
+        "confidence",
+        "created_by",
+        "metadata_json",
+    },
+    "themes": {
+        "id",
+        "name",
+        "summary",
+        "theme_type",
+        "severity",
+        "frequency",
+        "user_segment",
+        "workflow",
+        "metadata_json",
+    },
+    "candidates": {
+        "id",
+        "title",
+        "summary",
+        "target_user",
+        "first_workflow",
+        "first_wedge",
+        "prototype_success_event",
+        "monetization_path",
+        "substitutes",
+        "risks",
+        "why_now",
+        "why_it_might_fail",
+        "score",
+        "rank",
+        "metadata_json",
+    },
+    "validation_gates": {
+        "id",
+        "candidate_id",
+        "phase",
+        "name",
+        "description",
+        "status",
+        "blocking",
+        "evidence_summary",
+        "missing_evidence",
+        "metadata_json",
+    },
+    "evidence_links": {
+        "id",
+        "source_id",
+        "excerpt_id",
+        "target_type",
+        "target_id",
+        "relationship",
+        "strength",
+        "notes",
+        "metadata_json",
+    },
+}
+
+
+@dataclass
+class AgentDraftValidationReport:
+    path: Path
+    is_valid: bool
+    package: AgentDraftPackage | None = None
+    errors: list[str] = field(default_factory=list)
+    grouped_errors: list[str] = field(default_factory=list)
+    repair_hints: list[str] = field(default_factory=list)
+
+    @property
+    def error_count(self) -> int:
+        return len(self.errors)
+
+    def build_repair_prompt(self) -> str:
+        summary_lines = self.grouped_errors or self.errors or ["No validation errors recorded."]
+        hint_lines = self.repair_hints or [
+            "Preserve the research meaning. Only repair APD draft schema shape, enums, and field names.",
+        ]
+        prompt_lines = [
+            "Repair this APD agent draft package so it passes strict APD draft validation.",
+            "Return only JSON.",
+            "Preserve the underlying research content and IDs unless a schema fix requires a field rename.",
+            "Use exact APD field names and enums.",
+            "Move unexpected extra object fields into metadata_json when they still matter.",
+            "",
+            "Validation summary:",
+        ]
+        prompt_lines.extend(f"- {line}" for line in summary_lines)
+        prompt_lines.append("")
+        prompt_lines.append("Likely fixes:")
+        prompt_lines.extend(f"- {line}" for line in hint_lines)
+        return "\n".join(prompt_lines)
+
+
+@dataclass
+class AgentDraftNormalizationResult:
+    normalized_data: dict[str, Any]
+    applied_fixes: list[str]
+    validation_report: AgentDraftValidationReport
+
+
+def validate_agent_draft_file(path: Path) -> AgentDraftValidationReport:
+    try:
+        raw_data = _read_raw_json(path)
+    except ValueError as exc:
+        error_text = str(exc)
+        return AgentDraftValidationReport(
+            path=path,
+            is_valid=False,
+            errors=[error_text],
+            grouped_errors=[error_text],
+        )
+    if not isinstance(raw_data, dict):
+        return AgentDraftValidationReport(
+            path=path,
+            is_valid=False,
+            errors=["top-level JSON value must be an object"],
+            grouped_errors=["Top-level JSON value must be an object."],
+            repair_hints=["Wrap the package in one JSON object with run, sources, claims, candidates, and related arrays."],
+        )
+
+    try:
+        package = AgentDraftPackage.model_validate(raw_data)
+    except ValidationError as exc:
+        errors = _format_validation_errors(exc)
+        grouped_errors = _collect_grouped_errors(raw_data)
+        repair_hints = _collect_repair_hints(raw_data)
+        if not grouped_errors:
+            grouped_errors = errors[:8]
+        return AgentDraftValidationReport(
+            path=path,
+            is_valid=False,
+            errors=errors,
+            grouped_errors=grouped_errors,
+            repair_hints=repair_hints,
+        )
+
+    return AgentDraftValidationReport(path=path, is_valid=True, package=package)
+
+
+def normalize_agent_draft_file(path: Path) -> AgentDraftNormalizationResult:
+    try:
+        raw_data = _read_raw_json(path)
+    except ValueError as exc:
+        report = AgentDraftValidationReport(
+            path=path,
+            is_valid=False,
+            errors=[str(exc)],
+            grouped_errors=[str(exc)],
+        )
+        return AgentDraftNormalizationResult(normalized_data={}, applied_fixes=[], validation_report=report)
+    if not isinstance(raw_data, dict):
+        report = AgentDraftValidationReport(
+            path=path,
+            is_valid=False,
+            errors=["top-level JSON value must be an object"],
+            grouped_errors=["Top-level JSON value must be an object."],
+        )
+        return AgentDraftNormalizationResult(normalized_data={}, applied_fixes=[], validation_report=report)
+
+    normalized = json.loads(json.dumps(raw_data))
+    applied_fixes: list[str] = []
+
+    _normalize_section_aliases(normalized, applied_fixes)
+    _normalize_claim_confidence(normalized, applied_fixes)
+    _normalize_gate_phases(normalized, applied_fixes)
+    _normalize_evidence_link_targets(normalized, applied_fixes)
+    _move_extra_fields_to_metadata(normalized, applied_fixes)
+
+    report = validate_agent_draft_data(path, normalized)
+    return AgentDraftNormalizationResult(
+        normalized_data=normalized,
+        applied_fixes=applied_fixes,
+        validation_report=report,
+    )
+
+
+def validate_agent_draft_data(path: Path, raw_data: dict[str, Any]) -> AgentDraftValidationReport:
+    try:
+        package = AgentDraftPackage.model_validate(raw_data)
+    except ValidationError as exc:
+        errors = _format_validation_errors(exc)
+        grouped_errors = _collect_grouped_errors(raw_data)
+        repair_hints = _collect_repair_hints(raw_data)
+        if not grouped_errors:
+            grouped_errors = errors[:8]
+        return AgentDraftValidationReport(
+            path=path,
+            is_valid=False,
+            errors=errors,
+            grouped_errors=grouped_errors,
+            repair_hints=repair_hints,
+        )
+
+    return AgentDraftValidationReport(path=path, is_valid=True, package=package)
+
+
+def _read_raw_json(path: Path) -> Any:
+    try:
+        raw_text = path.read_text(encoding="utf-8-sig")
+    except OSError as exc:
+        raise ValueError(f"could not read draft package: {exc}") from exc
+
+    try:
+        return json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+
+
+def _format_validation_errors(exc: ValidationError) -> list[str]:
+    errors: list[str] = []
+    for err in exc.errors():
+        location = ".".join(str(part) for part in err.get("loc", []))
+        message = err.get("msg", "validation error")
+        errors.append(f"{location}: {message}" if location else message)
+    return errors
+
+
+def _collect_grouped_errors(raw_data: dict[str, Any]) -> list[str]:
+    grouped: list[str] = []
+
+    for section, aliases in FIELD_ALIASES.items():
+        items = _section_items(raw_data, section)
+        for alias, canonical in aliases.items():
+            count = sum(1 for item in items if alias in item and canonical not in item)
+            if count:
+                grouped.append(
+                    f"{section}: rename {alias} -> {canonical} in {count} item(s)."
+                )
+
+    confidence_count = sum(
+        1
+        for item in _section_items(raw_data, "claims")
+        if isinstance(item.get("confidence"), str)
+    )
+    if confidence_count:
+        grouped.append(
+            f"claims: confidence must be numeric, not string, in {confidence_count} item(s)."
+        )
+
+    gate_phase_counts: dict[str, int] = {}
+    for item in _section_items(raw_data, "validation_gates"):
+        phase = item.get("phase")
+        if isinstance(phase, str) and phase in LEGACY_GATE_PHASE_MAP:
+            gate_phase_counts[phase] = gate_phase_counts.get(phase, 0) + 1
+    for phase, count in gate_phase_counts.items():
+        grouped.append(
+            f"validation_gates: phase {phase} is not allowed; use {LEGACY_GATE_PHASE_MAP[phase]} in {count} item(s)."
+        )
+
+    legacy_target_count = 0
+    for item in _section_items(raw_data, "evidence_links"):
+        if any(field in item for field in LEGACY_EVIDENCE_TARGET_FIELDS):
+            legacy_target_count += 1
+    if legacy_target_count:
+        grouped.append(
+            "evidence_links: replace legacy target fields like claim_id/theme_id/candidate_id/gate_id with target_type + target_id "
+            f"in {legacy_target_count} item(s)."
+        )
+
+    relationship_count = sum(
+        1
+        for item in _section_items(raw_data, "evidence_links")
+        if "relationship" not in item
+    )
+    if relationship_count:
+        grouped.append(
+            f"evidence_links: relationship is required in {relationship_count} item(s)."
+        )
+
+    extras = _collect_extra_field_summaries(raw_data)
+    grouped.extend(extras)
+    return grouped
+
+
+def _collect_repair_hints(raw_data: dict[str, Any]) -> list[str]:
+    hints: list[str] = []
+    for section, aliases in FIELD_ALIASES.items():
+        items = _section_items(raw_data, section)
+        for alias, canonical in aliases.items():
+            if any(alias in item and canonical not in item for item in items):
+                hints.append(f"In {section}, rename {alias} to {canonical}.")
+
+    if any(isinstance(item.get("confidence"), str) for item in _section_items(raw_data, "claims")):
+        hints.append("Convert claims.confidence values from quoted strings like \"0.72\" to numbers like 0.72.")
+
+    gate_aliases = [
+        phase
+        for phase in LEGACY_GATE_PHASE_MAP
+        if any(item.get("phase") == phase for item in _section_items(raw_data, "validation_gates"))
+    ]
+    if gate_aliases:
+        hints.append(
+            "Use validation_gates.phase values from the APD run phases only: "
+            + ", ".join(ALLOWED_GATE_PHASES)
+            + "."
+        )
+        for phase in gate_aliases:
+            hints.append(f"Map validation_gates.phase {phase} to {LEGACY_GATE_PHASE_MAP[phase]}.")
+
+    if any(any(field in item for field in LEGACY_EVIDENCE_TARGET_FIELDS) for item in _section_items(raw_data, "evidence_links")):
+        hints.append(
+            "Replace evidence_links legacy target fields with target_type and target_id: claim_id -> target_type claim, theme_id -> theme, candidate_id -> candidate, gate_id -> validation_gate."
+        )
+
+    if any("relationship" not in item for item in _section_items(raw_data, "evidence_links")):
+        hints.append(
+            "Each evidence link needs relationship set to one of: "
+            + ", ".join(ALLOWED_EVIDENCE_RELATIONSHIPS)
+            + "."
+        )
+
+    if _collect_extra_field_summaries(raw_data):
+        hints.append("Move unexpected extra object fields into metadata_json when they are still useful to keep.")
+
+    return hints
+
+
+def _section_items(raw_data: dict[str, Any], section: str) -> list[dict[str, Any]]:
+    value = raw_data.get(section)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _collect_extra_field_summaries(raw_data: dict[str, Any]) -> list[str]:
+    summaries: list[str] = []
+    run_value = raw_data.get("run")
+    if isinstance(run_value, dict):
+        extras = sorted(set(run_value) - OBJECT_ALLOWED_FIELDS["run"])
+        if extras:
+            summaries.append(f"run: unexpected fields {', '.join(extras)}.")
+
+    for section, allowed_fields in OBJECT_ALLOWED_FIELDS.items():
+        if section == "run":
+            continue
+        extras_count = 0
+        for item in _section_items(raw_data, section):
+            extras = set(item) - allowed_fields - set(FIELD_ALIASES.get(section, {})) - set(LEGACY_EVIDENCE_TARGET_FIELDS)
+            if extras:
+                extras_count += 1
+        if extras_count:
+            summaries.append(
+                f"{section}: move unexpected extra fields into metadata_json in {extras_count} item(s)."
+            )
+    return summaries
+
+
+def _normalize_section_aliases(raw_data: dict[str, Any], applied_fixes: list[str]) -> None:
+    for section, aliases in FIELD_ALIASES.items():
+        for index, item in enumerate(_section_items(raw_data, section)):
+            for alias, canonical in aliases.items():
+                if alias in item and canonical not in item:
+                    item[canonical] = item.pop(alias)
+                    applied_fixes.append(f"{section}[{index}]: renamed {alias} -> {canonical}")
+
+
+def _normalize_claim_confidence(raw_data: dict[str, Any], applied_fixes: list[str]) -> None:
+    for index, item in enumerate(_section_items(raw_data, "claims")):
+        confidence = item.get("confidence")
+        if isinstance(confidence, str):
+            try:
+                item["confidence"] = float(confidence)
+            except ValueError:
+                continue
+            applied_fixes.append(f"claims[{index}]: converted confidence string to number")
+
+
+def _normalize_gate_phases(raw_data: dict[str, Any], applied_fixes: list[str]) -> None:
+    for index, item in enumerate(_section_items(raw_data, "validation_gates")):
+        phase = item.get("phase")
+        if phase in LEGACY_GATE_PHASE_MAP:
+            item["phase"] = LEGACY_GATE_PHASE_MAP[phase]
+            applied_fixes.append(
+                f"validation_gates[{index}]: mapped phase {phase} -> {item['phase']}"
+            )
+
+
+def _normalize_evidence_link_targets(raw_data: dict[str, Any], applied_fixes: list[str]) -> None:
+    for index, item in enumerate(_section_items(raw_data, "evidence_links")):
+        if item.get("target_type") and item.get("target_id"):
+            continue
+
+        matches = [
+            (field_name, target_type, item.get(field_name))
+            for field_name, target_type in LEGACY_EVIDENCE_TARGET_FIELDS.items()
+            if item.get(field_name)
+        ]
+        if len(matches) != 1:
+            continue
+
+        field_name, target_type, target_id = matches[0]
+        item["target_type"] = target_type
+        item["target_id"] = target_id
+        item.pop(field_name, None)
+        applied_fixes.append(
+            f"evidence_links[{index}]: mapped {field_name} -> target_type={target_type}, target_id={target_id}"
+        )
+
+
+def _move_extra_fields_to_metadata(raw_data: dict[str, Any], applied_fixes: list[str]) -> None:
+    for section, allowed_fields in OBJECT_ALLOWED_FIELDS.items():
+        if section == "run":
+            continue
+        for index, item in enumerate(_section_items(raw_data, section)):
+            extras = sorted(
+                set(item)
+                - allowed_fields
+                - set(FIELD_ALIASES.get(section, {}))
+                - set(LEGACY_EVIDENCE_TARGET_FIELDS)
+            )
+            if not extras:
+                continue
+            metadata_json = item.get("metadata_json")
+            if not isinstance(metadata_json, dict):
+                metadata_json = {}
+                item["metadata_json"] = metadata_json
+            for field_name in extras:
+                metadata_json[field_name] = item.pop(field_name)
+            applied_fixes.append(
+                f"{section}[{index}]: moved unexpected fields to metadata_json ({', '.join(extras)})"
+            )

--- a/docs/agent-draft-import.md
+++ b/docs/agent-draft-import.md
@@ -24,6 +24,20 @@ Optional duplicate override:
 uv run python scripts/import_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json --allow-duplicate-external-id
 ```
 
+Validate before import:
+
+```text
+uv run python scripts/validate_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
+uv run python scripts/validate_agent_draft.py --path .local/drafts/dogfood-product-research.json --repair-hints
+uv run python scripts/validate_agent_draft.py --path .local/drafts/dogfood-product-research.json --repair-prompt
+```
+
+Optional best-effort normalization to an explicit output path:
+
+```text
+uv run python scripts/normalize_agent_draft.py --path .local/drafts/input.json --out .local/drafts/input.normalized.json
+```
+
 ## Re-import behavior
 
 - Default behavior: reject duplicate `external_draft_id` imports.
@@ -172,6 +186,77 @@ A package must include:
 - Malformed JSON or schema violations fail with clear validation errors.
 - Unknown references in excerpts, gates, or evidence links are skipped with warning lines.
 - Import warnings are recorded in run metadata under `metadata_json.agent_draft.import_warnings`.
+
+## Validation and repair loop
+
+Use this loop during dogfooding or external-agent handoff:
+
+1. Generate an APD draft package JSON file.
+2. Run `scripts/validate_agent_draft.py` before import.
+3. If validation fails, use `--repair-hints` or `--repair-prompt` to repair the JSON.
+4. Optionally run `scripts/normalize_agent_draft.py` to rewrite common near-miss fields to a new explicit output path.
+5. Re-run validation on the repaired or normalized file.
+6. Import only after strict validation passes.
+
+Validation is read-only and does not create a `Run` or any other database rows.
+
+Normalization is optional. It only writes to the output path you provide and does not import anything.
+
+Import remains the strict final gate. Validation and normalization should help repair packages, not weaken import rules.
+
+## Common near-miss fields
+
+The validator and normalizer recognize these common schema drifts:
+
+- `sources.type` -> `source_type`
+- `sources.accessed_at` -> `captured_at`
+- `evidence_excerpts.text` -> `excerpt_text`
+- `evidence_excerpts.locator` -> `location_reference`
+- `claims.claim` -> `statement`
+- `claims.confidence` string values should be numeric
+- `themes.theme` -> `name`
+- `candidates.name` -> `title`
+- `candidates.description` -> `summary`
+- `validation_gates.phase=problem_validation` -> `supported_opportunity`
+- `validation_gates.phase=solution_validation` -> `vetted_opportunity`
+- `validation_gates.phase=commercial_validation` -> `vetted_opportunity`
+- `evidence_links.claim_id|theme_id|candidate_id|gate_id` -> `target_type` + `target_id`
+- missing `evidence_links.relationship`
+- unexpected extra object fields that belong in `metadata_json`
+
+## Repair prompt template
+
+If you want a copyable prompt without running `--repair-prompt`, use this template:
+
+```text
+Repair this APD agent draft package so it passes strict APD draft validation.
+Return only JSON.
+Preserve the research meaning and IDs unless a schema repair requires a field rename.
+Use exact APD field names and enums.
+Move unexpected extra object fields into metadata_json when they still matter.
+
+Fix these common APD schema near-misses when present:
+- sources.type -> source_type
+- sources.accessed_at -> captured_at
+- evidence_excerpts.text -> excerpt_text
+- evidence_excerpts.locator -> location_reference
+- claims.claim -> statement
+- claims.confidence must be numeric, not a string
+- themes.theme -> name
+- candidates.name -> title
+- candidates.description -> summary
+- validation_gates.phase must be one of vague_notion, evidence_collected, supported_opportunity, vetted_opportunity, prototype_ready, build_approved
+- validation_gates.problem_validation -> supported_opportunity
+- validation_gates.solution_validation -> vetted_opportunity
+- validation_gates.commercial_validation -> vetted_opportunity
+- evidence_links.claim_id -> target_type claim + target_id
+- evidence_links.theme_id -> target_type theme + target_id
+- evidence_links.candidate_id -> target_type candidate + target_id
+- evidence_links.gate_id -> target_type validation_gate + target_id
+- evidence_links must include relationship: supports, weakens, contradicts, context_for, or example_of
+
+Return corrected JSON only.
+```
 
 ## Sample package
 

--- a/scripts/normalize_agent_draft.py
+++ b/scripts/normalize_agent_draft.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from apd.services.agent_draft_validation import normalize_agent_draft_file
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Best-effort normalize a near-miss APD agent draft package to an explicit output path. "
+            "Normalization never imports data and strict validation remains the final gate."
+        )
+    )
+    parser.add_argument("--path", required=True, help="Path to an input agent draft package JSON file")
+    parser.add_argument("--out", required=True, help="Explicit output path for the normalized JSON file")
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    input_path = Path(args.path)
+    output_path = Path(args.out)
+
+    result = normalize_agent_draft_file(input_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result.normalized_data, indent=2), encoding="utf-8")
+
+    report = result.validation_report
+    print(
+        " ".join(
+            [
+                f"path={input_path.as_posix()}",
+                f"out={output_path.as_posix()}",
+                f"applied_fixes={len(result.applied_fixes)}",
+                f"valid={'true' if report.is_valid else 'false'}",
+                f"errors={report.error_count}",
+            ]
+        )
+    )
+    for fix in result.applied_fixes[:20]:
+        print(f"FIX: {fix}")
+    if not report.is_valid:
+        for summary in report.grouped_errors[:12]:
+            print(f"ISSUE: {summary}")
+        for hint in report.repair_hints[:16]:
+            print(f"HINT: {hint}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_agent_draft.py
+++ b/scripts/validate_agent_draft.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from apd.services.agent_draft_validation import validate_agent_draft_file
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate an APD agent draft package JSON file without writing anything to the database. "
+            "Use this before import to catch schema drift and common near-miss fields."
+        )
+    )
+    parser.add_argument("--path", required=True, help="Path to an agent draft package JSON file")
+    parser.add_argument(
+        "--repair-hints",
+        action="store_true",
+        help="Print concise repair hints for common near-miss schema problems.",
+    )
+    parser.add_argument(
+        "--repair-prompt",
+        action="store_true",
+        help="Print a copyable repair prompt for an LLM or manual repair pass.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    draft_path = Path(args.path)
+    report = validate_agent_draft_file(draft_path)
+
+    if report.is_valid:
+        print(
+            " ".join(
+                [
+                    f"path={draft_path.as_posix()}",
+                    "valid=true",
+                    "errors=0",
+                    "hints=0",
+                ]
+            )
+        )
+        return 0
+
+    print(
+        " ".join(
+            [
+                f"path={draft_path.as_posix()}",
+                "valid=false",
+                f"errors={report.error_count}",
+                f"summaries={len(report.grouped_errors)}",
+                f"hints={len(report.repair_hints)}",
+            ]
+        )
+    )
+    for summary in report.grouped_errors[:12]:
+        print(f"ISSUE: {summary}")
+    if args.repair_hints:
+        for hint in report.repair_hints[:16]:
+            print(f"HINT: {hint}")
+    if args.repair_prompt:
+        print("REPAIR_PROMPT_BEGIN")
+        print(report.build_repair_prompt())
+        print("REPAIR_PROMPT_END")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_draft_validation.py
+++ b/tests/test_agent_draft_validation.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session
+
+from apd.app.db import Base
+from apd.domain.models import Run
+from apd.services.agent_draft_validation import validate_agent_draft_file
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SAMPLE_PACKAGE = ROOT / "apd" / "fixtures" / "examples" / "agent_draft_sample.json"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _near_miss_package() -> dict:
+    return {
+        "schema_version": "1.0",
+        "external_draft_id": "draft-near-miss",
+        "agent_name": "test-agent",
+        "run": {
+            "title": "Near miss package",
+            "intent": "Exercise repair hints",
+            "summary": "Contains common near-miss fields",
+        },
+        "sources": [
+            {
+                "id": "src-1",
+                "title": "Source One",
+                "type": "note",
+                "accessed_at": "2026-04-26T18:20:00Z",
+                "extra_note": "keep me",
+            }
+        ],
+        "evidence_excerpts": [
+            {
+                "id": "ex-1",
+                "source_id": "src-1",
+                "text": "Support text",
+                "locator": "note-1",
+            }
+        ],
+        "claims": [
+            {
+                "id": "claim-1",
+                "claim": "Claim text",
+                "confidence": "0.65",
+            }
+        ],
+        "themes": [
+            {
+                "id": "theme-1",
+                "theme": "Theme title",
+            }
+        ],
+        "candidates": [
+            {
+                "id": "cand-1",
+                "name": "Candidate name",
+                "description": "Candidate summary",
+            }
+        ],
+        "validation_gates": [
+            {
+                "id": "gate-1",
+                "candidate_id": "cand-1",
+                "phase": "problem_validation",
+                "name": "Validate urgency",
+            }
+        ],
+        "evidence_links": [
+            {
+                "id": "link-1",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "claim_id": "claim-1",
+            },
+            {
+                "id": "link-2",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "theme_id": "theme-1",
+                "relationship": "example_of",
+            },
+            {
+                "id": "link-3",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "candidate_id": "cand-1",
+                "relationship": "supports",
+            },
+            {
+                "id": "link-4",
+                "source_id": "src-1",
+                "excerpt_id": "ex-1",
+                "gate_id": "gate-1",
+                "relationship": "context_for",
+            },
+        ],
+    }
+
+
+def test_validate_agent_draft_sample_package_passes() -> None:
+    report = validate_agent_draft_file(SAMPLE_PACKAGE)
+    assert report.is_valid is True
+    assert report.error_count == 0
+    assert report.grouped_errors == []
+
+
+def test_validate_agent_draft_handles_utf8_bom(tmp_path) -> None:
+    bom_sample = tmp_path / "sample-with-bom.json"
+    payload = SAMPLE_PACKAGE.read_text(encoding="utf-8")
+    bom_sample.write_text(payload, encoding="utf-8-sig")
+
+    report = validate_agent_draft_file(bom_sample)
+
+    assert report.is_valid is True
+    assert report.error_count == 0
+
+
+def test_validate_agent_draft_invalid_package_outputs_actionable_hints(tmp_path) -> None:
+    near_miss_path = tmp_path / "near-miss.json"
+    _write_json(near_miss_path, _near_miss_package())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validate_agent_draft.py",
+            "--path",
+            str(near_miss_path),
+            "--repair-hints",
+            "--repair-prompt",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "valid=false" in result.stdout
+    assert "ISSUE: sources: rename type -> source_type" in result.stdout
+    assert "ISSUE: evidence_links: replace legacy target fields" in result.stdout
+    assert "HINT: In claims, rename claim to statement." in result.stdout
+    assert "HINT: Map validation_gates.phase problem_validation to supported_opportunity." in result.stdout
+    assert "REPAIR_PROMPT_BEGIN" in result.stdout
+    assert "Return only JSON." in result.stdout
+
+
+def test_validate_agent_draft_does_not_write_database(tmp_path) -> None:
+    db_path = tmp_path / "validate_only.db"
+    engine = create_engine(
+        f"sqlite+pysqlite:///{db_path}",
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validate_agent_draft.py",
+            "--path",
+            str(SAMPLE_PACKAGE),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "APD_DATABASE_URL": f"sqlite+pysqlite:///{db_path}"},
+    )
+
+    assert result.returncode == 0
+    with Session(engine) as session:
+        run_count = session.scalar(select(func.count()).select_from(Run))
+        assert run_count == 0
+
+
+def test_normalize_agent_draft_repairs_common_near_misses(tmp_path) -> None:
+    near_miss_path = tmp_path / "near-miss.json"
+    normalized_path = tmp_path / "near-miss.normalized.json"
+    payload = _near_miss_package()
+    payload["evidence_links"][0]["relationship"] = "supports"
+    _write_json(near_miss_path, payload)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/normalize_agent_draft.py",
+            "--path",
+            str(near_miss_path),
+            "--out",
+            str(normalized_path),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert normalized_path.exists()
+    assert "applied_fixes=" in result.stdout
+    report = validate_agent_draft_file(normalized_path)
+    assert report.is_valid is True


### PR DESCRIPTION
﻿## Summary

Adds a read-only APD agent draft validation workflow, actionable repair hints, a copyable repair prompt mode, and an optional best-effort normalization command that writes only to an explicit output path. Import validation remains strict and unchanged as the final gate.

Refs #34

## What Changed

- Added `apd/services/agent_draft_validation.py` for strict validation reports, grouped near-miss summaries, repair hints, repair prompt generation, and best-effort normalization.
- Added `scripts/validate_agent_draft.py` for validate-only checks with concise output and nonzero exit on invalid packages.
- Added `scripts/normalize_agent_draft.py` for explicit-output normalization of common schema drift before re-validation.
- Added `tests/test_agent_draft_validation.py` covering valid packages, invalid packages, near-miss hints, UTF-8 BOM handling, normalization, and validate-only no-DB behavior.
- Updated `docs/agent-draft-import.md` with the generate -> validate -> repair -> validate -> import loop, common near-miss mappings, and a copyable repair prompt template.
- Updated `README.md` to surface the validation and normalization command flow.

## Exact Files Changed

- `README.md`
- `docs/agent-draft-import.md`
- `apd/services/agent_draft_validation.py`
- `scripts/validate_agent_draft.py`
- `scripts/normalize_agent_draft.py`
- `tests/test_agent_draft_validation.py`

## Verification

Commands run:

```text
./scripts/test.ps1
python scripts/check_repo_readiness.py
uv run pytest -q tests/test_agent_draft_validation.py
uv run python scripts/validate_agent_draft.py --path apd/fixtures/examples/agent_draft_sample.json
uv run python scripts/validate_agent_draft.py --path .local/drafts/issue34-near-miss.json --repair-hints
uv run python scripts/normalize_agent_draft.py --path .local/drafts/issue34-near-miss.json --out .local/drafts/issue34-near-miss.normalized.json
uv run python scripts/normalize_agent_draft.py --path .local/drafts/issue34-near-miss-fixable.json --out .local/drafts/issue34-near-miss-fixable.normalized.json
uv run python scripts/validate_agent_draft.py --path .local/drafts/issue34-near-miss-fixable.normalized.json
```

Results:

- `./scripts/test.ps1`: passed
- `python scripts/check_repo_readiness.py`: `READY  Repo contains the required bootstrap files and directories.`
- `uv run pytest -q tests/test_agent_draft_validation.py`: passed (`5 passed`)
- validate-only against the sample package: `valid=true errors=0 hints=0`
- validate-only with `APD_DATABASE_URL=sqlite+pysqlite:///./.local/issue34-validate-only.db`: passed and no DB file was created
- strict validate + import with a fresh sqlite DB: alembic upgrade passed, validation passed, import succeeded with `imported=true`

## Sample Validation Output

Valid sample:

```text
path=apd/fixtures/examples/agent_draft_sample.json valid=true errors=0 hints=0
```

Invalid near-miss sample:

```text
path=.local/drafts/issue34-near-miss.json valid=false errors=25 summaries=9 hints=10
ISSUE: sources: rename type -> source_type in 1 item(s).
ISSUE: evidence_excerpts: rename text -> excerpt_text in 1 item(s).
ISSUE: claims: rename claim -> statement in 1 item(s).
ISSUE: themes: rename theme -> name in 1 item(s).
ISSUE: candidates: rename name -> title in 1 item(s).
ISSUE: candidates: rename description -> summary in 1 item(s).
ISSUE: validation_gates: phase problem_validation is not allowed; use supported_opportunity in 1 item(s).
ISSUE: evidence_links: replace legacy target fields like claim_id/theme_id/candidate_id/gate_id with target_type + target_id in 4 item(s).
ISSUE: evidence_links: relationship is required in 1 item(s).
```

Normalization with one remaining issue:

```text
path=.local/drafts/issue34-near-miss.json out=.local/drafts/issue34-near-miss.normalized.json applied_fixes=11 valid=false errors=1
ISSUE: evidence_links: relationship is required in 1 item(s).
```

Normalization after all required relationships are present:

```text
path=.local/drafts/issue34-near-miss-fixable.json out=.local/drafts/issue34-near-miss-fixable.normalized.json applied_fixes=11 valid=true errors=0
path=.local/drafts/issue34-near-miss-fixable.normalized.json valid=true errors=0 hints=0
```

## Normalization Status

Implemented. The normalizer only writes to the explicit `--out` path, does not import anything, and still requires strict validation before import.

## Risk / Deployment Impact

- No deployment changes.
- No external model calls.
- No import-validation weakening by default.
- Validate-only remains read-only and does not create database rows.

## Reviewer Focus

- Read-only validation path and exit codes
- Actionability and concision of grouped schema errors and repair hints
- Best-effort normalization behavior for common near-miss fields and legacy evidence-link targets
- UTF-8 BOM handling for Windows-created JSON files
- Confirmation that import remains the strict final gate
