### PR TITLE
Issue #53: add component repair and retry loop for model-generated batches

### DIFF
--- a/apd/services/research_brief_service.py
+++ b/apd/services/research_brief_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -256,3 +257,82 @@ def generate_ollama_component_prompt(brief: ResearchBrief) -> str:
     """Return a provider-agnostic component contract prompt for Ollama prototype execution."""
     base = generate_ollama_execution_prompt(brief)
     return "\n".join([base, "", "---", "", _COMPONENT_EXECUTION_CONSTRAINTS, "", "Return only the ResearchComponentBatch JSON object."])
+
+
+def generate_ollama_component_phase_prompt(
+    brief: ResearchBrief,
+    phase_name: str,
+    *,
+    candidate_ids: list[str] | None = None,
+) -> str:
+    """Return a phase-specific component batch prompt."""
+    base = generate_ollama_execution_prompt(brief)
+    candidates_block = ", ".join(candidate_ids or [])
+    if not candidates_block:
+        candidates_block = "(none yet)"
+
+    phase_instructions: dict[str, str] = {
+        "candidate_batch": (
+            "Phase: candidate_batch\n"
+            "- Return only ResearchComponentBatch JSON.\n"
+            "- Include at least one candidate.proposed event.\n"
+            "- No full APD draft package.\n"
+            "- No fake source URLs or citations."
+        ),
+        "claim_theme_batch": (
+            "Phase: claim_theme_batch\n"
+            "- Return only ResearchComponentBatch JSON.\n"
+            "- Use claim.proposed and/or theme.proposed events.\n"
+            "- Claims must be specific enough to influence product judgment.\n"
+            "- No fake source URLs or citations."
+        ),
+        "validation_gate_batch": (
+            "Phase: validation_gate_batch\n"
+            "- Return only ResearchComponentBatch JSON.\n"
+            "- Use validation_gate.proposed events.\n"
+            "- Prefer candidate_id values from existing candidates.\n"
+            f"- Existing candidate IDs: {candidates_block}"
+        ),
+    }
+    selected = phase_instructions.get(
+        phase_name,
+        "Phase: generic_component_batch\n- Return only ResearchComponentBatch JSON.",
+    )
+    return "\n".join([base, "", "---", "", _COMPONENT_EXECUTION_CONSTRAINTS, "", selected, "", "Return only the ResearchComponentBatch JSON object."])
+
+
+def generate_ollama_component_repair_prompt(
+    brief: ResearchBrief,
+    *,
+    phase_name: str,
+    validation_errors: list[str],
+    invalid_batch_data: dict[str, object] | None,
+) -> str:
+    """Return a phase-specific repair prompt for an invalid component batch."""
+    base = generate_ollama_execution_prompt(brief)
+    errors_block = "\n".join(f"- {line}" for line in validation_errors[:8]) or "- unknown validation error"
+    invalid_json = "{}" if invalid_batch_data is None else json.dumps(invalid_batch_data, ensure_ascii=False)
+    return "\n".join(
+        [
+            base,
+            "",
+            "---",
+            "",
+            _COMPONENT_EXECUTION_CONSTRAINTS,
+            "",
+            "Phase repair request:",
+            f"- Phase name: {phase_name}",
+            "- Return only corrected ResearchComponentBatch JSON.",
+            "- Preserve valid event external_id values where possible.",
+            "- Fix only schema/shape/required-content problems.",
+            "- Do not add prose.",
+            "",
+            "Validation errors:",
+            errors_block,
+            "",
+            "Invalid batch JSON:",
+            invalid_json,
+            "",
+            "Return only the corrected ResearchComponentBatch JSON object.",
+        ]
+    )

--- a/apd/services/research_components.py
+++ b/apd/services/research_components.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
@@ -74,6 +75,9 @@ class ComponentDraftAssembler:
         }
 
     def apply_batch(self, batch: ResearchComponentBatch) -> ComponentExecutionResult:
+        original_data = json.loads(json.dumps(self._data))
+        original_warnings = list(self._warnings)
+        original_event_ids = set(self._event_ids)
         errors: list[str] = []
         for index, event in enumerate(batch.events):
             if event.external_id in self._event_ids:
@@ -84,7 +88,12 @@ class ComponentDraftAssembler:
                 self._apply_event(event)
             except ValueError as exc:
                 errors.append(f"event[{index}] {event.event_type.value}: {exc}")
-        return ComponentExecutionResult(success=len(errors) == 0, package=self.package_dict(), errors=errors, warnings=list(self._warnings))
+        if errors:
+            self._data = original_data
+            self._warnings = original_warnings
+            self._event_ids = original_event_ids
+            return ComponentExecutionResult(success=False, package=None, errors=errors, warnings=list(self._warnings))
+        return ComponentExecutionResult(success=True, package=self.package_dict(), errors=[], warnings=list(self._warnings))
 
     def package_dict(self) -> dict[str, Any]:
         package = dict(self._data)

--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -14,10 +14,16 @@ from sqlalchemy.orm import Session
 from apd.services.agent_draft_import import AgentDraftPackage, import_agent_draft_package
 from apd.services.agent_draft_validation import validate_agent_draft_data
 from apd.services.research_brief_service import (
-    generate_ollama_component_prompt,
+    generate_ollama_component_phase_prompt,
+    generate_ollama_component_repair_prompt,
     generate_ollama_execution_prompt,
 )
-from apd.services.research_components import ComponentDraftAssembler, parse_component_batch_from_data
+from apd.services.research_components import (
+    ComponentDraftAssembler,
+    ResearchComponentBatch,
+    ResearchComponentEventType,
+    parse_component_batch_from_data,
+)
 
 
 def _iso_now() -> str:
@@ -194,6 +200,7 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
 def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, Any]:
     """Experimental component-based execution path using provider-agnostic event schema."""
     config, missing_env = get_ollama_execution_config()
+    component_repair_attempts = _parse_component_repair_attempts_env("APD_COMPONENT_REPAIR_ATTEMPTS", default=2)
     now = _iso_now()
     if config is None:
         return {
@@ -208,35 +215,6 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
         }
 
     started_at = now
