### PR TITLE
Run detail: candidate-first UI (Refs #35)

### DIFF
--- a/apd/web/queries.py
+++ b/apd/web/queries.py
@@ -122,6 +122,70 @@ def get_run_detail(db: Session, run_id: int) -> Optional[dict]:
         run.metadata_json and run.metadata_json.get("is_fixture")
     )
 
+    # Build lookups for inference
+    claims_by_id = {c.id: c for c in claims}
+    themes_by_id = {t.id: t for t in themes}
+
+    # Map validation gates by candidate for quick access
+    gates_by_candidate: dict[int, list[ValidationGate]] = {}
+    for g in validation_gates:
+        if g.candidate_id:
+            gates_by_candidate.setdefault(g.candidate_id, []).append(g)
+
+    # Build candidate-centered relations by inferring shared evidence (source/excerpt)
+    candidate_relations: dict[int, dict] = {}
+    # Precompute evidence references per target for faster checks
+    def _refs_for_links(links: list[dict]) -> tuple[set[int], set[int]]:
+        sids = set()
+        eids = set()
+        for L in links:
+            if L.get("source_id"):
+                sids.add(L.get("source_id"))
+            if L.get("excerpt_id"):
+                eids.add(L.get("excerpt_id"))
+        return sids, eids
+
+    candidate_links_index = evidence_index.get("candidate", {})
+    claim_links_index = evidence_index.get("claim", {})
+    theme_links_index = evidence_index.get("theme", {})
+
+    for c in candidates:
+        clinks = candidate_links_index.get(c.id, [])
+        c_sids, c_eids = _refs_for_links(clinks)
+
+        # Find claims/themes that share source or excerpt references with the candidate
+        related_claims: list[Claim] = []
+        for cid, clinks in claim_links_index.items():
+            sids, eids = _refs_for_links(clinks)
+            if (sids & c_sids) or (eids & c_eids):
+                claim_obj = claims_by_id.get(cid)
+                if claim_obj:
+                    related_claims.append(claim_obj)
+
+        related_themes: list[Theme] = []
+        for tid, tlinks in theme_links_index.items():
+            sids, eids = _refs_for_links(tlinks)
+            if (sids & c_sids) or (eids & c_eids):
+                theme_obj = themes_by_id.get(tid)
+                if theme_obj:
+                    related_themes.append(theme_obj)
+
+        candidate_relations[c.id] = {
+            "evidence": clinks,
+            "gates": gates_by_candidate.get(c.id, []),
+            "related_claims": related_claims,
+            "related_themes": related_themes,
+        }
+
+    # Unlinked material (not inferred to belong to any candidate)
+    linked_claim_ids = {cl.id for rel in candidate_relations.values() for cl in rel["related_claims"]}
+    linked_theme_ids = {t.id for rel in candidate_relations.values() for t in rel["related_themes"]}
+    linked_gate_ids = {g.id for rel in candidate_relations.values() for g in rel["gates"]}
+
+    unlinked_claims = [c for c in claims if c.id not in linked_claim_ids]
+    unlinked_themes = [t for t in themes if t.id not in linked_theme_ids]
+    unlinked_validation_gates = [g for g in validation_gates if g.id not in linked_gate_ids]
+
     return {
         "run": run,
         "sources": sources,
@@ -135,6 +199,10 @@ def get_run_detail(db: Session, run_id: int) -> Optional[dict]:
         "is_fixture": is_fixture,
         "decision_history": decision_history,
         "notes_by_target": _build_notes_by_target(review_notes),
+        "candidate_relations": candidate_relations,
+        "unlinked_claims": unlinked_claims,
+        "unlinked_themes": unlinked_themes,
+        "unlinked_validation_gates": unlinked_validation_gates,
     }
 
 

--- a/apd/web/templates/run_detail.html
+++ b/apd/web/templates/run_detail.html
@@ -80,32 +80,116 @@
 </section>
 {% endif %}
 
