### PR TITLE
Issue #51: Add provider-agnostic component execution prototype

### DIFF
--- a/apd/services/research_brief_service.py
+++ b/apd/services/research_brief_service.py
@@ -95,6 +95,33 @@ _OLLAMA_EXECUTION_CONSTRAINTS = """\
 - All output remains draft/unreviewed.
 """
 
+_COMPONENT_EXECUTION_CONSTRAINTS = """\
+## APD ResearchComponentBatch contract (mandatory)
+
+Return only one JSON object matching this shape:
+
+{
+  "schema_version": "1.0",
+  "batch_id": "<optional-id>",
+  "events": [
+    {
+      "schema_version": "1.0",
+      "event_type": "candidate.proposed|claim.proposed|theme.proposed|source.added|evidence_excerpt.added|validation_gate.proposed|evidence_link.added",
+      "external_id": "<required-event-id>",
+      "payload": { ... }
+    }
+  ]
+}
+
+Rules:
+- Return a ResearchComponentBatch only. Do not return a full APD draft package.
+- Use event_type values exactly as listed.
+- Every event needs schema_version, event_type, external_id, and payload.
+- For product investigations, include at least one candidate.proposed event.
+- Do not invent source URLs or citations.
+- If ungrounded, mark metadata as synthetic/model-prior.
+"""
+
 # ── CRUD ─────────────────────────────────────────────────────────────────────
 
 
@@ -223,3 +250,9 @@ def generate_ollama_execution_prompt(brief: ResearchBrief) -> str:
     """Return a stricter prompt for local Ollama execution."""
     base = generate_agent_prompt(brief)
     return "\n".join([base, "", "---", "", _OLLAMA_EXECUTION_CONSTRAINTS, "", "Return only the JSON package."])
+
+
+def generate_ollama_component_prompt(brief: ResearchBrief) -> str:
+    """Return a provider-agnostic component contract prompt for Ollama prototype execution."""
+    base = generate_ollama_execution_prompt(brief)
+    return "\n".join([base, "", "---", "", _COMPONENT_EXECUTION_CONSTRAINTS, "", "Return only the ResearchComponentBatch JSON object."])