-    prompt = generate_ollama_component_prompt(brief)
-    raw_batch_data, parse_error = _call_ollama_for_component_batch(config, prompt)
-    if parse_error:
-        finished_at = _iso_now()
-        return _build_result(
-            config,
-            "component_parse_failed",
-            started_at,
-            finished_at,
-            None,
-            [parse_error],
-            [],
-            provider_override="ollama-components",
-        )
-
-    batch, batch_errors = parse_component_batch_from_data(raw_batch_data)
-    if batch is None:
-        finished_at = _iso_now()
-        return _build_result(
-            config,
-            "component_validation_failed",
-            started_at,
-            finished_at,
-            None,
-            _first_errors(batch_errors, limit=5),
-            [],
-            provider_override="ollama-components",
-        )
-
     run_title = brief.title or (brief.research_question[:120] if brief.research_question else "Component Research")
     assembler = ComponentDraftAssembler(
         run_title=run_title,
@@ -244,21 +222,85 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
         agent_name="ollama-component-prototype",
         external_draft_id=f"brief-{brief.id}-components-{started_at}",
     )
-    assembly_result = assembler.apply_batch(batch)
-    if not assembly_result.success or assembly_result.package is None:
-        finished_at = _iso_now()
-        return _build_result(
-            config,
-            "component_assembly_failed",
-            started_at,
-            finished_at,
-            None,
-            _first_errors(assembly_result.errors, limit=5),
-            _first_errors(assembly_result.warnings, limit=5),
-            provider_override="ollama-components",
-        )
+    attempts_by_phase: dict[str, int] = {}
+    warnings_list: list[str] = []
+    candidate_ids: list[str] = []
+    phases = ["candidate_batch", "claim_theme_batch", "validation_gate_batch"]
 
-    report = validate_agent_draft_data(Path("<ollama-components-output>"), assembly_result.package)
+    for phase_name in phases:
+        errors_for_phase: list[str] = []
+        prior_raw_batch: dict[str, Any] | None = None
+        max_attempts = component_repair_attempts + 1
+        attempts_by_phase[phase_name] = 0
+
+        for attempt_index in range(max_attempts):
+            attempts_by_phase[phase_name] = attempt_index + 1
+            if attempt_index == 0:
+                prompt = generate_ollama_component_phase_prompt(brief, phase_name, candidate_ids=candidate_ids)
+            else:
+                prompt = generate_ollama_component_repair_prompt(
+                    brief,
+                    phase_name=phase_name,
+                    validation_errors=errors_for_phase,
+                    invalid_batch_data=prior_raw_batch,
+                )
+
+            raw_batch_data, parse_error = _call_ollama_for_component_batch(config, prompt)
+            if parse_error:
+                errors_for_phase = [f"{phase_name}: {parse_error}"]
+                prior_raw_batch = None
+                continue
+
+            prior_raw_batch = raw_batch_data
+            batch, batch_errors = parse_component_batch_from_data(raw_batch_data)
+            if batch is None:
+                errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(batch_errors, limit=5)]
+                continue
+
+            phase_errors = _validate_component_phase_batch(phase_name, batch)
+            if phase_errors:
+                errors_for_phase = phase_errors
+                continue
+
+            assembly_result = assembler.apply_batch(batch)
+            if not assembly_result.success:
+                errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(assembly_result.errors, limit=5)]
+                continue
+
+            if phase_name == "candidate_batch":
+                candidate_ids = [
+                    event.external_id
+                    for event in batch.events
+                    if event.event_type == ResearchComponentEventType.CANDIDATE_PROPOSED
+                ]
+            warnings_list.extend(_first_errors(assembly_result.warnings, limit=5))
+            break
+        else:
+            finished_at = _iso_now()
+            failure_status = "quality_failed_no_candidates" if phase_name == "candidate_batch" else "component_validation_failed"
+            if phase_name == "candidate_batch":
+                errors_for_phase = [
+                    (
+                        "The model returned no product candidates. Refine the brief toward a product/problem/opportunity, "
+                        "or try a stronger model."
+                    )
+                ]
+            return _build_result(
+                config,
+                failure_status,
+                started_at,
+                finished_at,
+                None,
+                _first_errors(errors_for_phase or [f"{phase_name}: failed"], limit=5),
+                _first_errors(warnings_list, limit=5),
+                provider_override="ollama-components",
+                mode="component_execution",
+                last_phase=phase_name,
+                attempts_by_phase=attempts_by_phase,
+            )
+
+    assembled_package = assembler.package_dict()
+    report = validate_agent_draft_data(Path("<ollama-components-output>"), assembled_package)
     if not report.is_valid or report.package is None:
         finished_at = _iso_now()
         return _build_result(
@@ -268,12 +310,15 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
             finished_at,
             None,
             _first_errors(report.errors, limit=5),
-            _first_errors(assembly_result.warnings, limit=5),
+            _first_errors(warnings_list, limit=5),
             provider_override="ollama-components",
+            mode="component_execution",
+            last_phase="final_validation",
+            attempts_by_phase=attempts_by_phase,
         )
 
     quality_result = _evaluate_product_quality_gate(report.package)
-    warnings_list = list(assembly_result.warnings) + quality_result.warnings
+    warnings_list.extend(quality_result.warnings)
     if quality_result.error:
         finished_at = _iso_now()
         return _build_result(
@@ -285,6 +330,9 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
             [quality_result.error],
             _first_errors(warnings_list, limit=5),
             provider_override="ollama-components",
+            mode="component_execution",
+            last_phase="quality_gate",
+            attempts_by_phase=attempts_by_phase,
         )
 
     try:
@@ -305,6 +353,9 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
             [f"import_failed: {exc}"],
             _first_errors(warnings_list, limit=5),
             provider_override="ollama-components",
+            mode="component_execution",
+            last_phase="import",
+            attempts_by_phase=attempts_by_phase,
         )
 
     finished_at = _iso_now()
