### PR TITLE
Issue #46: Add Ollama-backed local research brief execution

### DIFF
--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+from sqlalchemy.orm import Session
+
+from apd.services.agent_draft_import import import_agent_draft_package
+from apd.services.agent_draft_validation import validate_agent_draft_data
+from apd.services.research_brief_service import generate_agent_prompt
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class OllamaExecutionConfig:
+    provider: str
+    base_url: str
+    model: str
+    timeout_seconds: int
+    repair_attempts: int
+
+
+def get_ollama_execution_config() -> tuple[OllamaExecutionConfig | None, list[str]]:
+    provider = (os.getenv("APD_MODEL_PROVIDER") or "").strip().lower()
+    base_url = (os.getenv("APD_OLLAMA_BASE_URL") or "").strip()
+    model = (os.getenv("APD_OLLAMA_MODEL") or "").strip()
+
+    missing: list[str] = []
+    if provider != "ollama":
+        missing.append("APD_MODEL_PROVIDER=ollama")
+    if not base_url:
+        missing.append("APD_OLLAMA_BASE_URL")
+    if not model:
+        missing.append("APD_OLLAMA_MODEL")
+
+    if missing:
+        return None, missing
+
+    timeout_seconds = _parse_positive_int_env("APD_OLLAMA_TIMEOUT_SECONDS", default=120)
+    repair_attempts = _parse_nonnegative_int_env("APD_OLLAMA_REPAIR_ATTEMPTS", default=1)
+    # Scope guardrail: permit at most one repair call.
+    repair_attempts = min(repair_attempts, 1)
+
+    return (
+        OllamaExecutionConfig(
+            provider=provider,
+            base_url=base_url.rstrip("/"),
+            model=model,
+            timeout_seconds=timeout_seconds,
+            repair_attempts=repair_attempts,
+        ),
+        [],
+    )
+
+
+def extract_json_object_from_model_output(text: str) -> tuple[dict[str, Any] | None, str | None]:
+    candidate = text.strip()
+    if not candidate:
+        return None, "parse_failed: empty_model_output"
+
+    full = _parse_json_object(candidate)
+    if full is not None:
+        return full, None
+
+    fenced_match = re.search(r"```json\s*(\{.*?\})\s*```", candidate, flags=re.IGNORECASE | re.DOTALL)
+    if fenced_match:
+        fenced = _parse_json_object(fenced_match.group(1))
+        if fenced is not None:
+            return fenced, None
+
+    first = candidate.find("{")
+    last = candidate.rfind("}")
+    if first != -1 and last != -1 and first < last:
+        sliced = _parse_json_object(candidate[first : last + 1])
+        if sliced is not None:
+            return sliced, None
+
+    return None, "parse_failed: unable_to_extract_json_object"
+
+
+def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
+    config, missing_env = get_ollama_execution_config()
+    now = _iso_now()
+
+    if config is None:
+        return {
+            "success": False,
+            "provider": "ollama",
+            "status": "config_missing",
+            "started_at": now,
+            "finished_at": now,
+            "errors": [f"Missing required env: {value}" for value in missing_env],
+            "warnings": [],
+            "run_id": None,
+        }
+
+    prompt = generate_agent_prompt(brief)
+    status = "failed"
+    errors_list: list[str] = []
+    warnings_list: list[str] = []
+    run_id: int | None = None
+    started_at = now
+    finished_at = now
+
+    draft_data, parse_error = _call_ollama_for_draft(config, prompt)
+    if parse_error:
+        status = "parse_failed" if parse_error.startswith("parse_failed") else "provider_error"
+        errors_list.append(parse_error)
+        finished_at = _iso_now()
+        return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+    report = validate_agent_draft_data(Path("<ollama-output>"), draft_data)
+    package = report.package
+    if not report.is_valid or package is None:
+        normalized_data, normalize_fixes = _safe_normalize_near_miss(draft_data)
+        if normalize_fixes:
+            warnings_list.append(f"applied_normalization_fixes={len(normalize_fixes)}")
+            normalized_report = validate_agent_draft_data(Path("<ollama-output-normalized>"), normalized_data)
+            if normalized_report.is_valid and normalized_report.package is not None:
+                report = normalized_report
+                package = normalized_report.package
+
+    if (package is None or not report.is_valid) and config.repair_attempts > 0:
+        warnings_list.append("repair_attempted=1")
+        repaired_data, repair_error = _call_ollama_for_repair(config, draft_data, report.grouped_errors or report.errors)
+        if repair_error:
+            errors_list.append(repair_error)
+        elif repaired_data is not None:
+            repaired_report = validate_agent_draft_data(Path("<ollama-output-repair>"), repaired_data)
+            if repaired_report.is_valid and repaired_report.package is not None:
+                package = repaired_report.package
+                report = repaired_report
+                warnings_list.append("repair_succeeded=true")
+            else:
+                errors_list.extend(_first_errors(repaired_report.errors, limit=5))
+
+    if package is None or not report.is_valid:
+        status = "validation_failed"
+        if not errors_list:
+            errors_list.extend(_first_errors(report.errors, limit=5))
+        finished_at = _iso_now()
+        return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+    try:
+        import_result = import_agent_draft_package(
+            db,
+            package,
+            package_path=None,
+            allow_duplicate_external_id=False,
+        )
+    except Exception as exc:
+        status = "import_failed"
+        errors_list.append(f"import_failed: {exc}")
+        finished_at = _iso_now()
+        return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+    run_id = import_result.run_db_id
+    warnings_list.extend(_first_errors(import_result.warnings, limit=5))
+    status = "imported"
+    finished_at = _iso_now()
+    return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+
+def _build_result(
+    config: OllamaExecutionConfig,
+    status: str,
+    started_at: str,
+    finished_at: str,
+    run_id: int | None,
+    errors_list: list[str],
+    warnings_list: list[str],
+) -> dict[str, Any]:
+    return {
+        "success": status == "imported" and run_id is not None,
+        "provider": config.provider,
+        "model": config.model,
+        "status": status,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "errors": errors_list[:5],
+        "warnings": warnings_list[:5],
+        "run_id": run_id,
+    }
+
+
+def _call_ollama_for_draft(
+    config: OllamaExecutionConfig,
+    prompt: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    payload = {
+        "model": config.model,
+        "prompt": prompt,
+        "stream": False,
+    }
+    response_data, call_error = _ollama_generate(config, payload)
+    if call_error:
+        return None, call_error
+
+    output_text = str(response_data.get("response") or "")
+    if not output_text.strip():
+        return None, "provider_error: empty_ollama_response"
+
+    return extract_json_object_from_model_output(output_text)
+
+
+def _call_ollama_for_repair(
+    config: OllamaExecutionConfig,
+    prior_data: dict[str, Any],
+    validation_errors: list[str],
+) -> tuple[dict[str, Any] | None, str | None]:
+    errors_block = "\n".join(f"- {line}" for line in _first_errors(validation_errors, limit=8))
+    prior_json = json.dumps(prior_data, ensure_ascii=False)
+    prompt = (
+        "Repair this APD agent draft package so it passes strict APD draft validation.\n"
+        "Return only JSON.\n"
+        "Preserve meaning and IDs unless schema repair requires a rename.\n\n"
+        "Validation errors:\n"
+        f"{errors_block}\n\n"
+        "Draft JSON:\n"
+        f"{prior_json}"
+    )
+    payload = {
+        "model": config.model,
+        "prompt": prompt,
+        "stream": False,
+    }
+    response_data, call_error = _ollama_generate(config, payload)
+    if call_error:
+        return None, call_error
+
+    output_text = str(response_data.get("response") or "")
+    if not output_text.strip():
+        return None, "provider_error: empty_ollama_repair_response"
+
+    return extract_json_object_from_model_output(output_text)
+
+
+def _ollama_generate(
+    config: OllamaExecutionConfig,
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], str | None]:
+    url = f"{config.base_url}/api/generate"
+    body = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        url=url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=config.timeout_seconds) as resp:
+            status_code = getattr(resp, "status", 200)
+            raw = resp.read().decode("utf-8")
+    except error.HTTPError as exc:
+        return {}, f"provider_error: ollama_http_{exc.code}"
+    except error.URLError as exc:
+        return {}, f"provider_error: ollama_unreachable ({exc.reason})"
+    except TimeoutError:
+        return {}, "provider_error: ollama_timeout"
+    except Exception as exc:
+        return {}, f"provider_error: {exc}"
+
+    if status_code >= 400:
+        return {}, f"provider_error: ollama_http_{status_code}"
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}, "provider_error: ollama_invalid_json_response"
+
+    if not isinstance(parsed, dict):
+        return {}, "provider_error: ollama_response_not_object"
+
+    return parsed, None
+
+
+def _parse_json_object(candidate: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _first_errors(values: list[str], *, limit: int) -> list[str]:
+    return [str(v) for v in values[:limit]]
+
+
+def _parse_positive_int_env(name: str, *, default: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _parse_nonnegative_int_env(name: str, *, default: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+def _safe_normalize_near_miss(raw_data: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    normalized = json.loads(json.dumps(raw_data))
+    applied: list[str] = []
+
+    aliases: dict[str, dict[str, str]] = {
+        "sources": {"type": "source_type", "accessed_at": "captured_at"},
+        "evidence_excerpts": {"text": "excerpt_text", "locator": "location_reference"},
+        "claims": {"claim": "statement"},
+        "themes": {"theme": "name"},
+        "candidates": {"name": "title", "description": "summary"},
+    }
+
+    for section, mapping in aliases.items():
+        items = normalized.get(section)
+        if not isinstance(items, list):
+            continue
+        for idx, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            for old_name, new_name in mapping.items():
+                if old_name in item and new_name not in item:
+                    item[new_name] = item.pop(old_name)
+                    applied.append(f"{section}[{idx}]: {old_name}->{new_name}")
+
+    gate_phase_map = {
+        "problem_validation": "supported_opportunity",
+        "solution_validation": "vetted_opportunity",
+        "commercial_validation": "vetted_opportunity",
+    }
+    gates = normalized.get("validation_gates")
+    if isinstance(gates, list):
+        for idx, gate in enumerate(gates):
+            if not isinstance(gate, dict):
+                continue
+            phase = gate.get("phase")
+            mapped = gate_phase_map.get(phase)
+            if mapped:
+                gate["phase"] = mapped
+                applied.append(f"validation_gates[{idx}]: phase->{mapped}")
+
+    links = normalized.get("evidence_links")
+    legacy_target_map = {
+        "claim_id": "claim",
+        "theme_id": "theme",
+        "candidate_id": "candidate",
+        "gate_id": "validation_gate",
+    }
+    if isinstance(links, list):
+        for idx, link in enumerate(links):
+            if not isinstance(link, dict):
+                continue
+            if link.get("target_type") and link.get("target_id"):
+                continue
+            matches = [(field_name, target_type) for field_name, target_type in legacy_target_map.items() if link.get(field_name)]
+            if len(matches) != 1:
+                continue
+            field_name, target_type = matches[0]
+            link["target_type"] = target_type
+            link["target_id"] = link.pop(field_name)
+            applied.append(f"evidence_links[{idx}]: {field_name}->target_type,target_id")
+
+    return normalized, applied

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -49,8 +49,8 @@ def _iso_now() -> str:
 
 
 def _save_last_execution(db: Session, brief, execution_data: dict) -> None:
-    meta = brief.metadata_json or {}
-    meta["last_execution"] = execution_data
+    meta = dict(brief.metadata_json or {})
+    meta["last_execution"] = dict(execution_data)
     brief.metadata_json = meta
     db.add(brief)
     db.commit()

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
-from datetime import datetime
 
 from apd.app.db import SessionLocal
 from apd.domain.models import DecisionValue, ReviewStatus, ReviewTargetType
@@ -23,6 +23,10 @@ from apd.services.research_brief_service import (
     get_brief,
     list_briefs,
 )
+from apd.services.research_execution_ollama import (
+    execute_research_brief_ollama,
+    get_ollama_execution_config,
+)
 from apd.services.research_execution_stub import execute_research_brief_stub
 from apd.web.queries import get_recent_runs, get_run_detail
 
@@ -38,6 +42,19 @@ def _get_db():
         yield db
     finally:
         db.close()
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _save_last_execution(db: Session, brief, execution_data: dict) -> None:
+    meta = brief.metadata_json or {}
+    meta["last_execution"] = execution_data
+    brief.metadata_json = meta
+    db.add(brief)
+    db.commit()
+    db.refresh(brief)
 
 
 @router.get("/", response_class=RedirectResponse, include_in_schema=False)
@@ -223,10 +240,17 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")
     prompt = generate_agent_prompt(brief)
+    ollama_config, missing_ollama_env = get_ollama_execution_config()
     return templates.TemplateResponse(
         request,
         "brief_detail.html",
-        {"brief": brief, "agent_prompt": prompt},
+        {
+            "brief": brief,
+            "agent_prompt": prompt,
+            "ollama_ready": ollama_config is not None,
+            "missing_ollama_env": missing_ollama_env,
+            "ollama_model": ollama_config.model if ollama_config else None,
+        },
     )
 
 
@@ -236,26 +260,83 @@ def start_research(brief_id: int, db: Session = Depends(_get_db)):
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")
 
-    # record running status in brief metadata
-    meta = brief.metadata_json or {}
-    meta["last_execution"] = {"status": "running", "started_at": datetime.utcnow().isoformat()}
-    brief.metadata_json = meta
-    db.add(brief)
-    db.commit()
-    db.refresh(brief)
+    _save_last_execution(
+        db,
+        brief,
+        {
+            "provider": "stub",
+            "status": "running",
+            "started_at": _iso_now(),
+            "errors": [],
+            "warnings": [],
+            "run_id": None,
+        },
+    )
 
     result = execute_research_brief_stub(db, brief)
-
-    meta = brief.metadata_json or {}
-    meta["last_execution"] = {**meta.get("last_execution", {}), "finished_at": datetime.utcnow().isoformat(), "result": result}
-    brief.metadata_json = meta
-    db.add(brief)
-    db.commit()
-    db.refresh(brief)
+    _save_last_execution(
+        db,
+        brief,
+        {
+            "provider": "stub",
+            "status": "imported" if result.get("success") else "failed",
+            "started_at": (brief.metadata_json or {}).get("last_execution", {}).get("started_at") or _iso_now(),
+            "finished_at": _iso_now(),
+            "errors": [str(e) for e in (result.get("errors") or [])][:5],
+            "warnings": [str(w) for w in (result.get("warnings") or [])][:5],
+            "run_id": result.get("run_id"),
+        },
+    )
 
     if result.get("success") and result.get("run_id"):
         return RedirectResponse(url=f"/runs/{result.get('run_id')}", status_code=303)
 
     # On failure, return to brief detail so the UI can show last_execution with errors
+    return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+
+@router.post("/briefs/{brief_id}/start-research-ollama", response_class=RedirectResponse)
+def start_research_ollama(brief_id: int, db: Session = Depends(_get_db)):
+    brief = get_brief(db, brief_id)
+    if brief is None:
+        raise HTTPException(status_code=404, detail="Research brief not found")
+
+    config, missing_env = get_ollama_execution_config()
+    if config is None:
+        _save_last_execution(
+            db,
+            brief,
+            {
+                "provider": "ollama",
+                "status": "config_missing",
+                "started_at": _iso_now(),
+                "finished_at": _iso_now(),
+                "errors": [f"Missing required env: {value}" for value in missing_env],
+                "warnings": [],
+                "run_id": None,
+            },
+        )
+        return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+    _save_last_execution(
+        db,
+        brief,
+        {
+            "provider": "ollama",
+            "model": config.model,
+            "status": "running",
+            "started_at": _iso_now(),
+            "errors": [],
+            "warnings": [],
+            "run_id": None,
+        },
+    )
+
+    result = execute_research_brief_ollama(db, brief)
+    _save_last_execution(db, brief, result)
+
+    if result.get("success") and result.get("run_id"):
+        return RedirectResponse(url=f"/runs/{result.get('run_id')}", status_code=303)
+
     return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -138,6 +138,33 @@
       <button type="submit" class="btn btn-sm btn-primary">Start Research (stub)</button>
     </form>
   </div>
+
+  <div class="notice-box" style="
+    background: #ecfeff;
+    border: 1px solid #a5f3fc;
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
+    color: #155e75;
+  ">
+    <strong>Local Ollama execution (Issue #46):</strong>
+    {% if ollama_ready %}
+      APD is configured for Ollama model <code>{{ ollama_model }}</code>.
+      <form method="post" action="/briefs/{{ brief.id }}/start-research-ollama" style="display:inline; margin-left:0.5rem;">
+        <button type="submit" class="btn btn-sm btn-primary">Start Research with Ollama</button>
+      </form>
+    {% else %}
+      Configure all required env vars to enable this path:
+      <code>APD_MODEL_PROVIDER=ollama</code>,
+      <code>APD_OLLAMA_BASE_URL=http://localhost:11434</code>,
+      <code>APD_OLLAMA_MODEL=&lt;installed-model-name&gt;</code>.
+      {% if missing_ollama_env and missing_ollama_env|length > 0 %}
+        Missing now:
+        <code>{{ missing_ollama_env | join(", ") }}</code>.
+      {% endif %}
+    {% endif %}
+  </div>
   
   {% if brief.metadata_json and brief.metadata_json.get('last_execution') %}
   <div class="card" style="margin-top:1rem;">

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -30,3 +30,36 @@ Notes
 - The current workflow is manual: APD does not run models itself yet. Automation is tracked in issue #44.
  - A website-first prototype (Issue #44) is available that demonstrates an in-process, deterministic "stub" runner. The stub does not call external models or services; it builds a synthetic agent draft package, validates it with APD's validators, and imports it locally so you can exercise the end-to-end import and run creation flow without external network calls.
 - The generated prompt includes reminders about APD's expected field names and schema. Use them to avoid common near-miss errors (e.g. `sources.source_type`, `evidence_excerpts.excerpt_text`, `claims.statement`).
+
+## Local Ollama execution (Issue #46)
+
+APD now supports a local Ollama execution path from brief detail pages.
+
+Required environment variables:
+
+- `APD_MODEL_PROVIDER=ollama`
+- `APD_OLLAMA_BASE_URL=http://localhost:11434`
+- `APD_OLLAMA_MODEL=<installed-model-name>`
+
+Optional:
+
+- `APD_OLLAMA_TIMEOUT_SECONDS` (default: `120`)
+- `APD_OLLAMA_REPAIR_ATTEMPTS` (default: `1`, capped at one repair call)
+
+Behavior:
+
+- APD calls local Ollama `POST /api/generate` with `stream=false`.
+- APD extracts JSON from the model output using a narrow parser:
+  1) full output as JSON,
+  2) fenced ```json block,
+  3) substring from first `{` to last `}`,
+  4) otherwise parse failure.
+- APD validates strictly, applies safe normalization for common near-miss fields, and attempts at most one repair call.
+- APD imports only when strict validation passes.
+- Brief metadata stores concise execution diagnostics under `metadata_json.last_execution`.
+
+Limitations:
+
+- Ollama only. No other provider integrations are included in this path.
+- No streaming, background jobs, source fetching, or external publishing.
+- Tests mock Ollama calls; live Ollama verification is manual.

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -1,5 +1,4 @@
-"""Tests for website-first stub research execution (issue #44).
-"""
+"""Tests for research execution paths (stub + Ollama)."""
 
 from __future__ import annotations
 
@@ -10,6 +9,11 @@ import pytest
 
 from apd.app.db import Base
 from apd.services.research_brief_service import create_brief, get_brief
+from apd.services.research_execution_ollama import (
+    execute_research_brief_ollama,
+    extract_json_object_from_model_output,
+    get_ollama_execution_config,
+)
 from apd.services.research_execution_stub import execute_research_brief_stub
 
 
@@ -86,5 +90,187 @@ def test_start_research_route_creates_run(client):
     assert resp2.status_code == 200
     # Should redirect to run detail and show the run title
     assert "Web stub" in resp2.text
+
+
+def test_ollama_config_detection_missing_env(monkeypatch):
+    monkeypatch.delenv("APD_MODEL_PROVIDER", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_MODEL", raising=False)
+
+    config, missing = get_ollama_execution_config()
+    assert config is None
+    assert "APD_MODEL_PROVIDER=ollama" in missing
+    assert "APD_OLLAMA_BASE_URL" in missing
+    assert "APD_OLLAMA_MODEL" in missing
+
+
+def test_extract_json_object_plain_json():
+    text = '{"run":{"title":"T","intent":"I"},"claims":[{"id":"c1","statement":"S"}]}'
+    parsed, parse_error = extract_json_object_from_model_output(text)
+    assert parse_error is None
+    assert parsed is not None
+    assert parsed["run"]["title"] == "T"
+
+
+def test_extract_json_object_from_fenced_block():
+    text = """
+    Here is your draft:
+    ```json
+    {"run":{"title":"T","intent":"I"},"claims":[{"id":"c1","statement":"S"}]}
+    ```
+    """
+    parsed, parse_error = extract_json_object_from_model_output(text)
+    assert parse_error is None
+    assert parsed is not None
+    assert parsed["run"]["intent"] == "I"
+
+
+def test_execute_ollama_success_path_imports_run(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_OLLAMA_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Ollama brief", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    def _fake_generate(config, payload):
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","external_draft_id":"ollama-1","agent_name":"ollama-test",'
+                    '"run":{"title":"Ollama run","intent":"Q"},"claims":[{"id":"c1","statement":"S"}]}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+
+    result = execute_research_brief_ollama(db, brief)
+    assert result["success"] is True
+    assert result["status"] == "imported"
+    assert isinstance(result["run_id"], int)
+
+
+def test_execute_ollama_unparseable_output_fails_without_import(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_OLLAMA_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Bad parse", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    def _fake_generate(config, payload):
+        return ({"response": "not json"}, None)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+
+    result = execute_research_brief_ollama(db, brief)
+    assert result["success"] is False
+    assert result["status"] == "parse_failed"
+    assert result["run_id"] is None
+
+
+def test_execute_ollama_validation_failure_repair_succeeds(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_OLLAMA_REPAIR_ATTEMPTS", "1")
+
+    brief = create_brief(db, title="Repair brief", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    calls = {"count": 0}
+
+    def _fake_generate(config, payload):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            # Missing required claims.statement (no alias field) to force repair.
+            return (
+                {
+                    "response": (
+                        '{"schema_version":"1.0","external_draft_id":"repair-1","agent_name":"ollama-test",'
+                        '"run":{"title":"R","intent":"Q"},"claims":[{"id":"c1"}]}'
+                    )
+                },
+                None,
+            )
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","external_draft_id":"repair-1b","agent_name":"ollama-test",'
+                    '"run":{"title":"R2","intent":"Q"},"claims":[{"id":"c1","statement":"fixed"}]}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+
+    result = execute_research_brief_ollama(db, brief)
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["status"] == "imported"
+    assert isinstance(result["run_id"], int)
+
+
+def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):
+    resp = client.post("/briefs", data={"title": "Web ollama", "research_question": "What is X?"}, follow_redirects=False)
+    assert resp.status_code == 303
+    brief_id = int(resp.headers["location"].split("/")[-1])
+
+    monkeypatch.setattr(
+        "apd.web.routes.get_ollama_execution_config",
+        lambda: (
+            type("Cfg", (), {"model": "llama3"})(),
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        "apd.web.routes.execute_research_brief_ollama",
+        lambda db, brief: {
+            "success": False,
+            "provider": "ollama",
+            "model": "llama3",
+            "status": "validation_failed",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "finished_at": "2026-01-01T00:00:01+00:00",
+            "errors": ["mocked failure"],
+            "warnings": [],
+            "run_id": None,
+        },
+    )
+
+    resp2 = client.post(f"/briefs/{brief_id}/start-research-ollama", follow_redirects=True)
+    assert resp2.status_code == 200
+    assert "mocked failure" in resp2.text
+
+
+def test_start_research_ollama_route_handles_missing_config(client, monkeypatch):
+    resp = client.post("/briefs", data={"title": "Web ollama config", "research_question": "What is X?"}, follow_redirects=False)
+    assert resp.status_code == 303
+    brief_id = int(resp.headers["location"].split("/")[-1])
+
+    monkeypatch.setattr(
+        "apd.web.routes.get_ollama_execution_config",
+        lambda: (None, ["APD_MODEL_PROVIDER=ollama", "APD_OLLAMA_MODEL"]),
+    )
+
+    resp2 = client.post(f"/briefs/{brief_id}/start-research-ollama", follow_redirects=True)
+    assert resp2.status_code == 200
+    assert "Missing required env" in resp2.text
+    assert "APD_OLLAMA_MODEL" in resp2.text
+
+
+def test_stub_route_still_works_when_ollama_path_exists(client):
+    resp = client.post("/briefs", data={"title": "Stub still works", "research_question": "What is X?"}, follow_redirects=False)
+    assert resp.status_code == 303
+    brief_id = int(resp.headers["location"].split("/")[-1])
+
+    resp2 = client.post(f"/briefs/{brief_id}/start-research", follow_redirects=True)
+    assert resp2.status_code == 200
+    assert "Stub still works" in resp2.text
 
 


### PR DESCRIPTION
## Summary
- add an Ollama-backed local research brief execution path using `POST /api/generate` with `stream=false`
- keep the existing stub execution route working and timezone-safe
- add config-aware brief detail UI for `Start Research with Ollama` or missing env guidance
- validate, safe-normalize, optionally repair (max one attempt), and import only on strict validation success
- persist concise execution diagnostics in `ResearchBrief.metadata_json.last_execution`

Refs #46

## Files Changed
- apd/services/research_execution_ollama.py
- apd/web/routes.py
- apd/web/templates/brief_detail.html
- tests/test_research_execution.py
- docs/briefs.md

## Verification
- Added/updated tests in `tests/test_research_execution.py` covering:
  - missing Ollama config detection
  - JSON extraction (plain JSON and fenced JSON)
  - success path import
  - unparseable output failure without import
  - validation failure + repair success
  - route behavior with mocked Ollama path (no live service)
  - stub route still works
- Lightweight checks run in Codex sandbox:
  - `git diff --stat`
  - `git status --short --branch`
- Full tests were **not run in Codex sandbox** because this environment cannot access the uv-managed Python interpreter.
- All Ollama tests use mocks; no live Ollama service calls are required by test execution.
- Manual live Ollama verification was **not performed** here and is expected to be done locally.