--- a/apd/services/research_components.py
+++ b/apd/services/research_components.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+class ResearchComponentEventType(StrEnum):
+    CANDIDATE_PROPOSED = "candidate.proposed"
+    CLAIM_PROPOSED = "claim.proposed"
+    THEME_PROPOSED = "theme.proposed"
+    SOURCE_ADDED = "source.added"
+    EVIDENCE_EXCERPT_ADDED = "evidence_excerpt.added"
+    VALIDATION_GATE_PROPOSED = "validation_gate.proposed"
+    EVIDENCE_LINK_ADDED = "evidence_link.added"
+
+
+class ResearchComponentEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default="1.0", min_length=1)
+    event_type: ResearchComponentEventType
+    external_id: str = Field(min_length=1)
+    payload: dict[str, Any]
+
+
+class ResearchComponentBatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default="1.0", min_length=1)
+    batch_id: str | None = None
+    events: list[ResearchComponentEvent] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ComponentExecutionResult:
+    success: bool
+    package: dict[str, Any] | None
+    errors: list[str]
+    warnings: list[str]
+
+
+class ComponentDraftAssembler:
+    def __init__(self, *, run_title: str, run_intent: str | None, agent_name: str, external_draft_id: str):
+        self._run_title = run_title
+        self._run_intent = run_intent
+        self._agent_name = agent_name
+        self._external_draft_id = external_draft_id
+        self._warnings: list[str] = []
+        self._event_ids: set[str] = set()
+        self._data: dict[str, Any] = {
+            "schema_version": "1.0",
+            "external_draft_id": external_draft_id,
+            "agent_name": agent_name,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "run": {
+                "title": run_title,
+                "intent": run_intent,
+                "mode": "ollama_component_execution",
+                "recommendation": "needs_human_review",
+            },
+            "warnings": [],
+            "limitations": ["Component-based prototype output assembled from typed model events."],
+            "sources": [],
+            "evidence_excerpts": [],
+            "claims": [],
+            "themes": [],
+            "candidates": [],
+            "validation_gates": [],
+            "evidence_links": [],
+        }
+
+    def apply_batch(self, batch: ResearchComponentBatch) -> ComponentExecutionResult:
+        errors: list[str] = []
+        for index, event in enumerate(batch.events):
+            if event.external_id in self._event_ids:
+                errors.append(f"duplicate event external_id in batch: {event.external_id}")
+                continue
+            self._event_ids.add(event.external_id)
+            try:
+                self._apply_event(event)
+            except ValueError as exc:
+                errors.append(f"event[{index}] {event.event_type.value}: {exc}")
+        return ComponentExecutionResult(success=len(errors) == 0, package=self.package_dict(), errors=errors, warnings=list(self._warnings))
+
+    def package_dict(self) -> dict[str, Any]:
+        package = dict(self._data)
+        package["warnings"] = list(self._warnings)
+        return package
+
+    def _apply_event(self, event: ResearchComponentEvent) -> None:
+        payload = dict(event.payload or {})
+        metadata = payload.get("metadata_json")
+        if metadata is None or not isinstance(metadata, dict):
+            metadata = {}
+        payload["metadata_json"] = metadata
+
+        if event.event_type == ResearchComponentEventType.CANDIDATE_PROPOSED:
+            title = str(payload.get("title") or "").strip()
+            if not title:
+                raise ValueError("candidate payload requires title")
+            self._data["candidates"].append(
+                {
+                    "id": event.external_id,
+                    "title": title,
+                    "summary": payload.get("summary"),
+                    "target_user": payload.get("target_user"),
+                    "first_workflow": payload.get("first_workflow"),
+                    "first_wedge": payload.get("first_wedge"),
+                    "prototype_success_event": payload.get("prototype_success_event"),
+                    "monetization_path": payload.get("monetization_path"),
+                    "substitutes": payload.get("substitutes"),
+                    "risks": payload.get("risks"),
+                    "why_now": payload.get("why_now"),
+                    "why_it_might_fail": payload.get("why_it_might_fail"),
+                    "metadata_json": metadata,
+                }
+            )
+            return
+
+        if event.event_type == ResearchComponentEventType.CLAIM_PROPOSED:
+            statement = str(payload.get("statement") or "").strip()
+            if not statement:
+                raise ValueError("claim payload requires statement")
+            claim: dict[str, Any] = {
+                "id": event.external_id,
+                "statement": statement,
+                "claim_type": payload.get("claim_type"),
+                "created_by": payload.get("created_by"),
+                "metadata_json": metadata,
+            }
+            if payload.get("confidence") is not None:
+                try:
+                    claim["confidence"] = float(payload["confidence"])
+                except (TypeError, ValueError):
+                    raise ValueError("claim confidence must be numeric")
+            self._data["claims"].append(claim)
+            return
+
+        if event.event_type == ResearchComponentEventType.THEME_PROPOSED:
+            name = str(payload.get("name") or "").strip()
+            if not name:
+                raise ValueError("theme payload requires name")
+            self._data["themes"].append(
+                {
+                    "id": event.external_id,
+                    "name": name,
+                    "summary": payload.get("summary"),
+                    "theme_type": payload.get("theme_type"),
+                    "severity": payload.get("severity"),
+                    "frequency": payload.get("frequency"),
+                    "user_segment": payload.get("user_segment"),
+                    "workflow": payload.get("workflow"),
+                    "metadata_json": metadata,
+                }
+            )
+            return
+
+        if event.event_type == ResearchComponentEventType.SOURCE_ADDED:
+            source_type = str(payload.get("source_type") or "").strip()
+            if not source_type:
+                raise ValueError("source payload requires source_type")
+            self._data["sources"].append(
+                {
+                    "id": event.external_id,
+                    "title": payload.get("title"),
+                    "source_type": source_type,
+                    "url": payload.get("url"),
+                    "origin": payload.get("origin"),
+                    "summary": payload.get("summary"),
+                    "metadata_json": metadata,
+                }
+            )
+            return
+
+        if event.event_type == ResearchComponentEventType.EVIDENCE_EXCERPT_ADDED:
+            source_id = str(payload.get("source_id") or "").strip()
+            excerpt_text = str(payload.get("excerpt_text") or "").strip()
+            if not source_id or not excerpt_text:
+                raise ValueError("evidence excerpt payload requires source_id and excerpt_text")
+            self._data["evidence_excerpts"].append(
+                {
+                    "id": event.external_id,
+                    "source_id": source_id,
+                    "excerpt_text": excerpt_text,
+                    "location_reference": payload.get("location_reference"),
+                    "excerpt_type": payload.get("excerpt_type"),
+                    "metadata_json": metadata,
+                }
+            )
+            return
+
+        if event.event_type == ResearchComponentEventType.VALIDATION_GATE_PROPOSED:
+            name = str(payload.get("name") or "").strip()
+            if not name:
+                raise ValueError("validation gate payload requires name")
+            self._data["validation_gates"].append(
+                {
+                    "id": event.external_id,
+                    "candidate_id": payload.get("candidate_id"),
+                    "phase": payload.get("phase"),
+                    "name": name,
+                    "description": payload.get("description"),
+                    "status": payload.get("status"),
+                    "blocking": payload.get("blocking", True),
+                    "evidence_summary": payload.get("evidence_summary"),
+                    "missing_evidence": payload.get("missing_evidence"),
+                    "metadata_json": metadata,
+                }
+            )
+            return
+
+        if event.event_type == ResearchComponentEventType.EVIDENCE_LINK_ADDED:
+            target_type = str(payload.get("target_type") or "").strip()
+            target_id = str(payload.get("target_id") or "").strip()
+            relationship = str(payload.get("relationship") or "").strip()
+            if not target_type or not target_id or not relationship:
+                raise ValueError("evidence link payload requires target_type, target_id, and relationship")
+            self._data["evidence_links"].append(
+                {
+                    "id": event.external_id,
+                    "source_id": payload.get("source_id"),
+                    "excerpt_id": payload.get("excerpt_id"),
+                    "target_type": target_type,
+                    "target_id": target_id,
+                    "relationship": relationship,
+                    "strength": payload.get("strength"),
+                    "notes": payload.get("notes"),
+                    "metadata_json": metadata,
+                }
+            )
+            return
+
+        raise ValueError(f"unsupported event type: {event.event_type}")
+
+
+def parse_component_batch_from_data(raw_data: dict[str, Any]) -> tuple[ResearchComponentBatch | None, list[str]]:
+    try:
+        batch = ResearchComponentBatch.model_validate(raw_data)
+    except ValidationError as exc:
+        errors: list[str] = []
+        for err in exc.errors():
+            location = ".".join(str(part) for part in err.get("loc", []))
+            message = err.get("msg", "validation error")
+            errors.append(f"{location}: {message}" if location else message)
+        return None, errors
+    return batch, []

