### PR TITLE
Add research brief UI and generated agent prompt

### DIFF
--- a/alembic/versions/20260427_0002_add_research_briefs.py
+++ b/alembic/versions/20260427_0002_add_research_briefs.py
@@ -1,0 +1,65 @@
+"""add research_briefs table
+
+Revision ID: 20260427_0002
+Revises: 20260427_0001
+Create Date: 2026-04-27 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260427_0002"
+down_revision = "20260427_0001"
+branch_labels = None
+depends_on = None
+
+research_brief_status_enum = sa.Enum(
+    "draft",
+    "ready",
+    "external_agent_prompted",
+    "imported",
+    "archived",
+    name="researchbriefstatus",
+    native_enum=False,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "research_briefs",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("research_question", sa.Text(), nullable=False),
+        sa.Column("constraints", sa.Text(), nullable=True),
+        sa.Column("desired_depth", sa.String(64), nullable=True),
+        sa.Column("expected_outputs", sa.Text(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            research_brief_status_enum,
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("metadata_json", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("research_briefs")

--- a/apd/domain/models.py
+++ b/apd/domain/models.py
@@ -96,6 +96,14 @@ class EvidenceStrength(StrEnum):
     STRONG = "strong"
 
 
+class ResearchBriefStatus(StrEnum):
+    DRAFT = "draft"
+    READY = "ready"
+    EXTERNAL_AGENT_PROMPTED = "external_agent_prompted"
+    IMPORTED = "imported"
+    ARCHIVED = "archived"
+
+
 class Run(Base):
     __tablename__ = "runs"
 
@@ -383,3 +391,23 @@ class Artifact(Base):
 
     run: Mapped[Run] = relationship(back_populates="artifacts")
     candidate: Mapped[Optional[Candidate]] = relationship(back_populates="artifacts")
+
+
+class ResearchBrief(Base):
+    __tablename__ = "research_briefs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    research_question: Mapped[str] = mapped_column(Text, nullable=False)
+    constraints: Mapped[Optional[str]] = mapped_column(Text)
+    desired_depth: Mapped[Optional[str]] = mapped_column(String(64))
+    expected_outputs: Mapped[Optional[str]] = mapped_column(Text)
+    notes: Mapped[Optional[str]] = mapped_column(Text)
+    status: Mapped[ResearchBriefStatus] = mapped_column(
+        SqlEnum(ResearchBriefStatus, native_enum=False, validate_strings=True),
+        nullable=False,
+        default=ResearchBriefStatus.DRAFT,
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
+    metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)

--- a/apd/services/research_brief_service.py
+++ b/apd/services/research_brief_service.py
@@ -1,0 +1,206 @@
+"""Research brief service: CRUD operations and agent prompt generation."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from apd.domain.models import ResearchBrief, ResearchBriefStatus
+
+# ── APD schema field reminders embedded in every generated prompt ─────────────
+_SCHEMA_REMINDERS = """\
+## APD draft JSON schema requirements
+
+Return a single JSON object matching the APD agent draft package format.
+
+### Top-level shape
+
+```json
+{
+  "schema_version": "1.0",
+  "external_draft_id": "<unique-id>",
+  "agent_name": "<your-agent-name>",
+  "generated_at": "<ISO-8601 datetime>",
+  "run": { ... },
+  "sources": [ ... ],
+  "evidence_excerpts": [ ... ],
+  "claims": [ ... ],
+  "themes": [ ... ],
+  "candidates": [ ... ],
+  "validation_gates": [ ... ],
+  "evidence_links": [ ... ]
+}
+```
+
+### Required and common field names — use these exactly
+
+| Object            | Required field      | Common wrong name |
+|-------------------|---------------------|-------------------|
+| sources           | source_type         | type              |
+| evidence_excerpts | excerpt_text        | text              |
+| claims            | statement           | claim             |
+| themes            | name                | theme             |
+| candidates        | title               | name              |
+| candidates        | summary             | description       |
+| evidence_links    | target_type         | claim_id / theme_id / candidate_id / gate_id |
+| evidence_links    | target_id           | (same as above)   |
+| evidence_links    | relationship        | (must be present) |
+
+### Allowed values
+
+- `sources.source_type`: any descriptive string (e.g. "reddit_thread", "blog_post", "hn_comment")
+- `evidence_links.target_type`: claim | theme | candidate | validation_gate
+- `evidence_links.relationship`: supports | weakens | contradicts | context_for | example_of
+- `evidence_links.strength`: weak | medium | strong
+- `validation_gates.phase`: vague_notion | evidence_collected | supported_opportunity | vetted_opportunity | prototype_ready | build_approved
+- `validation_gates.status`: not_started | in_progress | satisfied | weak | failed | waived
+
+### Minimum required content
+
+The package must include:
+- A `run` object with `title` or `intent`.
+- At least one of: `sources`, `claims`, or `candidates`.
+
+Produce as many of the following as the research supports:
+- sources and evidence_excerpts (with source → excerpt links)
+- claims (specific assertions about users, pain, workflow, substitutes, willingness-to-pay, or risk)
+- themes (clusters of related pain, need, workaround, or opportunity)
+- candidates (possible product wedges with title and summary)
+- validation_gates (required checks before a run can credibly advance)
+- evidence_links (connecting excerpts or sources to claims, themes, candidates, or gates)
+
+### APD validation and repair tooling
+
+APD includes a validation and repair tool you can run before import:
+
+```bash
+uv run python scripts/validate_agent_draft.py --path <draft.json> --repair-hints
+uv run python scripts/normalize_agent_draft.py --path <draft.json> --out <normalized.json>
+```
+
+Producing valid JSON on the first attempt avoids requiring a repair loop.
+"""
+
+# ── CRUD ─────────────────────────────────────────────────────────────────────
+
+
+def create_brief(
+    db: Session,
+    *,
+    title: str,
+    research_question: str,
+    constraints: Optional[str] = None,
+    desired_depth: Optional[str] = None,
+    expected_outputs: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> ResearchBrief:
+    brief = ResearchBrief(
+        title=title.strip(),
+        research_question=research_question.strip(),
+        constraints=constraints.strip() if constraints else None,
+        desired_depth=desired_depth.strip() if desired_depth else None,
+        expected_outputs=expected_outputs.strip() if expected_outputs else None,
+        notes=notes.strip() if notes else None,
+        status=ResearchBriefStatus.DRAFT,
+    )
+    db.add(brief)
+    db.commit()
+    db.refresh(brief)
+    return brief
+
+
+def list_briefs(db: Session) -> list[ResearchBrief]:
+    return (
+        db.query(ResearchBrief)
+        .order_by(ResearchBrief.created_at.desc())
+        .all()
+    )
+
+
+def get_brief(db: Session, brief_id: int) -> Optional[ResearchBrief]:
+    return db.query(ResearchBrief).filter(ResearchBrief.id == brief_id).first()
+
+
+def update_brief_status(
+    db: Session,
+    brief: ResearchBrief,
+    status: ResearchBriefStatus,
+) -> ResearchBrief:
+    brief.status = status
+    db.commit()
+    db.refresh(brief)
+    return brief
+
+
+# ── Prompt generation ─────────────────────────────────────────────────────────
+
+
+def generate_agent_prompt(brief: ResearchBrief) -> str:
+    """Return a copyable agent prompt for the given research brief."""
+    lines: list[str] = []
+
+    lines.append("# APD Research Agent Prompt")
+    lines.append("")
+    lines.append(
+        "You are a product research agent. Your task is to investigate the research "
+        "direction below and return structured findings as a valid APD agent draft JSON package."
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Research direction")
+    lines.append("")
+    lines.append(brief.research_question)
+    lines.append("")
+
+    if brief.constraints:
+        lines.append("## Constraints")
+        lines.append("")
+        lines.append(brief.constraints)
+        lines.append("")
+
+    if brief.desired_depth:
+        lines.append("## Desired depth")
+        lines.append("")
+        lines.append(brief.desired_depth)
+        lines.append("")
+
+    if brief.expected_outputs:
+        lines.append("## Expected outputs")
+        lines.append("")
+        lines.append(brief.expected_outputs)
+        lines.append("")
+
+    if brief.notes:
+        lines.append("## Additional notes")
+        lines.append("")
+        lines.append(brief.notes)
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(_SCHEMA_REMINDERS)
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## Safety constraints (mandatory)")
+    lines.append("")
+    lines.append(
+        "- Return only valid APD draft JSON. Do not wrap it in prose or markdown fences "
+        "unless the entire response is a single fenced ```json block."
+    )
+    lines.append("- All output is draft and unreviewed. Do not assert conclusions as facts.")
+    lines.append(
+        "- Do not publish externally, create GitHub issues or repositories, send emails, "
+        "post to social media, or take any external actions."
+    )
+    lines.append("- Do not call external APIs, fetch live URLs, or access private data.")
+    lines.append("- Do not run code or execute commands.")
+    lines.append("")
+    lines.append(
+        "Return only the JSON package. APD will import and review it."
+    )
+
+    return "\n".join(lines)

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -16,6 +16,12 @@ from apd.web.mutations import (
     update_run_decision,
 )
 from apd.services.report_export import export_run_markdown_report
+from apd.services.research_brief_service import (
+    create_brief,
+    generate_agent_prompt,
+    get_brief,
+    list_briefs,
+)
 from apd.web.queries import get_recent_runs, get_run_detail
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -161,4 +167,63 @@ def export_report(run_id: int, db: Session = Depends(_get_db)):
     if result is None:
         raise HTTPException(status_code=404, detail="Run not found")
     return RedirectResponse(url=f"/runs/{run_id}#artifacts", status_code=303)
+
+
+# ── Research briefs ────────────────────────────────────────────────────────────
+
+
+@router.get("/briefs", response_class=HTMLResponse)
+def briefs_list(request: Request, db: Session = Depends(_get_db)):
+    briefs = list_briefs(db)
+    return templates.TemplateResponse(
+        request,
+        "briefs_list.html",
+        {"briefs": briefs},
+    )
+
+
+@router.get("/briefs/new", response_class=HTMLResponse)
+def briefs_new(request: Request):
+    return templates.TemplateResponse(
+        request,
+        "brief_new.html",
+        {},
+    )
+
+
+@router.post("/briefs", response_class=RedirectResponse)
+def briefs_create(
+    title: str = Form(...),
+    research_question: str = Form(...),
+    constraints: str = Form(""),
+    desired_depth: str = Form(""),
+    expected_outputs: str = Form(""),
+    notes: str = Form(""),
+    db: Session = Depends(_get_db),
+):
+    if not title.strip() or not research_question.strip():
+        raise HTTPException(status_code=422, detail="Title and research question are required")
+    brief = create_brief(
+        db,
+        title=title,
+        research_question=research_question,
+        constraints=constraints or None,
+        desired_depth=desired_depth or None,
+        expected_outputs=expected_outputs or None,
+        notes=notes or None,
+    )
+    return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+
+@router.get("/briefs/{brief_id}", response_class=HTMLResponse)
+def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)):
+    brief = get_brief(db, brief_id)
+    if brief is None:
+        raise HTTPException(status_code=404, detail="Research brief not found")
+    prompt = generate_agent_prompt(brief)
+    return templates.TemplateResponse(
+        request,
+        "brief_detail.html",
+        {"brief": brief, "agent_prompt": prompt},
+    )
 

