### PR TITLE
Issue #44: Website-first deterministic stub runner and Start Research flow

### DIFF
--- a/apd/services/research_execution_stub.py
+++ b/apd/services/research_execution_stub.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from apd.services.research_brief_service import get_brief
+from apd.services.agent_draft_validation import validate_agent_draft_data
+from apd.services.agent_draft_import import import_agent_draft_package, AgentDraftPackage
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_stub_package_dict(brief) -> dict[str, Any]:
+    now = _iso_now()
+    external_id = f"brief-{brief.id}-{now}"
+    run_title = brief.title or (brief.research_question[:120] if brief.research_question else "Stub Research")
+    run_intent = brief.research_question
+    package = {
+        "schema_version": "1.0",
+        "external_draft_id": external_id,
+        "agent_name": "apd-stub-runner",
+        "generated_at": now,
+        "run": {
+            "title": run_title,
+            "intent": run_intent,
+            "summary": "This is deterministic stub output for website-first execution prototype. Not real research.",
+            "mode": "stub_research_execution",
+            "phase": "evidence_collected",
+            "recommendation": "needs_human_review",
+        },
+        "warnings": ["This is deterministic stub output, not real research."],
+        "limitations": ["No model call, no source fetching, no external research performed."],
+        "sources": [
+            {
+                "id": "src-1",
+                "title": "Stub source for brief",
+                "source_type": "stub",
+                "url": None,
+                "origin": "apd-stub-runner",
+                "metadata_json": {"brief_id": brief.id},
+            }
+        ],
+        "evidence_excerpts": [
+            {"id": "ex-1", "source_id": "src-1", "excerpt_text": "Stub excerpt text generated from brief."}
+        ],
+        "claims": [
+            {"id": "claim-1", "statement": "Stub claim derived from brief."}
+        ],
+        "themes": [
+            {"id": "theme-1", "name": "Stub theme"}
+        ],
+        "candidates": [
+            {"id": "cand-1", "title": "Stub candidate", "summary": "A synthetic candidate produced by the stub runner."}
+        ],
+        "validation_gates": [
+            {"id": "gate-1", "candidate_id": "cand-1", "phase": "evidence_collected", "name": "Stub validation gate"}
+        ],
+        "evidence_links": [
+            {"id": "link-1", "source_id": "src-1", "excerpt_id": "ex-1", "target_type": "claim", "target_id": "claim-1", "relationship": "supports", "strength": "medium"},
+            {"id": "link-2", "source_id": "src-1", "excerpt_id": "ex-1", "target_type": "theme", "target_id": "theme-1", "relationship": "example_of", "strength": "weak"},
+            {"id": "link-3", "source_id": "src-1", "excerpt_id": "ex-1", "target_type": "candidate", "target_id": "cand-1", "relationship": "supports", "strength": "medium"},
+            {"id": "link-4", "source_id": "src-1", "excerpt_id": "ex-1", "target_type": "validation_gate", "target_id": "gate-1", "relationship": "context_for", "strength": "weak"},
+        ],
+    }
+    return package
+
+
+def execute_research_brief_stub(db: Session, brief) -> dict[str, Any]:
+    """Build a deterministic stub package, validate it, import it, and return import result.
+
+    Returns a dict with keys: success (bool), message (str), run_id (int|None).
+    """
+    package_dict = build_stub_package_dict(brief)
+
+    # Validate using in-memory data (path used only for reporting)
+    report = validate_agent_draft_data(Path("<stub>"), package_dict)
+    if not report.is_valid or report.package is None:
+        return {"success": False, "message": "Validation failed", "errors": report.errors}
+
+    # Import using the already-validated package model
+    try:
+        result = import_agent_draft_package(db, report.package, package_path=None, allow_duplicate_external_id=False)
+    except Exception as exc:
+        return {"success": False, "message": f"Import failed: {exc}", "errors": [str(exc)]}
+
+    return {"success": True, "message": "Imported", "run_id": result.run_db_id, "warnings": result.warnings}

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
+from datetime import datetime
 
 from apd.app.db import SessionLocal
 from apd.domain.models import DecisionValue, ReviewStatus, ReviewTargetType
@@ -22,6 +23,7 @@ from apd.services.research_brief_service import (
     get_brief,
     list_briefs,
 )
+from apd.services.research_execution_stub import execute_research_brief_stub
 from apd.web.queries import get_recent_runs, get_run_detail
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -226,4 +228,34 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
         "brief_detail.html",
         {"brief": brief, "agent_prompt": prompt},
     )
+
+
+@router.post("/briefs/{brief_id}/start-research", response_class=RedirectResponse)
+def start_research(brief_id: int, db: Session = Depends(_get_db)):
+    brief = get_brief(db, brief_id)
+    if brief is None:
+        raise HTTPException(status_code=404, detail="Research brief not found")
+
+    # record running status in brief metadata
+    meta = brief.metadata_json or {}
+    meta["last_execution"] = {"status": "running", "started_at": datetime.utcnow().isoformat()}
+    brief.metadata_json = meta
+    db.add(brief)
+    db.commit()
+    db.refresh(brief)
+
+    result = execute_research_brief_stub(db, brief)
+
+    meta = brief.metadata_json or {}
+    meta["last_execution"] = {**meta.get("last_execution", {}), "finished_at": datetime.utcnow().isoformat(), "result": result}
+    brief.metadata_json = meta
+    db.add(brief)
+    db.commit()
+    db.refresh(brief)
+
+    if result.get("success") and result.get("run_id"):
+        return RedirectResponse(url=f"/runs/{result.get('run_id')}", status_code=303)
+
+    # On failure, return to brief detail so the UI can show last_execution with errors
+    return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -131,14 +131,20 @@
     font-size: 0.8rem;
     color: #0369a1;
   ">
