### PR TITLE
Issue #49: Tighten local research prompts and quality gates

### DIFF
--- a/apd/services/research_brief_service.py
+++ b/apd/services/research_brief_service.py
@@ -82,6 +82,19 @@ uv run python scripts/normalize_agent_draft.py --path <draft.json> --out <normal
 Producing valid JSON on the first attempt avoids requiring a repair loop.
 """
 
+_OLLAMA_EXECUTION_CONSTRAINTS = """\
+## Local Ollama execution constraints (mandatory)
+
+- APD is a product investigation system, not a general Q&A system.
+- If this brief is not product/problem/opportunity oriented, return a structured needs-clarification draft instead of inventing a product run.
+- Do not invent sources, URLs, citations, Reddit threads, forum posts, or evidence.
+- No source text/source pack is provided in this local run. If evidence is ungrounded, label it as synthetic/model-prior in source metadata and avoid fake URLs.
+- For a normal product investigation run, include at least one candidate.
+- Claims must be specific enough to influence product judgment.
+- Candidates should include target user, first workflow, first wedge, substitutes, risks, and validation gates when possible.
+- All output remains draft/unreviewed.
+"""
+
 # ── CRUD ─────────────────────────────────────────────────────────────────────
 
 
@@ -204,3 +217,9 @@ def generate_agent_prompt(brief: ResearchBrief) -> str:
     )
 
     return "\n".join(lines)
+
+
+def generate_ollama_execution_prompt(brief: ResearchBrief) -> str:
+    """Return a stricter prompt for local Ollama execution."""
+    base = generate_agent_prompt(brief)
+    return "\n".join([base, "", "---", "", _OLLAMA_EXECUTION_CONSTRAINTS, "", "Return only the JSON package."])

--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -11,9 +11,9 @@ from urllib import error, request
 
 from sqlalchemy.orm import Session
 
-from apd.services.agent_draft_import import import_agent_draft_package
+from apd.services.agent_draft_import import AgentDraftPackage, import_agent_draft_package
 from apd.services.agent_draft_validation import validate_agent_draft_data
-from apd.services.research_brief_service import generate_agent_prompt
+from apd.services.research_brief_service import generate_ollama_execution_prompt
 
 
 def _iso_now() -> str:
@@ -27,6 +27,14 @@ class OllamaExecutionConfig:
     model: str
     timeout_seconds: int
     repair_attempts: int
+    keep_alive: int | str
+
+
+@dataclass(frozen=True)
+class ProductQualityGateResult:
+    status: str
+    error: str | None
+    warnings: list[str]
 
 
 def get_ollama_execution_config() -> tuple[OllamaExecutionConfig | None, list[str]]:
@@ -49,6 +57,7 @@ def get_ollama_execution_config() -> tuple[OllamaExecutionConfig | None, list[st
     repair_attempts = _parse_nonnegative_int_env("APD_OLLAMA_REPAIR_ATTEMPTS", default=1)
     # Scope guardrail: permit at most one repair call.
     repair_attempts = min(repair_attempts, 1)
+    keep_alive = _parse_keep_alive_env("APD_OLLAMA_KEEP_ALIVE", default=0)
 
     return (
         OllamaExecutionConfig(
@@ -57,6 +66,7 @@ def get_ollama_execution_config() -> tuple[OllamaExecutionConfig | None, list[st
             model=model,
             timeout_seconds=timeout_seconds,
             repair_attempts=repair_attempts,
+            keep_alive=keep_alive,
         ),
         [],
     )
@@ -103,7 +113,7 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
             "run_id": None,
         }
 
-    prompt = generate_agent_prompt(brief)
+    prompt = generate_ollama_execution_prompt(brief)
     status = "failed"
     errors_list: list[str] = []
     warnings_list: list[str] = []
@@ -149,6 +159,13 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
             errors_list.extend(_first_errors(report.errors, limit=5))
         finished_at = _iso_now()
         return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+    quality_result = _evaluate_product_quality_gate(package)
+    warnings_list.extend(quality_result.warnings)
+    if quality_result.error:
+        finished_at = _iso_now()
+        errors_list.append(quality_result.error)
+        return _build_result(config, quality_result.status, started_at, finished_at, run_id, errors_list, warnings_list)
 
     try:
         import_result = import_agent_draft_package(
@@ -196,11 +213,7 @@ def _call_ollama_for_draft(
     config: OllamaExecutionConfig,
     prompt: str,
 ) -> tuple[dict[str, Any] | None, str | None]:
-    payload = {
-        "model": config.model,
-        "prompt": prompt,
-        "stream": False,
-    }
+    payload = _build_generate_payload(config, prompt)
     response_data, call_error = _ollama_generate(config, payload)
     if call_error:
         return None, call_error
@@ -228,11 +241,7 @@ def _call_ollama_for_repair(
         "Draft JSON:\n"
         f"{prior_json}"
     )
-    payload = {
-        "model": config.model,
-        "prompt": prompt,
-        "stream": False,
-    }
+    payload = _build_generate_payload(config, prompt)
     response_data, call_error = _ollama_generate(config, payload)
     if call_error:
         return None, call_error
@@ -283,6 +292,42 @@ def _ollama_generate(
     return parsed, None
 
 
+def _build_generate_payload(config: OllamaExecutionConfig, prompt: str) -> dict[str, Any]:
+    return {
+        "model": config.model,
+        "prompt": prompt,
+        "stream": False,
+        "keep_alive": config.keep_alive,
+    }
+
+
+def _evaluate_product_quality_gate(package: AgentDraftPackage) -> ProductQualityGateResult:
+    if len(package.candidates) == 0:
+        return ProductQualityGateResult(
+            status="quality_failed_no_candidates",
+            error=(
+                "The model returned no product candidates. Refine the brief toward a product/problem/opportunity, "
+                "or try a stronger model."
+            ),
+            warnings=[],
+        )
+
+    recommendation = (package.run.recommendation or "").strip().lower()
+    if recommendation in {"needs_clarification", "needs-clarification"}:
+        return ProductQualityGateResult(
+            status="needs_clarification",
+            error="The model requested clarification. Refine the brief with a concrete product/problem/opportunity focus.",
+            warnings=[],
+        )
+
+    has_source_urls = any(bool(source.url and str(source.url).strip()) for source in package.sources)
+    warnings: list[str] = []
+    if has_source_urls:
+        warnings.append("quality_warning_unprovided_source_urls")
+
+    return ProductQualityGateResult(status="ok", error=None, warnings=warnings)
+
+
 def _parse_json_object(candidate: str) -> dict[str, Any] | None:
     try:
         parsed = json.loads(candidate)
@@ -317,6 +362,16 @@ def _parse_nonnegative_int_env(name: str, *, default: int) -> int:
     except ValueError:
         return default
     return value if value >= 0 else default
+
+
+def _parse_keep_alive_env(name: str, *, default: int) -> int | str:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return raw
 
 
 def _safe_normalize_near_miss(raw_data: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -45,6 +45,7 @@ Optional:
 
 - `APD_OLLAMA_TIMEOUT_SECONDS` (default: `120`)
 - `APD_OLLAMA_REPAIR_ATTEMPTS` (default: `1`, capped at one repair call)
+- `APD_OLLAMA_KEEP_ALIVE` (default: `0`, unload model after each APD run to free GPU/VRAM)
 
 Behavior:
 
@@ -55,11 +56,15 @@ Behavior:
   3) substring from first `{` to last `}`,
   4) otherwise parse failure.
 - APD validates strictly, applies safe normalization for common near-miss fields, and attempts at most one repair call.
-- APD imports only when strict validation passes.
+- APD imports only when strict validation and a minimal product-quality gate pass.
+- Schema-valid output is not automatically product-useful. APD rejects zero-candidate local runs with `quality_failed_no_candidates`.
+- If local output includes source URLs without provided source context, APD records a quality warning (`quality_warning_unprovided_source_urls`).
 - Brief metadata stores concise execution diagnostics under `metadata_json.last_execution`.
+- APD sends Ollama requests with `keep_alive: 0` by default so local model resources are released after execution.
 
 Limitations:
 
 - Ollama only. No other provider integrations are included in this path.
 - No streaming, background jobs, source fetching, or external publishing.
+- Local/Ollama runs should not invent sources, URLs, citations, or claims of fetched web evidence.
 - Tests mock Ollama calls; live Ollama verification is manual.

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -139,7 +139,8 @@ def test_execute_ollama_success_path_imports_run(db, monkeypatch):
             {
                 "response": (
                     '{"schema_version":"1.0","external_draft_id":"ollama-1","agent_name":"ollama-test",'
-                    '"run":{"title":"Ollama run","intent":"Q"},"claims":[{"id":"c1","statement":"S"}]}'
+                    '"run":{"title":"Ollama run","intent":"Q"},"claims":[{"id":"c1","statement":"S"}],'
+                    '"candidates":[{"id":"cand-1","title":"Candidate 1","summary":"S"}]}'
                 )
             },
             None,
@@ -201,7 +202,8 @@ def test_execute_ollama_validation_failure_repair_succeeds(db, monkeypatch):
             {
                 "response": (
                     '{"schema_version":"1.0","external_draft_id":"repair-1b","agent_name":"ollama-test",'
-                    '"run":{"title":"R2","intent":"Q"},"claims":[{"id":"c1","statement":"fixed"}]}'
+                    '"run":{"title":"R2","intent":"Q"},"claims":[{"id":"c1","statement":"fixed"}],'
+                    '"candidates":[{"id":"cand-1","title":"Candidate 1"}]}'
                 )
             },
             None,
@@ -214,6 +216,95 @@ def test_execute_ollama_validation_failure_repair_succeeds(db, monkeypatch):
     assert result["success"] is True
     assert result["status"] == "imported"
     assert isinstance(result["run_id"], int)
+
+
+def test_execute_ollama_zero_candidate_fails_quality_gate(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_OLLAMA_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="No candidates", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    def _fake_generate(config, payload):
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","external_draft_id":"qc-1","agent_name":"ollama-test",'
+                    '"run":{"title":"R","intent":"Q"},"claims":[{"id":"c1","statement":"S"}]}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama(db, brief)
+    assert result["success"] is False
+    assert result["status"] == "quality_failed_no_candidates"
+    assert result["run_id"] is None
+    assert any("no product candidates" in err.lower() for err in result["errors"])
+
+
+def test_execute_ollama_source_url_adds_quality_warning(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_OLLAMA_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="URL warning", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    def _fake_generate(config, payload):
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","external_draft_id":"qc-2","agent_name":"ollama-test",'
+                    '"run":{"title":"R","intent":"Q"},"sources":[{"id":"src-1","source_type":"forum","url":"https://example.com"}],'
+                    '"candidates":[{"id":"cand-1","title":"Candidate 1"}]}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama(db, brief)
+    assert result["success"] is True
+    assert result["status"] == "imported"
+    assert "quality_warning_unprovided_source_urls" in result["warnings"]
+
+
+def test_execute_ollama_payload_defaults_keep_alive_zero_and_uses_strict_prompt(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.delenv("APD_OLLAMA_KEEP_ALIVE", raising=False)
+    monkeypatch.setenv("APD_OLLAMA_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Prompt+payload", research_question="Q")
+    brief = get_brief(db, brief.id)
+    captured_payloads = []
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","external_draft_id":"qc-3","agent_name":"ollama-test",'
+                    '"run":{"title":"R","intent":"Q"},"candidates":[{"id":"cand-1","title":"Candidate 1"}]}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama(db, brief)
+    assert result["success"] is True
+    assert captured_payloads
+    first_payload = captured_payloads[0]
+    assert first_payload.get("keep_alive") == 0
+    assert "product investigation system" in first_payload.get("prompt", "").lower()
+    assert "do not invent sources" in first_payload.get("prompt", "").lower()
 
 
 def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):


### PR DESCRIPTION
## Summary
- tighten the local Ollama execution prompt to emphasize APD product-investigation scope, avoid invented sources, and require clearer candidate-oriented output
- add a small post-validation product-quality gate in the Ollama path before import
  - reject zero-candidate outputs with `quality_failed_no_candidates`
  - return a concise user-facing error in `last_execution`
  - mark URL-without-provided-context as `quality_warning_unprovided_source_urls`
  - support `needs_clarification` recommendation status when returned by the model
- add local Ollama lifecycle behavior to free GPU/VRAM by default using `keep_alive: 0` on generate calls (including repair calls), with optional `APD_OLLAMA_KEEP_ALIVE` override
- keep existing stub execution path unchanged

Refs #49

## Files Changed
- apd/services/research_brief_service.py
- apd/services/research_execution_ollama.py
- tests/test_research_execution.py
- docs/briefs.md

## Verification
- Attempted in Codex sandbox:
  - `powershell -ExecutionPolicy Bypass -File ./scripts/test.ps1` -> failed: `uv` not found in PATH
  - `python scripts/check_repo_readiness.py` -> failed: `python` not found in PATH
- Local tests were not run successfully in this Codex sandbox due Python/uv availability limits.
- GitHub Actions/local user verification is required.
- Tests in this PR mock Ollama HTTP behavior; no live Ollama instance is required for automated tests.
- Manual live Ollama verification was not performed in this environment.
- Default behavior now unloads/frees local Ollama GPU resources after execution via `keep_alive: 0`.