@@ -318,6 +369,9 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
         [],
         _first_errors(warnings_list, limit=5),
         provider_override="ollama-components",
+        mode="component_execution",
+        last_phase="import",
+        attempts_by_phase=attempts_by_phase,
     )
 
 
@@ -330,8 +384,11 @@ def _build_result(
     errors_list: list[str],
     warnings_list: list[str],
     provider_override: str | None = None,
+    mode: str | None = None,
+    last_phase: str | None = None,
+    attempts_by_phase: dict[str, int] | None = None,
 ) -> dict[str, Any]:
-    return {
+    result = {
         "success": status == "imported" and run_id is not None,
         "provider": provider_override or config.provider,
         "model": config.model,
@@ -342,6 +399,13 @@ def _build_result(
         "warnings": warnings_list[:5],
         "run_id": run_id,
     }
+    if mode is not None:
+        result["mode"] = mode
+    if last_phase is not None:
+        result["last_phase"] = last_phase
+    if attempts_by_phase is not None:
+        result["attempts_by_phase"] = dict(attempts_by_phase)
+    return result
 
 
 def _call_ollama_for_draft(
@@ -524,6 +588,36 @@ def _parse_keep_alive_env(name: str, *, default: int) -> int | str:
         return int(raw)
     except ValueError:
         return raw
+
+
+def _parse_component_repair_attempts_env(name: str, *, default: int) -> int:
+    value = _parse_nonnegative_int_env(name, default=default)
+    return min(value, 3)
+
+
+def _validate_component_phase_batch(phase_name: str, batch: ResearchComponentBatch) -> list[str]:
+    event_types = {event.event_type for event in batch.events}
+    if phase_name == "candidate_batch":
+        if ResearchComponentEventType.CANDIDATE_PROPOSED not in event_types:
+            return [
+                (
+                    "The model returned no product candidates. Refine the brief toward a product/problem/opportunity, "
+                    "or try a stronger model."
+                )
+            ]
+        return []
+    if phase_name == "claim_theme_batch":
+        if (
+            ResearchComponentEventType.CLAIM_PROPOSED not in event_types
+            and ResearchComponentEventType.THEME_PROPOSED not in event_types
+        ):
+            return [f"{phase_name}: batch must include claim.proposed and/or theme.proposed"]
+        return []
+    if phase_name == "validation_gate_batch":
+        if ResearchComponentEventType.VALIDATION_GATE_PROPOSED not in event_types:
+            return [f"{phase_name}: batch must include validation_gate.proposed"]
+        return []
+    return []
 
 
 def _safe_normalize_near_miss(raw_data: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:

--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -130,71 +130,73 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
     run_id: int | None = None
     started_at = now
     finished_at = now
-
-    draft_data, parse_error = _call_ollama_for_draft(config, prompt)
-    if parse_error:
-        status = "parse_failed" if parse_error.startswith("parse_failed") else "provider_error"
-        errors_list.append(parse_error)
-        finished_at = _iso_now()
-        return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
-
-    report = validate_agent_draft_data(Path("<ollama-output>"), draft_data)
-    package = report.package
-    if not report.is_valid or package is None:
-        normalized_data, normalize_fixes = _safe_normalize_near_miss(draft_data)
-        if normalize_fixes:
-            warnings_list.append(f"applied_normalization_fixes={len(normalize_fixes)}")
-            normalized_report = validate_agent_draft_data(Path("<ollama-output-normalized>"), normalized_data)
-            if normalized_report.is_valid and normalized_report.package is not None:
-                report = normalized_report
-                package = normalized_report.package
-
-    if (package is None or not report.is_valid) and config.repair_attempts > 0:
-        warnings_list.append("repair_attempted=1")
-        repaired_data, repair_error = _call_ollama_for_repair(config, draft_data, report.grouped_errors or report.errors)
-        if repair_error:
-            errors_list.append(repair_error)
-        elif repaired_data is not None:
-            repaired_report = validate_agent_draft_data(Path("<ollama-output-repair>"), repaired_data)
-            if repaired_report.is_valid and repaired_report.package is not None:
-                package = repaired_report.package
-                report = repaired_report
-                warnings_list.append("repair_succeeded=true")
-            else:
-                errors_list.extend(_first_errors(repaired_report.errors, limit=5))
-
-    if package is None or not report.is_valid:
-        status = "validation_failed"
-        if not errors_list:
-            errors_list.extend(_first_errors(report.errors, limit=5))
-        finished_at = _iso_now()
-        return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
-
-    quality_result = _evaluate_product_quality_gate(package)
-    warnings_list.extend(quality_result.warnings)
-    if quality_result.error:
-        finished_at = _iso_now()
-        errors_list.append(quality_result.error)
-        return _build_result(config, quality_result.status, started_at, finished_at, run_id, errors_list, warnings_list)
-
     try:
-        import_result = import_agent_draft_package(
-            db,
-            package,
-            package_path=None,
-            allow_duplicate_external_id=False,
-        )
-    except Exception as exc:
-        status = "import_failed"
-        errors_list.append(f"import_failed: {exc}")
+        draft_data, parse_error = _call_ollama_for_draft(config, prompt)
+        if parse_error:
+            status = "parse_failed" if parse_error.startswith("parse_failed") else "provider_error"
+            errors_list.append(parse_error)
+            finished_at = _iso_now()
+            return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+        report = validate_agent_draft_data(Path("<ollama-output>"), draft_data)
+        package = report.package
+        if not report.is_valid or package is None:
+            normalized_data, normalize_fixes = _safe_normalize_near_miss(draft_data)
+            if normalize_fixes:
+                warnings_list.append(f"applied_normalization_fixes={len(normalize_fixes)}")
+                normalized_report = validate_agent_draft_data(Path("<ollama-output-normalized>"), normalized_data)
+                if normalized_report.is_valid and normalized_report.package is not None:
+                    report = normalized_report
+                    package = normalized_report.package
+
+        if (package is None or not report.is_valid) and config.repair_attempts > 0:
+            warnings_list.append("repair_attempted=1")
+            repaired_data, repair_error = _call_ollama_for_repair(config, draft_data, report.grouped_errors or report.errors)
+            if repair_error:
+                errors_list.append(repair_error)
+            elif repaired_data is not None:
+                repaired_report = validate_agent_draft_data(Path("<ollama-output-repair>"), repaired_data)
+                if repaired_report.is_valid and repaired_report.package is not None:
+                    package = repaired_report.package
+                    report = repaired_report
+                    warnings_list.append("repair_succeeded=true")
+                else:
+                    errors_list.extend(_first_errors(repaired_report.errors, limit=5))
+
+        if package is None or not report.is_valid:
+            status = "validation_failed"
+            if not errors_list:
+                errors_list.extend(_first_errors(report.errors, limit=5))
+            finished_at = _iso_now()
+            return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+        quality_result = _evaluate_product_quality_gate(package)
+        warnings_list.extend(quality_result.warnings)
+        if quality_result.error:
+            finished_at = _iso_now()
+            errors_list.append(quality_result.error)
+            return _build_result(config, quality_result.status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+        try:
+            import_result = import_agent_draft_package(
+                db,
+                package,
+                package_path=None,
+                allow_duplicate_external_id=False,
+            )
+        except Exception as exc:
+            status = "import_failed"
+            errors_list.append(f"import_failed: {exc}")
+            finished_at = _iso_now()
+            return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+
+        run_id = import_result.run_db_id
+        warnings_list.extend(_first_errors(import_result.warnings, limit=5))
+        status = "imported"
         finished_at = _iso_now()
         return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
-
-    run_id = import_result.run_db_id
-    warnings_list.extend(_first_errors(import_result.warnings, limit=5))
-    status = "imported"
-    finished_at = _iso_now()
-    return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+    finally:
+        _unload_ollama_model(config)
 
 
 def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, Any]:
@@ -215,164 +217,167 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
         }
 
     started_at = now
-    run_title = brief.title or (brief.research_question[:120] if brief.research_question else "Component Research")
-    assembler = ComponentDraftAssembler(
-        run_title=run_title,
-        run_intent=brief.research_question,
-        agent_name="ollama-component-prototype",
-        external_draft_id=f"brief-{brief.id}-components-{started_at}",
-    )
-    attempts_by_phase: dict[str, int] = {}
-    warnings_list: list[str] = []
-    candidate_ids: list[str] = []
-    phases = ["candidate_batch", "claim_theme_batch", "validation_gate_batch"]
+    try:
+        run_title = brief.title or (brief.research_question[:120] if brief.research_question else "Component Research")
+        assembler = ComponentDraftAssembler(
+            run_title=run_title,
+            run_intent=brief.research_question,
+            agent_name="ollama-component-prototype",
+            external_draft_id=f"brief-{brief.id}-components-{started_at}",
+        )
+        attempts_by_phase: dict[str, int] = {}
+        warnings_list: list[str] = []
+        candidate_ids: list[str] = []
+        phases = ["candidate_batch", "claim_theme_batch", "validation_gate_batch"]
 
-    for phase_name in phases:
-        errors_for_phase: list[str] = []
-        prior_raw_batch: dict[str, Any] | None = None
-        max_attempts = component_repair_attempts + 1
-        attempts_by_phase[phase_name] = 0
+        for phase_name in phases:
+            errors_for_phase: list[str] = []
+            prior_raw_batch: dict[str, Any] | None = None
+            max_attempts = component_repair_attempts + 1
+            attempts_by_phase[phase_name] = 0
 
-        for attempt_index in range(max_attempts):
-            attempts_by_phase[phase_name] = attempt_index + 1
-            if attempt_index == 0:
-                prompt = generate_ollama_component_phase_prompt(brief, phase_name, candidate_ids=candidate_ids)
+            for attempt_index in range(max_attempts):
+                attempts_by_phase[phase_name] = attempt_index + 1
+                if attempt_index == 0:
+                    prompt = generate_ollama_component_phase_prompt(brief, phase_name, candidate_ids=candidate_ids)
+                else:
+                    prompt = generate_ollama_component_repair_prompt(
+                        brief,
+                        phase_name=phase_name,
+                        validation_errors=errors_for_phase,
+                        invalid_batch_data=prior_raw_batch,
+                    )
+
+                raw_batch_data, parse_error = _call_ollama_for_component_batch(config, prompt)
+                if parse_error:
+                    errors_for_phase = [f"{phase_name}: {parse_error}"]
+                    prior_raw_batch = None
+                    continue
+
+                prior_raw_batch = raw_batch_data
+                batch, batch_errors = parse_component_batch_from_data(raw_batch_data)
+                if batch is None:
+                    errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(batch_errors, limit=5)]
+                    continue
+
+                phase_errors = _validate_component_phase_batch(phase_name, batch)
+                if phase_errors:
+                    errors_for_phase = phase_errors
+                    continue
+
+                assembly_result = assembler.apply_batch(batch)
+                if not assembly_result.success:
+                    errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(assembly_result.errors, limit=5)]
+                    continue
+
+                if phase_name == "candidate_batch":
+                    candidate_ids = [
+                        event.external_id
+                        for event in batch.events
+                        if event.event_type == ResearchComponentEventType.CANDIDATE_PROPOSED
+                    ]
+                warnings_list.extend(_first_errors(assembly_result.warnings, limit=5))
+                break
             else:
-                prompt = generate_ollama_component_repair_prompt(
-                    brief,
-                    phase_name=phase_name,
-                    validation_errors=errors_for_phase,
-                    invalid_batch_data=prior_raw_batch,
+                finished_at = _iso_now()
+                failure_status = "quality_failed_no_candidates" if phase_name == "candidate_batch" else "component_validation_failed"
+                if phase_name == "candidate_batch":
+                    errors_for_phase = [
+                        (
+                            "The model returned no product candidates. Refine the brief toward a product/problem/opportunity, "
+                            "or try a stronger model."
+                        )
+                    ]
+                return _build_result(
+                    config,
+                    failure_status,
+                    started_at,
+                    finished_at,
+                    None,
+                    _first_errors(errors_for_phase or [f"{phase_name}: failed"], limit=5),
+                    _first_errors(warnings_list, limit=5),
+                    provider_override="ollama-components",
+                    mode="component_execution",
+                    last_phase=phase_name,
+                    attempts_by_phase=attempts_by_phase,
                 )
 
-            raw_batch_data, parse_error = _call_ollama_for_component_batch(config, prompt)
-            if parse_error:
-                errors_for_phase = [f"{phase_name}: {parse_error}"]
-                prior_raw_batch = None
-                continue
-
-            prior_raw_batch = raw_batch_data
-            batch, batch_errors = parse_component_batch_from_data(raw_batch_data)
-            if batch is None:
-                errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(batch_errors, limit=5)]
-                continue
-
-            phase_errors = _validate_component_phase_batch(phase_name, batch)
-            if phase_errors:
-                errors_for_phase = phase_errors
-                continue
-
-            assembly_result = assembler.apply_batch(batch)
-            if not assembly_result.success:
-                errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(assembly_result.errors, limit=5)]
-                continue
-
-            if phase_name == "candidate_batch":
-                candidate_ids = [
-                    event.external_id
-                    for event in batch.events
-                    if event.event_type == ResearchComponentEventType.CANDIDATE_PROPOSED
-                ]
-            warnings_list.extend(_first_errors(assembly_result.warnings, limit=5))
-            break
-        else:
+        assembled_package = assembler.package_dict()
+        report = validate_agent_draft_data(Path("<ollama-components-output>"), assembled_package)
+        if not report.is_valid or report.package is None:
             finished_at = _iso_now()