-    <strong>Future:</strong>
-    A <em>Start Research</em> action that runs the agent automatically without copy-paste is
-    planned for a future release (tracked in issue #44). Until then, the workflow above is the
-    intended path.
-    <button type="button" class="btn btn-sm" disabled style="margin-left: 0.5rem; opacity: 0.4; cursor: not-allowed;">
-      Start Research (not yet available)
-    </button>
+    <strong>Website-first prototype:</strong>
+    This page can run a deterministic stub research runner that produces a clearly labeled synthetic APD draft.
+    It does not call any model or external service. Use the <em>Start Research (stub)</em> button below to run it.
+    <form method="post" action="/briefs/{{ brief.id }}/start-research" style="display:inline; margin-left:0.5rem;">
+      <button type="submit" class="btn btn-sm btn-primary">Start Research (stub)</button>
+    </form>
   </div>
+  
+  {% if brief.metadata_json and brief.metadata_json.get('last_execution') %}
+  <div class="card" style="margin-top:1rem;">
+    <h3>Last execution</h3>
+    <pre style="background:#fff; padding:0.75rem; border-radius:6px;">{{ brief.metadata_json.get('last_execution') | tojson }}</pre>
+  </div>
+  {% endif %}
 </div>
 
 <script>

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -28,4 +28,5 @@ Notes
 
 - APD will import the package as draft/unreviewed research for human inspection and review.
 - The current workflow is manual: APD does not run models itself yet. Automation is tracked in issue #44.
+ - A website-first prototype (Issue #44) is available that demonstrates an in-process, deterministic "stub" runner. The stub does not call external models or services; it builds a synthetic agent draft package, validates it with APD's validators, and imports it locally so you can exercise the end-to-end import and run creation flow without external network calls.
 - The generated prompt includes reminders about APD's expected field names and schema. Use them to avoid common near-miss errors (e.g. `sources.source_type`, `evidence_excerpts.excerpt_text`, `claims.statement`).

--- a/tests/test_research_briefs.py
+++ b/tests/test_research_briefs.py
@@ -314,7 +314,8 @@ def test_brief_detail_shows_future_start_research_disabled(client):
     assert resp.status_code == 200
     body = resp.text
     assert "Start Research" in body
-    assert "disabled" in body
+    # Website-first prototype now exposes Start Research (stub) — it should not be disabled
+    assert "not yet available" not in body
 
 
 def test_brief_list_shows_created_brief(client):

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -1,0 +1,90 @@
+"""Tests for website-first stub research execution (issue #44).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import pytest
+
+from apd.app.db import Base
+from apd.services.research_brief_service import create_brief, get_brief
+from apd.services.research_execution_stub import execute_research_brief_stub
+
+
+@pytest.fixture()
+def db(tmp_path):
+    db_path = tmp_path / "test_exec.db"
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}", future=True, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    with Session() as session:
+        yield session
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test_briefs_web.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+
+    test_engine = create_engine(
+        db_url,
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(test_engine)
+    TestSession = sessionmaker(
+        bind=test_engine, autoflush=False, autocommit=False, future=True
+    )
+
+    import apd.web.routes as web_routes
+    import apd.app.db as app_db
+
+    monkeypatch.setattr(app_db, "engine", test_engine)
+    monkeypatch.setattr(app_db, "SessionLocal", TestSession)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+
+    from fastapi.testclient import TestClient
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_execute_stub_service_imports_run(db):
+    brief = create_brief(db, title="Stub brief", research_question="Q")
+    # reload brief from DB
+    brief = get_brief(db, brief.id)
+    result = execute_research_brief_stub(db, brief)
+    assert result.get("success") is True
+    assert isinstance(result.get("run_id"), int)
+
+
+def test_start_research_route_creates_run(client):
+    # create brief via web route then start research
+    resp = client.post("/briefs", data={"title": "Web stub", "research_question": "What is X?"}, follow_redirects=False)
+    assert resp.status_code == 303
+    location = resp.headers["location"]
+    # get brief id from redirect
+    assert location.startswith("/briefs/")
+    brief_id = int(location.split("/")[-1])
+
+    # invoke start research
+    resp2 = client.post(f"/briefs/{brief_id}/start-research", follow_redirects=True)
+    assert resp2.status_code == 200
+    # Should redirect to run detail and show the run title
+    assert "Web stub" in resp2.text
+
+


### PR DESCRIPTION
﻿PR: Issue #44 — Website-first deterministic stub runner and Start Research flow

Files changed:
- apd/services/research_execution_stub.py
- apd/web/routes.py
- apd/web/templates/brief_detail.html
- tests/test_research_execution.py
- tests/test_research_briefs.py
- docs/briefs.md

Verification:
- ./scripts/test.ps1: All tests passed (warnings only).
- python scripts/check_repo_readiness.py: READY (all checks passed).

Notes:
- This implements a deterministic, in-process stub runner only. No external model APIs or services are called.
- Timestamps use naive UTC via datetime.utcnow(); tests emitted a deprecation warning recommending timezone-aware datetimes. I did not change this to keep scope minimal; can update to timezone-aware datetimes if you want.
- Manual browser verification: none performed; test suite uses TestClient for route checks.

Refs: #44