--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -13,7 +13,11 @@ from sqlalchemy.orm import Session
 
 from apd.services.agent_draft_import import AgentDraftPackage, import_agent_draft_package
 from apd.services.agent_draft_validation import validate_agent_draft_data
-from apd.services.research_brief_service import generate_ollama_execution_prompt
+from apd.services.research_brief_service import (
+    generate_ollama_component_prompt,
+    generate_ollama_execution_prompt,
+)
+from apd.services.research_components import ComponentDraftAssembler, parse_component_batch_from_data
 
 
 def _iso_now() -> str:
@@ -187,6 +191,136 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
     return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
 
 
+def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, Any]:
+    """Experimental component-based execution path using provider-agnostic event schema."""
+    config, missing_env = get_ollama_execution_config()
+    now = _iso_now()
+    if config is None:
+        return {
+            "success": False,
+            "provider": "ollama-components",
+            "status": "config_missing",
+            "started_at": now,
+            "finished_at": now,
+            "errors": [f"Missing required env: {value}" for value in missing_env],
+            "warnings": [],
+            "run_id": None,
+        }
+
+    started_at = now
+    prompt = generate_ollama_component_prompt(brief)
+    raw_batch_data, parse_error = _call_ollama_for_component_batch(config, prompt)
+    if parse_error:
+        finished_at = _iso_now()
+        return _build_result(
+            config,
+            "component_parse_failed",
+            started_at,
+            finished_at,
+            None,
+            [parse_error],
+            [],
+            provider_override="ollama-components",
+        )
+
+    batch, batch_errors = parse_component_batch_from_data(raw_batch_data)
+    if batch is None:
+        finished_at = _iso_now()
+        return _build_result(
+            config,
+            "component_validation_failed",
+            started_at,
+            finished_at,
+            None,
+            _first_errors(batch_errors, limit=5),
+            [],
+            provider_override="ollama-components",
+        )
+
+    run_title = brief.title or (brief.research_question[:120] if brief.research_question else "Component Research")
+    assembler = ComponentDraftAssembler(
+        run_title=run_title,
+        run_intent=brief.research_question,
+        agent_name="ollama-component-prototype",
+        external_draft_id=f"brief-{brief.id}-components-{started_at}",
+    )
+    assembly_result = assembler.apply_batch(batch)
+    if not assembly_result.success or assembly_result.package is None:
+        finished_at = _iso_now()
+        return _build_result(
+            config,
+            "component_assembly_failed",
+            started_at,
+            finished_at,
+            None,
+            _first_errors(assembly_result.errors, limit=5),
+            _first_errors(assembly_result.warnings, limit=5),
+            provider_override="ollama-components",
+        )
+
+    report = validate_agent_draft_data(Path("<ollama-components-output>"), assembly_result.package)
+    if not report.is_valid or report.package is None:
+        finished_at = _iso_now()
+        return _build_result(
+            config,
+            "validation_failed",
+            started_at,
+            finished_at,
+            None,
+            _first_errors(report.errors, limit=5),
+            _first_errors(assembly_result.warnings, limit=5),
+            provider_override="ollama-components",
+        )
+
+    quality_result = _evaluate_product_quality_gate(report.package)
+    warnings_list = list(assembly_result.warnings) + quality_result.warnings
+    if quality_result.error:
+        finished_at = _iso_now()
+        return _build_result(
+            config,
+            quality_result.status,
+            started_at,
+            finished_at,
+            None,
+            [quality_result.error],
+            _first_errors(warnings_list, limit=5),
+            provider_override="ollama-components",
+        )
+
+    try:
+        import_result = import_agent_draft_package(
+            db,
+            report.package,
+            package_path=None,
+            allow_duplicate_external_id=False,
+        )
+    except Exception as exc:
+        finished_at = _iso_now()
+        return _build_result(
+            config,
+            "import_failed",
+            started_at,
+            finished_at,
+            None,
+            [f"import_failed: {exc}"],
+            _first_errors(warnings_list, limit=5),
+            provider_override="ollama-components",
+        )
+
+    finished_at = _iso_now()
+    warnings_list.extend(import_result.warnings)
+    return _build_result(
+        config,
+        "imported",
+        started_at,
+        finished_at,
+        import_result.run_db_id,
+        [],
+        _first_errors(warnings_list, limit=5),
+        provider_override="ollama-components",
+    )
+
+
 def _build_result(
     config: OllamaExecutionConfig,
     status: str,
@@ -195,10 +329,11 @@ def _build_result(
     run_id: int | None,
     errors_list: list[str],
     warnings_list: list[str],
+    provider_override: str | None = None,
 ) -> dict[str, Any]:
     return {
         "success": status == "imported" and run_id is not None,
-        "provider": config.provider,
+        "provider": provider_override or config.provider,
         "model": config.model,
         "status": status,
         "started_at": started_at,
@@ -223,6 +358,23 @@ def _call_ollama_for_draft(
         return None, "provider_error: empty_ollama_response"
 
     return extract_json_object_from_model_output(output_text)
+
+
+def _call_ollama_for_component_batch(
+    config: OllamaExecutionConfig,
+    prompt: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    payload = _build_generate_payload(config, prompt)
+    response_data, call_error = _ollama_generate(config, payload)
+    if call_error:
+        return None, call_error
+    output_text = str(response_data.get("response") or "")
+    if not output_text.strip():
+        return None, "provider_error: empty_ollama_response"
+    parsed, parse_error = extract_json_object_from_model_output(output_text)
+    if parse_error:
+        return None, parse_error
+    return parsed, None
 
 
 def _call_ollama_for_repair(

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -24,6 +24,7 @@ from apd.services.research_brief_service import (
     list_briefs,
 )
 from apd.services.research_execution_ollama import (
+    execute_research_brief_ollama_components,
     execute_research_brief_ollama,
     get_ollama_execution_config,
 )
@@ -338,5 +339,50 @@ def start_research_ollama(brief_id: int, db: Session = Depends(_get_db)):
     if result.get("success") and result.get("run_id"):
         return RedirectResponse(url=f"/runs/{result.get('run_id')}", status_code=303)
 
+    return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+
+@router.post("/briefs/{brief_id}/start-research-ollama-components", response_class=RedirectResponse)
+def start_research_ollama_components(brief_id: int, db: Session = Depends(_get_db)):
+    brief = get_brief(db, brief_id)
+    if brief is None:
+        raise HTTPException(status_code=404, detail="Research brief not found")
+
+    config, missing_env = get_ollama_execution_config()
+    if config is None:
+        _save_last_execution(
+            db,
+            brief,
+            {
+                "provider": "ollama-components",
+                "status": "config_missing",
+                "started_at": _iso_now(),
+                "finished_at": _iso_now(),
+                "errors": [f"Missing required env: {value}" for value in missing_env],
+                "warnings": [],
+                "run_id": None,
+            },
+        )
+        return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+    _save_last_execution(
+        db,
+        brief,
+        {
+            "provider": "ollama-components",
+            "model": config.model,
+            "status": "running",
+            "started_at": _iso_now(),
+            "errors": [],
+            "warnings": [],
+            "run_id": None,
+        },
+    )
+
+    result = execute_research_brief_ollama_components(db, brief)
+    _save_last_execution(db, brief, result)
+
+    if result.get("success") and result.get("run_id"):
+        return RedirectResponse(url=f"/runs/{result.get('run_id')}", status_code=303)
     return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -154,6 +154,9 @@
       <form method="post" action="/briefs/{{ brief.id }}/start-research-ollama" style="display:inline; margin-left:0.5rem;">
         <button type="submit" class="btn btn-sm btn-primary">Start Research with Ollama</button>
       </form>
+      <form method="post" action="/briefs/{{ brief.id }}/start-research-ollama-components" style="display:inline; margin-left:0.5rem;">
+        <button type="submit" class="btn btn-sm btn-primary">Start Research with Components (experimental)</button>
+      </form>
     {% else %}
       Configure all required env vars to enable this path:
       <code>APD_MODEL_PROVIDER=ollama</code>,

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -68,3 +68,32 @@ Limitations:
 - No streaming, background jobs, source fetching, or external publishing.
 - Local/Ollama runs should not invent sources, URLs, citations, or claims of fetched web evidence.
 - Tests mock Ollama calls; live Ollama verification is manual.
+
+## Component-based execution prototype (Issue #51)
+
+APD now includes an experimental component-based execution path that uses a provider-agnostic event contract.
+
+Why this exists:
+
+- Monolithic draft JSON generation is brittle across models.
+- Component batches let APD validate smaller typed events before final import.
+- APD still assembles a standard APD draft package and uses strict draft validation/import as the final gate.
+
+What this is:
+
+- A synchronous website-first prototype path (`Start Research with Components (experimental)`).
+- Provider-agnostic schema names (`ResearchComponentEvent`, `ResearchComponentBatch`, `ComponentDraftAssembler`).
+- Ollama is the first adapter implementation.
+
+What this is not:
+
+- Not browser streaming.
+- Not WebSockets or SSE.
+- Not background jobs.
+- Not a provider registry.
+
+Current component minimum:
+
+- Supports candidate, claim, and theme events (plus optional source/excerpt/gate/link events).
+- Rejects zero-candidate assembled output before import.
+- Uses the same keep-alive behavior (`keep_alive: 0` default) to free local model resources after execution.

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -8,8 +8,13 @@ from sqlalchemy.orm import sessionmaker
 import pytest
 
 from apd.app.db import Base
+from apd.services.research_components import (
+    ComponentDraftAssembler,
+    parse_component_batch_from_data,
+)
 from apd.services.research_brief_service import create_brief, get_brief
 from apd.services.research_execution_ollama import (
+    execute_research_brief_ollama_components,
     execute_research_brief_ollama,
     extract_json_object_from_model_output,
     get_ollama_execution_config,
@@ -125,6 +130,66 @@ def test_extract_json_object_from_fenced_block():
     assert parsed["run"]["intent"] == "I"
 
 
+def test_component_batch_valid_events_assemble_to_draft_package():
+    raw_batch = {
+        "schema_version": "1.0",
+        "batch_id": "batch-1",
+        "events": [
+            {
+                "schema_version": "1.0",
+                "event_type": "candidate.proposed",
+                "external_id": "cand-1",
+                "payload": {"title": "Candidate A", "summary": "S"},
+            },
+            {
+                "schema_version": "1.0",
+                "event_type": "claim.proposed",
+                "external_id": "claim-1",
+                "payload": {"statement": "Claim text"},
+            },
+            {
+                "schema_version": "1.0",
+                "event_type": "theme.proposed",
+                "external_id": "theme-1",
+                "payload": {"name": "Theme A"},
+            },
+        ],
+    }
+    batch, errors = parse_component_batch_from_data(raw_batch)
+    assert batch is not None
+    assert not errors
+
+    assembler = ComponentDraftAssembler(
+        run_title="Component run",
+        run_intent="Q",
+        agent_name="component-test",
+        external_draft_id="ext-1",
+    )
+    result = assembler.apply_batch(batch)
+    assert result.success is True
+    assert result.package is not None
+    assert len(result.package["candidates"]) == 1
+    assert len(result.package["claims"]) == 1
+    assert len(result.package["themes"]) == 1
+
+
+def test_component_batch_malformed_event_fails_validation():
+    raw_batch = {
+        "schema_version": "1.0",
+        "events": [
+            {
+                "schema_version": "1.0",
+                "event_type": "claim.proposed",
+                # missing external_id
+                "payload": {"statement": "Claim text"},
+            }
+        ],
+    }
+    batch, errors = parse_component_batch_from_data(raw_batch)
+    assert batch is None
+    assert errors
+
+
 def test_execute_ollama_success_path_imports_run(db, monkeypatch):
     monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
     monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
@@ -152,6 +217,93 @@ def test_execute_ollama_success_path_imports_run(db, monkeypatch):
     assert result["success"] is True
     assert result["status"] == "imported"
     assert isinstance(result["run_id"], int)
+
+
+def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+
+    brief = create_brief(db, title="Components brief", research_question="Q")
+    brief = get_brief(db, brief.id)
+    captured_payloads = []
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b1","events":['
+                    '{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate A","summary":"S"}},'
+                    '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim A"}},'
+                    '{"schema_version":"1.0","event_type":"theme.proposed","external_id":"theme-1","payload":{"name":"Theme A"}}'
+                    ']}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components(db, brief)
+    assert result["success"] is True
+    assert result["status"] == "imported"
+    assert isinstance(result["run_id"], int)
+    assert captured_payloads
+    assert captured_payloads[0].get("keep_alive") == 0
+
+
+def test_execute_ollama_components_zero_candidate_fails_before_import(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+
+    brief = create_brief(db, title="Components no candidate", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    def _fake_generate(config, payload):
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b1","events":['
+                    '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim A"}}'
+                    ']}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components(db, brief)
+    assert result["success"] is False
+    assert result["status"] == "quality_failed_no_candidates"
+    assert result["run_id"] is None
+
+
+def test_execute_ollama_components_malformed_batch_does_not_import(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+
+    brief = create_brief(db, title="Components malformed", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    def _fake_generate(config, payload):
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b1","events":['
+                    '{"schema_version":"1.0","event_type":"candidate.proposed","payload":{"title":"Candidate A"}}'
+                    ']}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components(db, brief)
+    assert result["success"] is False
+    assert result["status"] == "component_validation_failed"
+    assert result["run_id"] is None
 
 
 def test_execute_ollama_unparseable_output_fails_without_import(db, monkeypatch):
@@ -337,6 +489,38 @@ def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):
     resp2 = client.post(f"/briefs/{brief_id}/start-research-ollama", follow_redirects=True)
     assert resp2.status_code == 200
     assert "mocked failure" in resp2.text
+
+
+def test_start_research_ollama_components_route_uses_mocked_service(client, monkeypatch):
+    resp = client.post("/briefs", data={"title": "Web components", "research_question": "What is X?"}, follow_redirects=False)
+    assert resp.status_code == 303
+    brief_id = int(resp.headers["location"].split("/")[-1])
+
+    monkeypatch.setattr(
+        "apd.web.routes.get_ollama_execution_config",
+        lambda: (
+            type("Cfg", (), {"model": "llama3"})(),
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        "apd.web.routes.execute_research_brief_ollama_components",
+        lambda db, brief: {
+            "success": False,
+            "provider": "ollama-components",
+            "model": "llama3",
+            "status": "component_validation_failed",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "finished_at": "2026-01-01T00:00:01+00:00",
+            "errors": ["mocked components failure"],
+            "warnings": [],
+            "run_id": None,
+        },
+    )
+
+    resp2 = client.post(f"/briefs/{brief_id}/start-research-ollama-components", follow_redirects=True)
+    assert resp2.status_code == 200
+    assert "mocked components failure" in resp2.text
 
 
 def test_start_research_ollama_route_handles_missing_config(client, monkeypatch):


### PR DESCRIPTION
## Summary
- add a provider-agnostic typed component contract and assembler for research execution prototypes
  - `ResearchComponentEvent`
  - `ResearchComponentBatch`
  - `ComponentExecutionResult`
  - `ComponentDraftAssembler`
- add an experimental Ollama-backed component execution path that:
  - requests `ResearchComponentBatch` JSON (not monolithic draft JSON)
  - validates component events
  - assembles a normal APD draft package
  - runs existing strict APD draft validation before import
  - enforces zero-candidate failure before import
- add a new website-first route/button for experimental component execution:
  - `POST /briefs/{brief_id}/start-research-ollama-components`
  - UI label: `Start Research with Components (experimental)`
- keep existing single-package Ollama path and stub path unchanged
- preserve Ollama keep-alive lifecycle behavior (`keep_alive: 0` by default) in component calls
- update docs to explain provider-agnostic component prototype rationale and scope limits

Refs #51

## Files Changed
- apd/services/research_components.py
- apd/services/research_brief_service.py
- apd/services/research_execution_ollama.py
- apd/web/routes.py
- apd/web/templates/brief_detail.html
- tests/test_research_execution.py
- docs/briefs.md

## Verification
- Attempted in Codex sandbox:
  - `powershell -ExecutionPolicy Bypass -File ./scripts/test.ps1` -> failed (`uv` not found in PATH)
  - `python scripts/check_repo_readiness.py` -> failed (`python` not found in PATH)
- Local test execution was not possible in this sandbox due missing `uv`/`python` availability.
- GitHub Actions/local user verification is required.
- No live Ollama is required for automated tests; tests mock Ollama/provider calls.
- This prototype is not browser streaming yet (no WebSockets/SSE/background jobs).
- Existing single-package Ollama and stub execution paths remain supported.