-            failure_status = "quality_failed_no_candidates" if phase_name == "candidate_batch" else "component_validation_failed"
-            if phase_name == "candidate_batch":
-                errors_for_phase = [
-                    (
-                        "The model returned no product candidates. Refine the brief toward a product/problem/opportunity, "
-                        "or try a stronger model."
-                    )
-                ]
             return _build_result(
                 config,
-                failure_status,
+                "validation_failed",
                 started_at,
                 finished_at,
                 None,
-                _first_errors(errors_for_phase or [f"{phase_name}: failed"], limit=5),
+                _first_errors(report.errors, limit=5),
                 _first_errors(warnings_list, limit=5),
                 provider_override="ollama-components",
                 mode="component_execution",
-                last_phase=phase_name,
+                last_phase="final_validation",
                 attempts_by_phase=attempts_by_phase,
             )
 
-    assembled_package = assembler.package_dict()
-    report = validate_agent_draft_data(Path("<ollama-components-output>"), assembled_package)
-    if not report.is_valid or report.package is None:
-        finished_at = _iso_now()
-        return _build_result(
-            config,
-            "validation_failed",
-            started_at,
-            finished_at,
-            None,
-            _first_errors(report.errors, limit=5),
-            _first_errors(warnings_list, limit=5),
-            provider_override="ollama-components",
-            mode="component_execution",
-            last_phase="final_validation",
-            attempts_by_phase=attempts_by_phase,
-        )
+        quality_result = _evaluate_product_quality_gate(report.package)
+        warnings_list.extend(quality_result.warnings)
+        if quality_result.error:
+            finished_at = _iso_now()
+            return _build_result(
+                config,
+                quality_result.status,
+                started_at,
+                finished_at,
+                None,
+                [quality_result.error],
+                _first_errors(warnings_list, limit=5),
+                provider_override="ollama-components",
+                mode="component_execution",
+                last_phase="quality_gate",
+                attempts_by_phase=attempts_by_phase,
+            )
 