-{# Sources #}
-<section class="card" id="sources">
-  <h2>Sources <span class="count-badge">{{ detail.sources | length }}</span></h2>
-  {% if detail.sources %}
-  <table class="detail-table">
-    <thead>
-      <tr><th>#</th><th>Title</th><th>Type</th><th>URL / Reference</th><th>Summary</th></tr>
-    </thead>
-    <tbody>
-      {% for s in detail.sources %}
-      <tr>
-        <td class="count">{{ loop.index }}</td>
-        <td>{{ s.title or "Untitled" }}</td>
-        <td><span class="badge">{{ s.source_type }}</span></td>
-        <td>
-          {% if s.url %}<a href="{{ s.url }}" target="_blank" rel="noopener">{{ s.url | truncate(60) }}</a>
-          {% elif s.raw_path %}{{ s.raw_path }}
-          {% else %}<span class="muted">—</span>{% endif %}
-        </td>
-        <td class="summary-cell">{{ s.summary or "" }}</td>
-      </tr>
+{# Candidates (candidate-first review surface) #}
+<section class="card" id="candidates">
+  <h2>Candidates <span class="count-badge">{{ detail.candidates | length }}</span></h2>
+  {% if detail.candidates %}
+  {% for c in detail.candidates %}
+  {% set rel = detail.candidate_relations.get(c.id, {}) %}
+  {% set elinks = rel.get('evidence') or [] %}
+  {% set cand_notes = detail.notes_by_target.get("candidate", {}).get(c.id, []) %}
+  <div class="candidate-card review-item status-{{ c.review_status }}" id="candidate-{{ c.id }}">
+    <div class="candidate-header">
+      <strong>{{ c.title }}</strong>
+      <span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span>
+      {% if c.decision %}<span class="decision decision-{{ c.decision }}">{{ c.decision.replace("_", " ") }}</span>{% endif %}
+      {% if c.is_agent_generated %}<span class="badge badge-agent">agent</span>{% endif %}
+      {% if c.rank %}<span class="rank-badge">rank {{ c.rank }}</span>{% endif %}
+    </div>
+    {% if c.summary %}<p>{{ c.summary }}</p>{% endif %}
+    <dl class="candidate-details">
+      {% if c.target_user %}<div><dt>Target user</dt><dd>{{ c.target_user }}</dd></div>{% endif %}
+      {% if c.first_workflow %}<div><dt>First workflow</dt><dd>{{ c.first_workflow }}</dd></div>{% endif %}
+      {% if c.first_wedge %}<div><dt>First wedge</dt><dd>{{ c.first_wedge }}</dd></div>{% endif %}
+      {% if c.monetization_path %}<div><dt>Monetization</dt><dd>{{ c.monetization_path }}</dd></div>{% endif %}
+      {% if c.substitutes %}<div><dt>Substitutes</dt><dd>{{ c.substitutes }}</dd></div>{% endif %}
+      {% if c.risks %}<div><dt>Risks</dt><dd>{{ c.risks }}</dd></div>{% endif %}
+      {% if c.why_now %}<div><dt>Why now</dt><dd>{{ c.why_now }}</dd></div>{% endif %}
+      {% if c.why_it_might_fail %}<div><dt>Why it might fail</dt><dd>{{ c.why_it_might_fail }}</dd></div>{% endif %}
+    </dl>
+
+    {% if rel.get('gates') %}
+    <div class="candidate-gates">
+      <strong>Validation Gates</strong>
+      <ul>
+        {% for g in rel.get('gates') %}
+        <li class="gate-{{ g.status }}">{{ g.name }} — <span class="muted">{{ g.status.replace("_", " ") }}</span>
+          {% if g.missing_evidence %}<div class="muted">Missing: {{ g.missing_evidence }}</div>{% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    {% if rel.get('related_themes') %}
+    <div class="candidate-themes">
+      <strong>Related Themes</strong>
+      <ul>
+        {% for t in rel.get('related_themes') %}
+        <li>{{ t.name }} — <span class="muted">{{ t.summary or "" }}</span></li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% else %}
+    <div class="muted">No linked themes yet.</div>
+    {% endif %}
+
+    {% if rel.get('related_claims') %}
+    <div class="candidate-claims">
+      <strong>Related Claims</strong>
+      <ul>
+        {% for cl in rel.get('related_claims') %}
+        <li>{{ cl.statement }} <span class="muted">(status: {{ cl.review_status }})</span></li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% else %}
+    <div class="muted">No linked claims yet.</div>
+    {% endif %}
+
+    {% if elinks %}
+    <div class="evidence-links-row">
+      <span class="label">Evidence:</span>
+      {% for el in elinks %}
+      <span class="evidence-link" title="{{ el.relationship_type }}{% if el.strength %} ({{ el.strength }}){% endif %}">
+        {% if el.source_title %}{{ el.source_title | truncate(40) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
+        <span class="rel-type">{{ el.relationship_type }}</span>
+      </span>
       {% endfor %}
-    </tbody>
-  </table>
+    </div>
+    {% endif %}
+
+    {% if cand_notes %}
+    <ul class="inline-notes">
+      {% for n in cand_notes %}
+      <li>
+        {% if n.author %}<strong>{{ n.author }}</strong>: {% endif %}{{ n.note }}
+        <span class="muted note-date">{{ n.created_at.strftime("%Y-%m-%d") if n.created_at else "" }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+
+    <details class="review-form-details">
+      <summary>Review this candidate</summary>
+      <form method="post" action="/runs/{{ run.id }}/candidates/{{ c.id }}/review" class="review-form">
+        <div class="form-row">
+          <label>Status</label>
+          <select name="review_status" class="form-select">
+            {% for rs in review_statuses %}
+            <option value="{{ rs }}" {% if c.review_status == rs %}selected{% endif %}>{{ rs.replace("_", " ") }}</option>
+            {% endfor %}
+          </select>
+          <label>Note (optional)</label>
+          <input type="text" name="note" class="form-input" placeholder="Add a review note…" maxlength="1000">
+          <button type="submit" class="btn btn-sm">Save</button>
+        </div>
+      </form>
+    </details>
+  </div>
+  {% endfor %}
   {% else %}
-  <p class="muted">No sources.</p>
+  <p class="muted">No candidates.</p>
   {% endif %}
 </section>
 
@@ -207,73 +291,32 @@
   {% endif %}
 </section>
 
-{# Candidates #}
-<section class="card" id="candidates">
-  <h2>Candidates <span class="count-badge">{{ detail.candidates | length }}</span></h2>
-  {% if detail.candidates %}
-  {% for c in detail.candidates %}
-  {% set elinks = detail.evidence_index.get("candidate", {}).get(c.id, []) %}
-  {% set cand_notes = detail.notes_by_target.get("candidate", {}).get(c.id, []) %}
-  <div class="candidate-card review-item status-{{ c.review_status }}" id="candidate-{{ c.id }}">
-    <div class="candidate-header">
-      <strong>{{ c.title }}</strong>
-      <span class="status-badge status-{{ c.review_status }}">{{ c.review_status.replace("_", " ") }}</span>
-      {% if c.decision %}<span class="decision decision-{{ c.decision }}">{{ c.decision.replace("_", " ") }}</span>{% endif %}
-      {% if c.is_agent_generated %}<span class="badge badge-agent">agent</span>{% endif %}
-      {% if c.rank %}<span class="rank-badge">rank {{ c.rank }}</span>{% endif %}
-    </div>
-    {% if c.summary %}<p>{{ c.summary }}</p>{% endif %}
-    <dl class="candidate-details">
-      {% if c.target_user %}<div><dt>Target user</dt><dd>{{ c.target_user }}</dd></div>{% endif %}
-      {% if c.first_workflow %}<div><dt>First workflow</dt><dd>{{ c.first_workflow }}</dd></div>{% endif %}
-      {% if c.first_wedge %}<div><dt>First wedge</dt><dd>{{ c.first_wedge }}</dd></div>{% endif %}
-      {% if c.monetization_path %}<div><dt>Monetization</dt><dd>{{ c.monetization_path }}</dd></div>{% endif %}
-      {% if c.substitutes %}<div><dt>Substitutes</dt><dd>{{ c.substitutes }}</dd></div>{% endif %}
-      {% if c.risks %}<div><dt>Risks</dt><dd>{{ c.risks }}</dd></div>{% endif %}
-      {% if c.why_now %}<div><dt>Why now</dt><dd>{{ c.why_now }}</dd></div>{% endif %}
-      {% if c.why_it_might_fail %}<div><dt>Why it might fail</dt><dd>{{ c.why_it_might_fail }}</dd></div>{% endif %}
-    </dl>
-    {% if elinks %}
-    <div class="evidence-links-row">
-      <span class="label">Evidence:</span>
-      {% for el in elinks %}
-      <span class="evidence-link" title="{{ el.relationship_type }}{% if el.strength %} ({{ el.strength }}){% endif %}">
-        {% if el.source_title %}{{ el.source_title | truncate(40) }}{% elif el.source_id %}src#{{ el.source_id }}{% else %}—{% endif %}
-        <span class="rel-type">{{ el.relationship_type }}</span>
-      </span>
+{# Sources #}
+<section class="card" id="sources">
+  <h2>Sources <span class="count-badge">{{ detail.sources | length }}</span></h2>
+  {% if detail.sources %}
+  <table class="detail-table">
+    <thead>
+      <tr><th>#</th><th>Title</th><th>Type</th><th>URL / Reference</th><th>Summary</th></tr>
+    </thead>
+    <tbody>
+      {% for s in detail.sources %}
+      <tr>
+        <td class="count">{{ loop.index }}</td>
+        <td>{{ s.title or "Untitled" }}</td>
+        <td><span class="badge">{{ s.source_type }}</span></td>
+        <td>
+          {% if s.url %}<a href="{{ s.url }}" target="_blank" rel="noopener">{{ s.url | truncate(60) }}</a>
+          {% elif s.raw_path %}{{ s.raw_path }}
+          {% else %}<span class="muted">—</span>{% endif %}
+        </td>
+        <td class="summary-cell">{{ s.summary or "" }}</td>
+      </tr>
       {% endfor %}
-    </div>
-    {% endif %}
-    {% if cand_notes %}
-    <ul class="inline-notes">
-      {% for n in cand_notes %}
-      <li>
-        {% if n.author %}<strong>{{ n.author }}</strong>: {% endif %}{{ n.note }}
-        <span class="muted note-date">{{ n.created_at.strftime("%Y-%m-%d") if n.created_at else "" }}</span>
-      </li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    <details class="review-form-details">
-      <summary>Review this candidate</summary>
-      <form method="post" action="/runs/{{ run.id }}/candidates/{{ c.id }}/review" class="review-form">
-        <div class="form-row">
-          <label>Status</label>
-          <select name="review_status" class="form-select">
-            {% for rs in review_statuses %}
-            <option value="{{ rs }}" {% if c.review_status == rs %}selected{% endif %}>{{ rs.replace("_", " ") }}</option>
-            {% endfor %}
-          </select>
-          <label>Note (optional)</label>
-          <input type="text" name="note" class="form-input" placeholder="Add a review note…" maxlength="1000">
-          <button type="submit" class="btn btn-sm">Save</button>
-        </div>
-      </form>
-    </details>
-  </div>
-  {% endfor %}
+    </tbody>
+  </table>
   {% else %}
-  <p class="muted">No candidates.</p>
+  <p class="muted">No sources.</p>
   {% endif %}
 </section>
 
@@ -314,6 +357,45 @@
   </table>
   {% else %}
   <p class="muted">No validation gates.</p>
+  {% endif %}
+</section>
+
+{# Unlinked / needs organization #}
+<section class="card" id="unlinked">
+  <h2>Unlinked / Needs organization</h2>
+  {% if detail.unlinked_claims or detail.unlinked_themes or detail.unlinked_validation_gates %}
+  {% if detail.unlinked_claims %}
+  <div>
+    <strong>Unlinked Claims</strong>
+    <ul>
+      {% for uc in detail.unlinked_claims %}
+      <li>{{ uc.statement }} <span class="muted">(status: {{ uc.review_status }})</span></li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+  {% if detail.unlinked_themes %}
+  <div>
+    <strong>Unlinked Themes</strong>
+    <ul>
+      {% for ut in detail.unlinked_themes %}
+      <li>{{ ut.name }} — <span class="muted">{{ ut.summary or "" }}</span></li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+  {% if detail.unlinked_validation_gates %}
+  <div>
+    <strong>Unlinked Validation Gates</strong>
+    <ul>
+      {% for ug in detail.unlinked_validation_gates %}
+      <li>{{ ug.name }} — <span class="muted">{{ ug.missing_evidence or "" }}</span></li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+  {% else %}
+  <p class="muted">No unlinked material; all items are associated with candidates.</p>
   {% endif %}
 </section>
 

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -27,6 +27,10 @@ uv run python scripts/import_agent_draft.py --path <normalized.json>
 Notes
 
 - APD will import the package as draft/unreviewed research for human inspection and review.
+
+Note: The run review UI is candidate-first — the run detail page surfaces product
+candidates before sources and reasoning so reviewers can prioritize candidate
+inspection and then trace claims/themes/gates back to supporting evidence.
 - The current workflow is manual: APD does not run models itself yet. Automation is tracked in issue #44.
  - A website-first prototype (Issue #44) is available that demonstrates an in-process, deterministic "stub" runner. The stub does not call external models or services; it builds a synthetic agent draft package, validates it with APD's validators, and imports it locally so you can exercise the end-to-end import and run creation flow without external network calls.
 - The generated prompt includes reminders about APD's expected field names and schema. Use them to avoid common near-miss errors (e.g. `sources.source_type`, `evidence_excerpts.excerpt_text`, `claims.statement`).

--- a/tests/test_candidate_first_ui.py
+++ b/tests/test_candidate_first_ui.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+def test_candidates_render_before_sources(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    body = resp.text
+    # Find section headings and assert candidates appears earlier than sources
+    idx_cand = body.find("Candidates")
+    idx_sources = body.find("Sources")
+    assert idx_cand != -1 and idx_sources != -1
+    assert idx_cand < idx_sources
+
+
+def test_candidate_card_includes_title_and_linked_gate(client):
+    resp = client.get("/runs/1")
+    assert resp.status_code == 200
+    body = resp.text
+    # Fixture candidate title should appear
+    assert "Release Guardrails Assistant" in body
+    # The gate linked to that candidate in fixtures should appear
+    assert "Confirm willingness to pay" in body

--- a/tests/test_candidate_first_ui.py
+++ b/tests/test_candidate_first_ui.py
@@ -1,11 +1,56 @@
 from __future__ import annotations
 
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from apd.app.db import Base
+from apd.fixtures.seed import seed_fixture_data
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "test_ui.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+
+    from sqlalchemy.orm import sessionmaker
+    from fastapi.staticfiles import StaticFiles
+
+    test_engine = create_engine(db_url, future=True, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(test_engine)
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, autocommit=False, future=True)
+
+    with TestSession() as session:
+        seed_fixture_data(session)
+        session.commit()
+
+    import apd.web.routes as web_routes
+    import apd.app.db as app_db
+
+    monkeypatch.setattr(app_db, "engine", test_engine)
+    monkeypatch.setattr(app_db, "SessionLocal", TestSession)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
 
 def test_candidates_render_before_sources(client):
     resp = client.get("/runs/1")
     assert resp.status_code == 200
     body = resp.text
-    # Find section headings and assert candidates appears earlier than sources
     idx_cand = body.find("Candidates")
     idx_sources = body.find("Sources")
     assert idx_cand != -1 and idx_sources != -1
@@ -16,7 +61,5 @@ def test_candidate_card_includes_title_and_linked_gate(client):
     resp = client.get("/runs/1")
     assert resp.status_code == 200
     body = resp.text
-    # Fixture candidate title should appear
     assert "Release Guardrails Assistant" in body
-    # The gate linked to that candidate in fixtures should appear
     assert "Confirm willingness to pay" in body


### PR DESCRIPTION
## Summary

Rework the run detail page to a candidate-first review surface. Candidate cards appear near the top and surface related validation gates, inferred related themes and claims, and evidence links. Global sections (Themes, Claims, Validation Gates, Sources) remain available below, and an Unlinked / Needs organization area lists items not associated with any candidate.

Refs #35

## Files Changed

- apd/web/queries.py
- apd/web/templates/run_detail.html
- tests/test_candidate_first_ui.py
- docs/briefs.md

## Verification

- Ran python scripts/check_repo_readiness.py locally: PASS (readiness checks passed).
- Attempted to run tests locally via ./scripts/test.ps1 / pytest, but test execution failed in this environment due to missing runtime test dependencies (missing jinja2 in the local Python environment). The new tests were added and exercise the candidate-first UI; CI should run the full suite in GitHub Actions.

Notes:
- This is UI/query/view-model work only.
- No model/provider execution behavior changed.
- No database schema changes were made.

Please review the candidate-first UI and the simple inference logic used to attach related claims/themes/gates to candidates. CI will validate rendering and test coverage.