--- a/apd/web/static/style.css
+++ b/apd/web/static/style.css
@@ -379,3 +379,15 @@ tr.gate-weak td { background: #fffbeb; }
 
 /* badge-agent */
 .badge-agent { background: #ede9fe; color: #4c1d95; }
+
+/* research brief status badges */
+.brief-status-draft { background: #f1f5f9; color: #475569; }
+.brief-status-ready { background: #dbeafe; color: #1e40af; }
+.brief-status-external_agent_prompted { background: #fef3c7; color: #92400e; }
+.brief-status-imported { background: #d1fae5; color: #065f46; }
+.brief-status-archived { background: #f3f4f6; color: #6b7280; }
+
+/* nav links */
+.nav-sep { color: #475569; margin: 0 0.5rem; }
+.nav-link { color: #94a3b8; text-decoration: none; font-size: 0.85rem; margin-left: 0.5rem; }
+.nav-link:hover { color: #e2e8f0; }

--- a/apd/web/templates/base.html
+++ b/apd/web/templates/base.html
@@ -10,6 +10,9 @@
   <header>
     <nav>
       <a href="/runs" class="nav-brand">APD Research Cockpit</a>
+      <span class="nav-sep">|</span>
+      <a href="/briefs" class="nav-link">Research Briefs</a>
+      <a href="/runs" class="nav-link">Runs</a>
     </nav>
   </header>
   <main>

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -1,0 +1,159 @@
+{% extends "base.html" %}
+{% block title %}{{ brief.title }} — Research Brief — APD{% endblock %}
+{% block content %}
+<div class="breadcrumb">
+  <a href="/briefs">Research Briefs</a> &rsaquo; {{ brief.title | truncate(60) }}
+</div>
+
+<section class="run-header">
+  <h1>
+    {{ brief.title }}
+    <span class="badge brief-status-{{ brief.status }}">{{ brief.status.replace("_", " ") }}</span>
+  </h1>
+  <div class="run-meta">
+    <span class="muted">Created {{ brief.created_at.strftime("%Y-%m-%d %H:%M UTC") if brief.created_at else "—" }}</span>
+  </div>
+</section>
+
+<!-- Brief content -->
+<div class="card">
+  <h2>Brief content</h2>
+
+  <table class="detail-table" style="max-width: 800px;">
+    <tr>
+      <th style="width: 180px;">Research question</th>
+      <td style="white-space: pre-wrap;">{{ brief.research_question }}</td>
+    </tr>
+    {% if brief.constraints %}
+    <tr>
+      <th>Constraints</th>
+      <td style="white-space: pre-wrap;">{{ brief.constraints }}</td>
+    </tr>
+    {% endif %}
+    {% if brief.desired_depth %}
+    <tr>
+      <th>Desired depth</th>
+      <td>{{ brief.desired_depth }}</td>
+    </tr>
+    {% endif %}
+    {% if brief.expected_outputs %}
+    <tr>
+      <th>Expected outputs</th>
+      <td style="white-space: pre-wrap;">{{ brief.expected_outputs }}</td>
+    </tr>
+    {% endif %}
+    {% if brief.notes %}
+    <tr>
+      <th>Notes</th>
+      <td style="white-space: pre-wrap;">{{ brief.notes }}</td>
+    </tr>
+    {% endif %}
+  </table>
+</div>
+
+<!-- Generated agent prompt -->
+<div class="card" id="agent-prompt">
+  <h2>Generated agent prompt</h2>
+
+  <div class="notice-box" style="
+    background: #fef9c3;
+    border: 1px solid #fde68a;
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+  ">
+    <strong>Manual mode — APD is not yet running the model.</strong>
+    Copy the prompt below and paste it into an external research agent (e.g. Claude, GPT-4).
+    The agent will return an APD draft JSON package that you can validate and import.
+    This manual copy-paste step is temporary; automated execution is planned for a future release.
+  </div>
+
+  <div style="margin-bottom: 0.75rem;">
+    <button
+      type="button"
+      class="btn btn-primary btn-sm"
+      onclick="copyPrompt()"
+      id="copy-btn"
+    >Copy prompt</button>
+    <span id="copy-confirm" style="display:none; margin-left: 0.5rem; color: #065f46; font-size: 0.8rem;">Copied!</span>
+  </div>
+
+  <pre id="prompt-text" style="
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 1rem;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 600px;
+    overflow-y: auto;
+  ">{{ agent_prompt }}</pre>
+</div>
+
+<!-- Next steps -->
+<div class="card" id="next-steps">
+  <h2>Next steps</h2>
+  <ol style="font-size: 0.875rem; line-height: 1.8; padding-left: 1.25rem;">
+    <li>Copy the prompt above and run it in your external research agent.</li>
+    <li>
+      Save the returned JSON to a local file, then validate it:
+      <br>
+      <code style="background:#f1f5f9; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.8rem;">
+        uv run python scripts/validate_agent_draft.py --path &lt;draft.json&gt; --repair-hints
+      </code>
+    </li>
+    <li>
+      If validation fails, normalize common near-miss fields:
+      <br>
+      <code style="background:#f1f5f9; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.8rem;">
+        uv run python scripts/normalize_agent_draft.py --path &lt;draft.json&gt; --out &lt;normalized.json&gt;
+      </code>
+    </li>
+    <li>
+      Import the validated draft:
+      <br>
+      <code style="background:#f1f5f9; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.8rem;">
+        uv run python scripts/import_agent_draft.py --path &lt;normalized.json&gt;
+      </code>
+    </li>
+    <li>Open the imported run in <a href="/runs">Runs</a> and review the evidence chain.</li>
+  </ol>
+
+  <div class="notice-box" style="
+    background: #f0f9ff;
+    border: 1px solid #bae6fd;
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin-top: 1rem;
+    font-size: 0.8rem;
+    color: #0369a1;
+  ">
+    <strong>Future:</strong>
+    A <em>Start Research</em> action that runs the agent automatically without copy-paste is
+    planned for a future release (tracked in issue #44). Until then, the workflow above is the
+    intended path.
+    <button type="button" class="btn btn-sm" disabled style="margin-left: 0.5rem; opacity: 0.4; cursor: not-allowed;">
+      Start Research (not yet available)
+    </button>
+  </div>
+</div>
+
+<script>
+function copyPrompt() {
+  var text = document.getElementById("prompt-text").textContent;
+  navigator.clipboard.writeText(text).then(function() {
+    var btn = document.getElementById("copy-btn");
+    var confirm = document.getElementById("copy-confirm");
+    btn.textContent = "Copied!";
+    confirm.style.display = "inline";
+    setTimeout(function() {
+      btn.textContent = "Copy prompt";
+      confirm.style.display = "none";
+    }, 2000);
+  });
+}
+</script>
+{% endblock %}

--- a/apd/web/templates/brief_new.html
+++ b/apd/web/templates/brief_new.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+{% block title %}New Research Brief — APD{% endblock %}
+{% block content %}
+<div class="breadcrumb">
+  <a href="/briefs">Research Briefs</a> &rsaquo; New Brief
+</div>
+
+<section class="page-header">
+  <h1>New Research Brief</h1>
+  <p class="muted">
+    Fill in a product investigation direction. APD will generate a prompt you can copy
+    and run in an external research agent.
+  </p>
+</section>
+
+<div class="card">
+  <form method="post" action="/briefs">
+
+    <div class="form-field" style="margin-bottom: 1rem;">
+      <label for="title" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
+        Brief title <span class="required-mark" style="color: #ef4444;">*</span>
+      </label>
+      <input
+        type="text"
+        id="title"
+        name="title"
+        class="form-input"
+        style="width: 100%; max-width: 600px;"
+        placeholder="e.g. Self-hosted ops tools for solo builders"
+        required
+      >
+    </div>
+
+    <div class="form-field" style="margin-bottom: 1rem;">
+      <label for="research_question" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
+        Research question / direction <span class="required-mark" style="color: #ef4444;">*</span>
+      </label>
+      <textarea
+        id="research_question"
+        name="research_question"
+        class="form-input"
+        style="width: 100%; max-width: 700px; height: 120px;"
+        placeholder="Describe what you want to investigate. What product space, pain, or opportunity are you curious about?"
+        required
+      ></textarea>
+    </div>
+
+    <div class="form-field" style="margin-bottom: 1rem;">
+      <label for="constraints" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
+        Constraints <span class="muted">(optional)</span>
+      </label>
+      <textarea
+        id="constraints"
+        name="constraints"
+        class="form-input"
+        style="width: 100%; max-width: 700px; height: 80px;"
+        placeholder="e.g. Focus on solo developers or small teams. Exclude enterprise tooling."
+      ></textarea>
+    </div>
+
+    <div class="form-field" style="margin-bottom: 1rem;">
+      <label for="desired_depth" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
+        Desired depth <span class="muted">(optional)</span>
+      </label>
+      <input
+        type="text"
+        id="desired_depth"
+        name="desired_depth"
+        class="form-input"
+        style="width: 100%; max-width: 400px;"
+        placeholder="e.g. surface-level overview, thorough with evidence links, focus on pain patterns"
+      >
+    </div>
+
+    <div class="form-field" style="margin-bottom: 1rem;">
+      <label for="expected_outputs" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
+        Expected outputs <span class="muted">(optional)</span>
+      </label>
+      <textarea
+        id="expected_outputs"
+        name="expected_outputs"
+        class="form-input"
+        style="width: 100%; max-width: 700px; height: 80px;"
+        placeholder="e.g. At least 3 product candidates with ranked scores, validation gates for each candidate, 5+ evidence-backed claims."
+      ></textarea>
+    </div>
+
+    <div class="form-field" style="margin-bottom: 1.5rem;">
+      <label for="notes" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
+        Notes <span class="muted">(optional)</span>
+      </label>
+      <textarea
+        id="notes"
+        name="notes"
+        class="form-input"
+        style="width: 100%; max-width: 700px; height: 80px;"
+        placeholder="Any additional context, known competitors, prior research, or background information."
+      ></textarea>
+    </div>
+
+    <div class="form-row">
+      <button type="submit" class="btn btn-primary">Save brief and generate prompt</button>
+      <a href="/briefs" class="btn" style="background: #e2e8f0; color: #1a1a1a; margin-left: 0.5rem;">Cancel</a>
+    </div>
+
+  </form>
+</div>
+{% endblock %}

--- a/apd/web/templates/briefs_list.html
+++ b/apd/web/templates/briefs_list.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block title %}Research Briefs — APD{% endblock %}
+{% block content %}
+<section class="page-header">
+  <h1>Research Briefs</h1>
+  <p class="muted">Create a brief to generate a prompt for an external research agent.</p>
+</section>
+
+<div style="margin-bottom: 1rem;">
+  <a href="/briefs/new" class="btn btn-primary">+ New Research Brief</a>
+</div>
+
+{% if briefs %}
+<table class="runs-table">
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Research Question</th>
+      <th>Status</th>
+      <th>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for brief in briefs %}
+    <tr>
+      <td>
+        <a href="/briefs/{{ brief.id }}">{{ brief.title }}</a>
+      </td>
+      <td class="summary-cell">{{ brief.research_question | truncate(120) }}</td>
+      <td>
+        <span class="badge brief-status-{{ brief.status }}">{{ brief.status.replace("_", " ") }}</span>
+      </td>
+      <td class="timestamp">{{ brief.created_at.strftime("%Y-%m-%d") if brief.created_at else "—" }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  <p>No research briefs yet.</p>
+  <p><a href="/briefs/new" class="btn btn-primary">Create your first brief</a></p>
+</div>
+{% endif %}
+{% endblock %}

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -1,0 +1,31 @@
+# Research Briefs
+
+APD supports creating a small research brief that generates a copyable agent prompt.
+
+Purpose
+
+- Reduce friction between a research question and the manual agent handoff.
+
+Workflow
+
+1. Create a research brief in the APD UI under `/briefs`.
+2. Copy the generated agent prompt shown on the brief detail page and paste it into an external research agent (e.g. GPT-4, Claude).
+3. Save the agent's JSON output to a local file.
+4. Validate the JSON using APD's validation tooling:
+
+```bash
+uv run python scripts/validate_agent_draft.py --path <draft.json> --repair-hints
+uv run python scripts/normalize_agent_draft.py --path <draft.json> --out <normalized.json>
+```
+
+5. After validation passes, import the draft:
+
+```bash
+uv run python scripts/import_agent_draft.py --path <normalized.json>
+```
+
+Notes
+
+- APD will import the package as draft/unreviewed research for human inspection and review.
+- The current workflow is manual: APD does not run models itself yet. Automation is tracked in issue #44.
+- The generated prompt includes reminders about APD's expected field names and schema. Use them to avoid common near-miss errors (e.g. `sources.source_type`, `evidence_excerpts.excerpt_text`, `claims.statement`).

--- a/tests/test_research_briefs.py
+++ b/tests/test_research_briefs.py
@@ -1,0 +1,353 @@
+"""Tests for research brief creation, listing, detail, and prompt generation."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from apd.app.db import Base
+from apd.domain.models import ResearchBrief, ResearchBriefStatus
+from apd.services.research_brief_service import (
+    create_brief,
+    generate_agent_prompt,
+    get_brief,
+    list_briefs,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Isolated in-memory-style SQLite session."""
+    db_path = tmp_path / "test_briefs.db"
+    engine = create_engine(
+        f"sqlite+pysqlite:///{db_path}",
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    with Session() as session:
+        yield session
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """TestClient wired to isolated SQLite DB — no fixture seed needed."""
+    db_path = tmp_path / "test_briefs_web.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+
+    test_engine = create_engine(
+        db_url,
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(test_engine)
+    TestSession = sessionmaker(
+        bind=test_engine, autoflush=False, autocommit=False, future=True
+    )
+
+    import apd.web.routes as web_routes
+    import apd.app.db as app_db
+
+    monkeypatch.setattr(app_db, "engine", test_engine)
+    monkeypatch.setattr(app_db, "SessionLocal", TestSession)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+# ── Service layer tests ────────────────────────────────────────────────────────
+
+
+def test_create_brief_minimal(db):
+    brief = create_brief(
+        db,
+        title="Self-hosted ops tools",
+        research_question="What pain do solo builders have with self-hosted infrastructure?",
+    )
+    assert brief.id is not None
+    assert brief.title == "Self-hosted ops tools"
+    assert brief.status == ResearchBriefStatus.DRAFT
+    assert brief.constraints is None
+    assert brief.created_at is not None
+
+
+def test_create_brief_with_all_fields(db):
+    brief = create_brief(
+        db,
+        title="Full brief",
+        research_question="Investigate CI/CD pain for small teams.",
+        constraints="Exclude enterprise tooling.",
+        desired_depth="thorough with evidence links",
+        expected_outputs="At least 3 candidates with validation gates.",
+        notes="Prior art: Coolify, Dokku.",
+    )
+    assert brief.title == "Full brief"
+    assert brief.constraints == "Exclude enterprise tooling."
+    assert brief.desired_depth == "thorough with evidence links"
+    assert brief.expected_outputs == "At least 3 candidates with validation gates."
+    assert brief.notes == "Prior art: Coolify, Dokku."
+
+
+def test_list_briefs_returns_most_recent_first(db):
+    create_brief(db, title="First", research_question="Q1")
+    create_brief(db, title="Second", research_question="Q2")
+    briefs = list_briefs(db)
+    assert len(briefs) == 2
+    # Most recently created should be first
+    assert briefs[0].title == "Second"
+    assert briefs[1].title == "First"
+
+
+def test_get_brief_returns_none_for_missing_id(db):
+    assert get_brief(db, 9999) is None
+
+
+def test_get_brief_returns_saved_brief(db):
+    created = create_brief(db, title="Find me", research_question="Q?")
+    found = get_brief(db, created.id)
+    assert found is not None
+    assert found.id == created.id
+    assert found.title == "Find me"
+
+
+# ── Prompt generation tests ────────────────────────────────────────────────────
+
+
+def _make_brief(
+    title="Test brief",
+    research_question="What pain does segment X have?",
+    constraints=None,
+    desired_depth=None,
+    expected_outputs=None,
+    notes=None,
+) -> ResearchBrief:
+    brief = ResearchBrief(
+        title=title,
+        research_question=research_question,
+        constraints=constraints,
+        desired_depth=desired_depth,
+        expected_outputs=expected_outputs,
+        notes=notes,
+        status=ResearchBriefStatus.DRAFT,
+    )
+    return brief
+
+
+def test_prompt_includes_research_question():
+    brief = _make_brief(research_question="What pain do solo devs face with deploys?")
+    prompt = generate_agent_prompt(brief)
+    assert "What pain do solo devs face with deploys?" in prompt
+
+
+def test_prompt_includes_constraints_when_present():
+    brief = _make_brief(constraints="Exclude enterprise tools.")
+    prompt = generate_agent_prompt(brief)
+    assert "Exclude enterprise tools." in prompt
+
+
+def test_prompt_excludes_constraints_section_when_absent():
+    brief = _make_brief()
+    prompt = generate_agent_prompt(brief)
+    assert "## Constraints" not in prompt
+
+
+def test_prompt_includes_apd_schema_field_reminders():
+    brief = _make_brief()
+    prompt = generate_agent_prompt(brief)
+    # Key field name reminders must appear
+    assert "source_type" in prompt
+    assert "excerpt_text" in prompt
+    assert "statement" in prompt
+    assert "target_type" in prompt
+    assert "target_id" in prompt
+    assert "relationship" in prompt
+
+
+def test_prompt_includes_safety_constraints():
+    brief = _make_brief()
+    prompt = generate_agent_prompt(brief)
+    assert "Do not publish externally" in prompt
+    assert "create GitHub issues" in prompt
+    assert "Do not call external APIs" in prompt
+
+
+def test_prompt_includes_desired_depth_when_present():
+    brief = _make_brief(desired_depth="surface-level overview")
+    prompt = generate_agent_prompt(brief)
+    assert "surface-level overview" in prompt
+
+
+def test_prompt_includes_expected_outputs_when_present():
+    brief = _make_brief(expected_outputs="3 candidates with validation gates")
+    prompt = generate_agent_prompt(brief)
+    assert "3 candidates with validation gates" in prompt
+
+
+def test_prompt_includes_notes_when_present():
+    brief = _make_brief(notes="Prior research: Coolify and Dokku.")
+    prompt = generate_agent_prompt(brief)
+    assert "Coolify and Dokku" in prompt
+
+
+def test_prompt_references_apd_allowed_phases():
+    brief = _make_brief()
+    prompt = generate_agent_prompt(brief)
+    assert "vague_notion" in prompt
+    assert "evidence_collected" in prompt
+
+
+# ── Web UI tests ───────────────────────────────────────────────────────────────
+
+
+def test_briefs_list_page_loads_empty(client):
+    resp = client.get("/briefs")
+    assert resp.status_code == 200
+    assert "Research Briefs" in resp.text
+
+
+def test_briefs_list_page_has_new_brief_link(client):
+    resp = client.get("/briefs")
+    assert resp.status_code == 200
+    assert "/briefs/new" in resp.text
+
+
+def test_brief_new_page_loads(client):
+    resp = client.get("/briefs/new")
+    assert resp.status_code == 200
+    assert "New Research Brief" in resp.text
+    assert "research_question" in resp.text
+
+
+def test_create_brief_via_post_redirects_to_detail(client):
+    resp = client.post(
+        "/briefs",
+        data={
+            "title": "CI/CD pain investigation",
+            "research_question": "What frustrates solo devs with CI/CD?",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"].startswith("/briefs/")
+
+
+def test_brief_detail_page_loads(client):
+    # Create via POST then follow redirect
+    resp = client.post(
+        "/briefs",
+        data={
+            "title": "Deploy pain",
+            "research_question": "What deployment pain exists for solo builders?",
+            "constraints": "No enterprise tools.",
+            "desired_depth": "thorough",
+            "notes": "Check Render, Fly, Coolify.",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Deploy pain" in body
+    assert "What deployment pain exists for solo builders?" in body
+    assert "No enterprise tools." in body
+
+
+def test_brief_detail_shows_generated_prompt(client):
+    resp = client.post(
+        "/briefs",
+        data={
+            "title": "Ops tooling",
+            "research_question": "What ops pain do small teams have?",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Generated agent prompt" in body
+    assert "What ops pain do small teams have?" in body
+    # Schema reminders should appear in the rendered prompt
+    assert "source_type" in body
+    assert "excerpt_text" in body
+
+
+def test_brief_detail_states_apd_not_running_model(client):
+    resp = client.post(
+        "/briefs",
+        data={
+            "title": "Market research",
+            "research_question": "What tools do indie hackers use for monitoring?",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    # Must clearly say APD is not running the model
+    assert "not yet running the model" in resp.text.lower() or "APD is not yet running" in resp.text
+
+
+def test_brief_detail_shows_future_start_research_disabled(client):
+    resp = client.post(
+        "/briefs",
+        data={
+            "title": "Market research",
+            "research_question": "What tools do indie hackers use for monitoring?",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Start Research" in body
+    assert "disabled" in body
+
+
+def test_brief_list_shows_created_brief(client):
+    client.post(
+        "/briefs",
+        data={"title": "Visible brief", "research_question": "Is this visible?"},
+    )
+    resp = client.get("/briefs")
+    assert resp.status_code == 200
+    assert "Visible brief" in resp.text
+
+
+def test_brief_detail_404_for_missing_brief(client):
+    resp = client.get("/briefs/99999")
+    assert resp.status_code == 404
+
+
+def test_runs_page_still_works_after_brief_routes_added(client):
+    resp = client.get("/runs")
+    assert resp.status_code == 200
+
+
+def test_nav_links_present_on_runs_page(client):
+    resp = client.get("/runs")
+    assert resp.status_code == 200
+    assert "/briefs" in resp.text
+
+
+def test_create_brief_with_empty_required_fields_returns_error(client):
+    resp = client.post(
+        "/briefs",
+        data={"title": "", "research_question": ""},
+        follow_redirects=False,
+    )
+    # Should return 422 or redirect back — not 2xx with empty brief created
+    assert resp.status_code in (303, 422)


### PR DESCRIPTION
﻿## Summary

Add a Research Brief creation UI and generated agent prompt so APD can be the starting point for product investigations.

This PR implements a minimal `ResearchBrief` model, Alembic migration, service layer, routes, Jinja templates, CSS, tests, and documentation pointers for the manual prompt -> validate -> import workflow.

Refs #31

## Files changed

- apd/domain/models.py (added `ResearchBriefStatus` and `ResearchBrief` model)
- alembic/versions/20260427_0002_add_research_briefs.py (new migration)
- apd/services/research_brief_service.py (new service + prompt generation)
- apd/web/routes.py (brief list/new/detail routes)
- apd/web/templates/briefs_list.html (new)
- apd/web/templates/brief_new.html (new)
- apd/web/templates/brief_detail.html (new)
- apd/web/static/style.css (brief status + nav styles)
- apd/web/templates/base.html (nav link to briefs)
- tests/test_research_briefs.py (new tests)

## Verification commands run locally

```
./scripts/test.ps1
python scripts/check_repo_readiness.py
```

Results:
- `./scripts/test.ps1` — all tests passed locally.
- `python scripts/check_repo_readiness.py` — readiness checks passed.

## Manual browser verification (instructions)

1. Use a clean throwaway SQLite DB:

```powershell
$env:APD_DATABASE_URL = 'sqlite+pysqlite:///./.local/apd_issue31_verify.db'
uv run alembic upgrade head
uv run uvicorn apd.app.main:app --port 8766
```

2. Open http://localhost:8766/briefs
3. Create a New Research Brief, then view the brief detail.
4. Confirm the generated agent prompt includes the research direction, constraints/notes, APD draft schema reminders, and safety constraints, and that the UI clearly states APD is not running the model yet.

(Manual browser verification has not been performed by this run — follow the steps above to verify.)

## Reviewer focus

- DB migration correctness for `research_briefs` table.
- Prompt text content and schema reminders.
- Template layout and copy for clarity (manual copy/paste workflow).
- Tests for service layer and HTTP endpoints.