-    quality_result = _evaluate_product_quality_gate(report.package)
-    warnings_list.extend(quality_result.warnings)
-    if quality_result.error:
-        finished_at = _iso_now()
-        return _build_result(
-            config,
-            quality_result.status,
-            started_at,
-            finished_at,
-            None,
-            [quality_result.error],
-            _first_errors(warnings_list, limit=5),
-            provider_override="ollama-components",
-            mode="component_execution",
-            last_phase="quality_gate",
-            attempts_by_phase=attempts_by_phase,
-        )
+        try:
+            import_result = import_agent_draft_package(
+                db,
+                report.package,
+                package_path=None,
+                allow_duplicate_external_id=False,
+            )
+        except Exception as exc:
+            finished_at = _iso_now()
+            return _build_result(
+                config,
+                "import_failed",
+                started_at,
+                finished_at,
+                None,
+                [f"import_failed: {exc}"],
+                _first_errors(warnings_list, limit=5),
+                provider_override="ollama-components",
+                mode="component_execution",
+                last_phase="import",
+                attempts_by_phase=attempts_by_phase,
+            )
 
-    try:
-        import_result = import_agent_draft_package(
-            db,
-            report.package,
-            package_path=None,
-            allow_duplicate_external_id=False,
-        )
-    except Exception as exc:
         finished_at = _iso_now()
+        warnings_list.extend(import_result.warnings)
         return _build_result(
             config,
-            "import_failed",
+            "imported",
             started_at,
             finished_at,
-            None,
-            [f"import_failed: {exc}"],
+            import_result.run_db_id,
+            [],
             _first_errors(warnings_list, limit=5),
             provider_override="ollama-components",
             mode="component_execution",
             last_phase="import",
             attempts_by_phase=attempts_by_phase,
         )
-
-    finished_at = _iso_now()
-    warnings_list.extend(import_result.warnings)
-    return _build_result(
-        config,
-        "imported",
-        started_at,
-        finished_at,
-        import_result.run_db_id,
-        [],
-        _first_errors(warnings_list, limit=5),
-        provider_override="ollama-components",
-        mode="component_execution",
-        last_phase="import",
-        attempts_by_phase=attempts_by_phase,
-    )
+    finally:
+        _unload_ollama_model(config)
 
 
 def _build_result(
@@ -412,7 +417,7 @@ def _call_ollama_for_draft(
     config: OllamaExecutionConfig,
     prompt: str,
 ) -> tuple[dict[str, Any] | None, str | None]:
-    payload = _build_generate_payload(config, prompt)
+    payload = _build_generate_payload(config, prompt, during_execution=True)
     response_data, call_error = _ollama_generate(config, payload)
     if call_error:
         return None, call_error
@@ -428,7 +433,7 @@ def _call_ollama_for_component_batch(
     config: OllamaExecutionConfig,
     prompt: str,
 ) -> tuple[dict[str, Any] | None, str | None]:
-    payload = _build_generate_payload(config, prompt)
+    payload = _build_generate_payload(config, prompt, during_execution=True)
     response_data, call_error = _ollama_generate(config, payload)
     if call_error:
         return None, call_error
@@ -457,7 +462,7 @@ def _call_ollama_for_repair(
         "Draft JSON:\n"
         f"{prior_json}"
     )
-    payload = _build_generate_payload(config, prompt)
+    payload = _build_generate_payload(config, prompt, during_execution=True)
     response_data, call_error = _ollama_generate(config, payload)
     if call_error:
         return None, call_error
@@ -508,13 +513,44 @@ def _ollama_generate(
     return parsed, None
 
 
-def _build_generate_payload(config: OllamaExecutionConfig, prompt: str) -> dict[str, Any]:
+def _build_generate_payload(
+    config: OllamaExecutionConfig,
+    prompt: str,
+    *,
+    during_execution: bool = False,
+) -> dict[str, Any]:
+    keep_alive_value = _execution_keep_alive(config) if during_execution else config.keep_alive
     return {
         "model": config.model,
         "prompt": prompt,
         "stream": False,
-        "keep_alive": config.keep_alive,
+        "keep_alive": keep_alive_value,
     }
+
+
+def _execution_keep_alive(config: OllamaExecutionConfig) -> int | str:
+    if _should_unload_after_execution(config):
+        return "5m"
+    return config.keep_alive
+
+
+def _should_unload_after_execution(config: OllamaExecutionConfig) -> bool:
+    keep_alive = config.keep_alive
+    if isinstance(keep_alive, int):
+        return keep_alive == 0
+    return str(keep_alive).strip() == "0"
+
+
+def _unload_ollama_model(config: OllamaExecutionConfig) -> None:
+    if not _should_unload_after_execution(config):
+        return
+    payload = {
+        "model": config.model,
+        "prompt": "",
+        "stream": False,
+        "keep_alive": 0,
+    }
+    _ollama_generate(config, payload)
 
 
 def _evaluate_product_quality_gate(package: AgentDraftPackage) -> ProductQualityGateResult:

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -97,3 +97,38 @@ Current component minimum:
 - Supports candidate, claim, and theme events (plus optional source/excerpt/gate/link events).
 - Rejects zero-candidate assembled output before import.
 - Uses the same keep-alive behavior (`keep_alive: 0` default) to free local model resources after execution.
+
+## Component repair and retry loop (Issue #53)
+
+Component execution now runs as small APD-orchestrated phases instead of trusting a single batch:
+
+- `candidate_batch` (required, must include at least one `candidate.proposed`)
+- `claim_theme_batch` (must include `claim.proposed` and/or `theme.proposed`)
+- `validation_gate_batch` (must include `validation_gate.proposed`)
+
+For each phase APD:
+
+- sends a phase-specific component prompt,
+- parses and validates the `ResearchComponentBatch`,
+- checks phase-specific required content,
+- retries with a repair prompt when invalid, including concise validation errors,
+- applies only valid batches to the assembler.
+
+Retry cap:
+
+- `APD_COMPONENT_REPAIR_ATTEMPTS` (default `2`, capped at `3`)
+- total attempts per phase are `1 + repair_attempts`
+
+Execution diagnostics in `ResearchBrief.metadata_json.last_execution` include:
+
+- `mode: component_execution`
+- `status`
+- `last_phase`
+- `attempts_by_phase`
+- concise `errors` and `warnings`
+
+This remains a synchronous prototype path:
+
+- no browser streaming
+- no WebSockets/SSE
+- no background jobs

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -61,6 +61,8 @@ Behavior:
 - If local output includes source URLs without provided source context, APD records a quality warning (`quality_warning_unprovided_source_urls`).
 - Brief metadata stores concise execution diagnostics under `metadata_json.last_execution`.
 - APD sends Ollama requests with `keep_alive: 0` by default so local model resources are released after execution.
+ - APD keeps the model warm during a single execution (generation/repair/component phases), then unloads at the end by default.
+ - If `APD_OLLAMA_KEEP_ALIVE` is explicitly set to a non-zero value, APD respects that and does not force an unload.
 
 Limitations:
 

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -199,7 +199,12 @@ def test_execute_ollama_success_path_imports_run(db, monkeypatch):
     brief = create_brief(db, title="Ollama brief", research_question="Q")
     brief = get_brief(db, brief.id)
 
+    captured_payloads = []
+
     def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         return (
             {
                 "response": (
@@ -217,6 +222,8 @@ def test_execute_ollama_success_path_imports_run(db, monkeypatch):
     assert result["success"] is True
     assert result["status"] == "imported"
     assert isinstance(result["run_id"], int)
+    assert captured_payloads[0].get("keep_alive") == "5m"
+    assert captured_payloads[-1].get("keep_alive") == 0
 
 
 def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):
@@ -264,6 +271,8 @@ def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):
 
     def _fake_generate(config, payload):
         captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         return responses.pop(0)
 
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
@@ -276,8 +285,9 @@ def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):
     assert result["attempts_by_phase"]["validation_gate_batch"] == 1
     assert isinstance(result["run_id"], int)
     assert captured_payloads
-    assert captured_payloads[0].get("keep_alive") == 0
-    assert len(captured_payloads) == 3
+    assert captured_payloads[0].get("keep_alive") == "5m"
+    assert captured_payloads[-1].get("keep_alive") == 0
+    assert len(captured_payloads) == 4
 
 
 def test_execute_ollama_components_zero_candidate_fails_before_import(db, monkeypatch):
@@ -291,6 +301,8 @@ def test_execute_ollama_components_zero_candidate_fails_before_import(db, monkey
     call_count = {"count": 0}
 
     def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         call_count["count"] += 1
         return (
             {
@@ -324,6 +336,8 @@ def test_execute_ollama_components_malformed_batch_does_not_import(db, monkeypat
     call_count = {"count": 0}
 
     def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         call_count["count"] += 1
         return (
             {
@@ -363,6 +377,8 @@ def test_execute_ollama_components_candidate_repair_then_imports(db, monkeypatch
 
     def _fake_generate(config, payload):
         prompts.append(payload.get("prompt", ""))
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         return responses.pop(0)
 
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
@@ -384,6 +400,8 @@ def test_execute_ollama_components_candidate_repair_exhausted_fails(db, monkeypa
     call_count = {"count": 0}
 
     def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         call_count["count"] += 1
         return (
             {
@@ -415,6 +433,8 @@ def test_execute_ollama_unparseable_output_fails_without_import(db, monkeypatch)
     brief = get_brief(db, brief.id)
 
     def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         return ({"response": "not json"}, None)
 
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
@@ -437,6 +457,8 @@ def test_execute_ollama_validation_failure_repair_succeeds(db, monkeypatch):
     calls = {"count": 0}
 
     def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         calls["count"] += 1
         if calls["count"] == 1:
             # Missing required claims.statement (no alias field) to force repair.
@@ -479,6 +501,8 @@ def test_execute_ollama_zero_candidate_fails_quality_gate(db, monkeypatch):
     brief = get_brief(db, brief.id)
 
     def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         return (
             {
                 "response": (
@@ -507,6 +531,8 @@ def test_execute_ollama_source_url_adds_quality_warning(db, monkeypatch):
     brief = get_brief(db, brief.id)
 
     def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         return (
             {
                 "response": (
@@ -525,7 +551,7 @@ def test_execute_ollama_source_url_adds_quality_warning(db, monkeypatch):
     assert "quality_warning_unprovided_source_urls" in result["warnings"]
 
 
-def test_execute_ollama_payload_defaults_keep_alive_zero_and_uses_strict_prompt(db, monkeypatch):
+def test_execute_ollama_payload_keeps_model_warm_then_unloads_and_uses_strict_prompt(db, monkeypatch):
     monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
     monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
@@ -538,6 +564,8 @@ def test_execute_ollama_payload_defaults_keep_alive_zero_and_uses_strict_prompt(
 
     def _fake_generate(config, payload):
         captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
         return (
             {
                 "response": (
@@ -553,9 +581,69 @@ def test_execute_ollama_payload_defaults_keep_alive_zero_and_uses_strict_prompt(
     assert result["success"] is True
     assert captured_payloads
     first_payload = captured_payloads[0]
-    assert first_payload.get("keep_alive") == 0
+    assert first_payload.get("keep_alive") == "5m"
     assert "product investigation system" in first_payload.get("prompt", "").lower()
     assert "do not invent sources" in first_payload.get("prompt", "").lower()
+    assert captured_payloads[-1].get("keep_alive") == 0
+    assert not str(captured_payloads[-1].get("prompt", "")).strip()
+
+
+def test_execute_ollama_explicit_keep_alive_respected_without_forced_unload(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_OLLAMA_KEEP_ALIVE", "10m")
+    monkeypatch.setenv("APD_OLLAMA_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Keep-alive explicit", research_question="Q")
+    brief = get_brief(db, brief.id)
+    captured_payloads = []
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","external_draft_id":"qc-4","agent_name":"ollama-test",'
+                    '"run":{"title":"R","intent":"Q"},"candidates":[{"id":"cand-1","title":"Candidate 1"}]}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama(db, brief)
+    assert result["success"] is True
+    assert len(captured_payloads) == 1
+    assert captured_payloads[0].get("keep_alive") == "10m"
+
+
+def test_execute_ollama_components_attempts_unload_after_run(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Components unload", research_question="Q")
+    brief = get_brief(db, brief.id)
+    captured_payloads = []
+    responses = [
+        ({"response": '{"schema_version":"1.0","batch_id":"b1","events":[{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate 1"}}]}'}, None),
+        ({"response": '{"schema_version":"1.0","batch_id":"b2","events":[{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim 1"}}]}'}, None),
+        ({"response": '{"schema_version":"1.0","batch_id":"b3","events":[{"schema_version":"1.0","event_type":"validation_gate.proposed","external_id":"gate-1","payload":{"name":"Gate 1","phase":"supported_opportunity","candidate_id":"cand-1"}}]}'}, None),
+    ]
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return responses.pop(0)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components(db, brief)
+    assert result["success"] is True
+    assert captured_payloads[-1].get("keep_alive") == 0
+    assert not str(captured_payloads[-1].get("prompt", "")).strip()
 
 
 def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -223,44 +223,75 @@ def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):
     monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
     monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "2")
 
     brief = create_brief(db, title="Components brief", research_question="Q")
     brief = get_brief(db, brief.id)
     captured_payloads = []
-
-    def _fake_generate(config, payload):
-        captured_payloads.append(payload)
-        return (
+    responses = [
+        (
             {
                 "response": (
-                    '{"schema_version":"1.0","batch_id":"b1","events":['
-                    '{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate A","summary":"S"}},'
+                    '{"schema_version":"1.0","batch_id":"b-candidate","events":['
+                    '{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate A","summary":"S"}}'
+                    ']}'
+                )
+            },
+            None,
+        ),
+        (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b-claim-theme","events":['
                     '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim A"}},'
                     '{"schema_version":"1.0","event_type":"theme.proposed","external_id":"theme-1","payload":{"name":"Theme A"}}'
                     ']}'
                 )
             },
             None,
-        )
+        ),
+        (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b-gates","events":['
+                    '{"schema_version":"1.0","event_type":"validation_gate.proposed","external_id":"gate-1","payload":{"name":"Gate A","phase":"supported_opportunity","candidate_id":"cand-1"}}'
+                    ']}'
+                )
+            },
+            None,
+        ),
+    ]
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        return responses.pop(0)
 
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
     result = execute_research_brief_ollama_components(db, brief)
     assert result["success"] is True
     assert result["status"] == "imported"
+    assert result["mode"] == "component_execution"
+    assert result["attempts_by_phase"]["candidate_batch"] == 1
+    assert result["attempts_by_phase"]["claim_theme_batch"] == 1
+    assert result["attempts_by_phase"]["validation_gate_batch"] == 1
     assert isinstance(result["run_id"], int)
     assert captured_payloads
     assert captured_payloads[0].get("keep_alive") == 0
+    assert len(captured_payloads) == 3
 
 
 def test_execute_ollama_components_zero_candidate_fails_before_import(db, monkeypatch):
     monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
     monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "2")
 
     brief = create_brief(db, title="Components no candidate", research_question="Q")
     brief = get_brief(db, brief.id)
+    call_count = {"count": 0}
 
     def _fake_generate(config, payload):
+        call_count["count"] += 1
         return (
             {
                 "response": (
@@ -276,6 +307,9 @@ def test_execute_ollama_components_zero_candidate_fails_before_import(db, monkey
     result = execute_research_brief_ollama_components(db, brief)
     assert result["success"] is False
     assert result["status"] == "quality_failed_no_candidates"
+    assert result["last_phase"] == "candidate_batch"
+    assert result["attempts_by_phase"]["candidate_batch"] == 3
+    assert call_count["count"] == 3
     assert result["run_id"] is None
 
 
@@ -283,11 +317,14 @@ def test_execute_ollama_components_malformed_batch_does_not_import(db, monkeypat
     monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
     monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "1")
 
     brief = create_brief(db, title="Components malformed", research_question="Q")
     brief = get_brief(db, brief.id)
+    call_count = {"count": 0}
 
     def _fake_generate(config, payload):
+        call_count["count"] += 1
         return (
             {
                 "response": (
@@ -302,8 +339,70 @@ def test_execute_ollama_components_malformed_batch_does_not_import(db, monkeypat
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
     result = execute_research_brief_ollama_components(db, brief)
     assert result["success"] is False
-    assert result["status"] == "component_validation_failed"
+    assert result["status"] == "quality_failed_no_candidates"
+    assert result["attempts_by_phase"]["candidate_batch"] == 2
+    assert call_count["count"] == 2
     assert result["run_id"] is None
+
+
+def test_execute_ollama_components_candidate_repair_then_imports(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "2")
+
+    brief = create_brief(db, title="Components candidate repair", research_question="Q")
+    brief = get_brief(db, brief.id)
+    prompts: list[str] = []
+    responses = [
+        ({"response": '{"schema_version":"1.0","batch_id":"bad","events":[{"schema_version":"1.0","event_type":"candidate.proposed","payload":{"title":"Missing ID"}}]}'}, None),
+        ({"response": '{"schema_version":"1.0","batch_id":"fixed","events":[{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate 1"}}]}'}, None),
+        ({"response": '{"schema_version":"1.0","batch_id":"claims","events":[{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim text"}}]}'}, None),
+        ({"response": '{"schema_version":"1.0","batch_id":"gates","events":[{"schema_version":"1.0","event_type":"validation_gate.proposed","external_id":"gate-1","payload":{"name":"Gate A","phase":"supported_opportunity","candidate_id":"cand-1"}}]}'}, None),
+    ]
+
+    def _fake_generate(config, payload):
+        prompts.append(payload.get("prompt", ""))
+        return responses.pop(0)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components(db, brief)
+    assert result["success"] is True
+    assert result["status"] == "imported"
+    assert result["attempts_by_phase"]["candidate_batch"] == 2
+    assert "phase repair request" in prompts[1].lower()
+
+
+def test_execute_ollama_components_candidate_repair_exhausted_fails(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "2")
+
+    brief = create_brief(db, title="Components candidate repair exhausted", research_question="Q")
+    brief = get_brief(db, brief.id)
+    call_count = {"count": 0}
+
+    def _fake_generate(config, payload):
+        call_count["count"] += 1
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"still-bad","events":['
+                    '{"schema_version":"1.0","event_type":"candidate.proposed","payload":{"title":"Missing ID"}}'
+                    ']}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components(db, brief)
+    assert result["success"] is False
+    assert result["status"] == "quality_failed_no_candidates"
+    assert result["last_phase"] == "candidate_batch"
+    assert result["attempts_by_phase"]["candidate_batch"] == 3
+    assert call_count["count"] == 3
 
 
 def test_execute_ollama_unparseable_output_fails_without_import(db, monkeypatch):


### PR DESCRIPTION
## Summary
- add bounded phased component execution retries for Ollama component mode (candidate_batch, claim_theme_batch, alidation_gate_batch)
- add phase-specific repair prompts that include concise validation errors and invalid batch JSON
- add component execution diagnostics (mode, last_phase, ttempts_by_phase) in metadata_json.last_execution
- keep existing single-package Ollama execution path and stub execution path working
- keep Ollama calls non-streaming and provider scope limited to local Ollama

Refs #53

## Files Changed
- pd/services/research_execution_ollama.py
- pd/services/research_brief_service.py
- pd/services/research_components.py
- 	ests/test_research_execution.py
- docs/briefs.md

## Verification
- git status --short --branch
- git diff --stat
- powershell -ExecutionPolicy Bypass -File ./scripts/test.ps1 (fails in Codex sandbox: uv not on PATH)
- python scripts/check_repo_readiness.py (fails in Codex sandbox: python not on PATH)
- tests were **not** run in this sandbox due missing runnable Python/uv interpreter access
- no live Ollama is required for tests (all test additions mock Ollama generate calls)
- manual live Ollama verification was **not** performed in this environment
- this is **not** browser streaming/background jobs
- existing stub and single-package Ollama paths remain in place and are covered by existing tests
