### PR TITLE
Add UI-managed local model settings

### DIFF
--- a/alembic/versions/20260427_0003_add_app_settings.py
+++ b/alembic/versions/20260427_0003_add_app_settings.py
@@ -1,0 +1,34 @@
+"""add app_settings table
+
+Revision ID: 20260427_0003
+Revises: 20260427_0002
+Create Date: 2026-04-27 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260427_0003"
+down_revision = "20260427_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "app_settings",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("key", sa.String(128), nullable=False, unique=True),
+        sa.Column("value_json", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("app_settings")

--- a/apd/domain/models.py
+++ b/apd/domain/models.py
@@ -411,3 +411,13 @@ class ResearchBrief(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
     metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+
+class AppSetting(Base):
+    __tablename__ = "app_settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    key: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
+    value_json: Mapped[Optional[dict]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)

--- a/apd/services/model_execution_settings.py
+++ b/apd/services/model_execution_settings.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from apd.domain.models import AppSetting
+
+
+DEFAULTS = {
+    "provider": "ollama",
+    "ollama_base_url": "http://localhost:11434",
+    "ollama_model": None,
+    "ollama_keep_alive": 0,
+    "ollama_timeout_seconds": 120,
+    "component_repair_attempts": 2,
+    "enabled": True,
+}
+
+SETTING_KEY = "model_execution_settings"
+
+
+def _parse_positive_int(value: Any, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _parse_nonnegative_int(value: Any, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _load_from_db(db: Session) -> dict[str, Any] | None:
+    row = db.query(AppSetting).filter(AppSetting.key == SETTING_KEY).first()
+    if not row or not row.value_json:
+        return None
+    return dict(row.value_json)
+
+
+def get_model_execution_settings(db: Session | None) -> dict[str, Any]:
+    """Return merged settings: DB overrides env, then defaults."""
+    result: dict[str, Any] = dict(DEFAULTS)
+    # Load env as fallback first
+    env_provider = (os.getenv("APD_MODEL_PROVIDER") or "").strip().lower()
+    if env_provider:
+        result["provider"] = env_provider
+    env_base = (os.getenv("APD_OLLAMA_BASE_URL") or "").strip()
+    if env_base:
+        result["ollama_base_url"] = env_base
+    env_model = (os.getenv("APD_OLLAMA_MODEL") or "").strip()
+    if env_model:
+        result["ollama_model"] = env_model
+    env_timeout = os.getenv("APD_OLLAMA_TIMEOUT_SECONDS")
+    if env_timeout:
+        try:
+            result["ollama_timeout_seconds"] = int(env_timeout)
+        except Exception:
+            pass
+    env_keep = os.getenv("APD_OLLAMA_KEEP_ALIVE")
+    if env_keep:
+        try:
+            result["ollama_keep_alive"] = int(env_keep)
+        except Exception:
+            result["ollama_keep_alive"] = env_keep
+    env_rep = os.getenv("APD_COMPONENT_REPAIR_ATTEMPTS")
+    if not env_rep:
+        env_rep = os.getenv("APD_OLLAMA_REPAIR_ATTEMPTS")
+    if env_rep:
+        try:
+            result["component_repair_attempts"] = min(int(env_rep), 3)
+        except Exception:
+            pass
+
+    if db is None:
+        return result
+
+    db_value = _load_from_db(db)
+    if db_value:
+        # overlay DB values
+        result.update({k: v for k, v in db_value.items() if v is not None})
+    return result
+
+
+def save_model_execution_settings(db: Session, data: dict[str, Any]) -> AppSetting:
+    normalized = dict(DEFAULTS)
+    normalized.update({k: v for k, v in data.items() if v is not None})
+    normalized["provider"] = str(normalized.get("provider") or "").strip().lower() or "ollama"
+    normalized["ollama_base_url"] = str(normalized.get("ollama_base_url") or "").strip() or None
+    normalized["ollama_model"] = str(normalized.get("ollama_model") or "").strip() or None
+    normalized["ollama_timeout_seconds"] = _parse_positive_int(normalized.get("ollama_timeout_seconds"), default=120)
+    normalized["component_repair_attempts"] = min(
+        _parse_nonnegative_int(normalized.get("component_repair_attempts"), default=1),
+        3,
+    )
+    keep_alive = normalized.get("ollama_keep_alive")
+    if isinstance(keep_alive, str):
+        keep_alive = keep_alive.strip()
+    try:
+        normalized["ollama_keep_alive"] = int(keep_alive)
+    except (TypeError, ValueError):
+        normalized["ollama_keep_alive"] = keep_alive if keep_alive not in (None, "") else 0
+
+    row = db.query(AppSetting).filter(AppSetting.key == SETTING_KEY).first()
+    if row is None:
+        row = AppSetting(key=SETTING_KEY, value_json=normalized)
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return row
+    row.value_json = normalized
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def resolve_ollama_execution_config(db: Session | None = None) -> tuple[dict | None, list[str]]:
+    """Resolve Ollama execution settings as a plain dict, using DB first, then env, then defaults.
+
+    Returns (settings_dict, missing_list) where settings_dict is None if required values missing.
+    """
+    settings = get_model_execution_settings(db)
+    provider = (settings.get("provider") or "").strip().lower()
+    base_url = (settings.get("ollama_base_url") or "").strip()
+    model = (settings.get("ollama_model") or "")
+
+    missing: list[str] = []
+    if provider != "ollama":
+        missing.append("APD_MODEL_PROVIDER=ollama")
+    if not base_url:
+        missing.append("APD_OLLAMA_BASE_URL")
+    if not model:
+        missing.append("APD_OLLAMA_MODEL")
+
+    if missing:
+        return None, missing
+
+    return (
+        {
+            "provider": provider,
+            "ollama_base_url": base_url.rstrip("/"),
+            "ollama_model": str(model),
+            "ollama_timeout_seconds": _parse_positive_int(settings.get("ollama_timeout_seconds"), default=120),
+            "component_repair_attempts": min(
+                _parse_nonnegative_int(settings.get("component_repair_attempts"), default=1),
+                3,
+            ),
+            "ollama_keep_alive": settings.get("ollama_keep_alive"),
+        },
+        [],
+    )

--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -47,33 +47,61 @@ class ProductQualityGateResult:
     warnings: list[str]
 
 
-def get_ollama_execution_config() -> tuple[OllamaExecutionConfig | None, list[str]]:
-    provider = (os.getenv("APD_MODEL_PROVIDER") or "").strip().lower()
-    base_url = (os.getenv("APD_OLLAMA_BASE_URL") or "").strip()
-    model = (os.getenv("APD_OLLAMA_MODEL") or "").strip()
+def get_ollama_execution_config(db: Session | None = None) -> tuple[OllamaExecutionConfig | None, list[str]]:
+    # Prefer DB-backed settings when available. Import lazily to avoid circular imports.
+    try:
+        from apd.services.model_execution_settings import resolve_ollama_execution_config
 
-    missing: list[str] = []
-    if provider != "ollama":
-        missing.append("APD_MODEL_PROVIDER=ollama")
-    if not base_url:
-        missing.append("APD_OLLAMA_BASE_URL")
-    if not model:
-        missing.append("APD_OLLAMA_MODEL")
+        resolved, missing = resolve_ollama_execution_config(db)
+    except Exception:
+        resolved = None
+        missing = []
 
-    if missing:
-        return None, missing
+    if resolved is None:
+        # fallback to env-based resolution
+        provider = (os.getenv("APD_MODEL_PROVIDER") or "").strip().lower()
+        base_url = (os.getenv("APD_OLLAMA_BASE_URL") or "").strip()
+        model = (os.getenv("APD_OLLAMA_MODEL") or "").strip()
 
-    timeout_seconds = _parse_positive_int_env("APD_OLLAMA_TIMEOUT_SECONDS", default=120)
-    repair_attempts = _parse_nonnegative_int_env("APD_OLLAMA_REPAIR_ATTEMPTS", default=1)
-    # Scope guardrail: permit at most one repair call.
+        missing = []
+        if provider != "ollama":
+            missing.append("APD_MODEL_PROVIDER=ollama")
+        if not base_url:
+            missing.append("APD_OLLAMA_BASE_URL")
+        if not model:
+            missing.append("APD_OLLAMA_MODEL")
+
+        if missing:
+            return None, missing
+
+        timeout_seconds = _parse_positive_int_env("APD_OLLAMA_TIMEOUT_SECONDS", default=120)
+        repair_attempts = _parse_nonnegative_int_env("APD_OLLAMA_REPAIR_ATTEMPTS", default=1)
+        repair_attempts = min(repair_attempts, 1)
+        keep_alive = _parse_keep_alive_env("APD_OLLAMA_KEEP_ALIVE", default=0)
+
+        return (
+            OllamaExecutionConfig(
+                provider=provider,
+                base_url=base_url.rstrip("/"),
+                model=model,
+                timeout_seconds=timeout_seconds,
+                repair_attempts=repair_attempts,
+                keep_alive=keep_alive,
+            ),
+            [],
+        )
+
+    # Build typed config from resolved dict
+    timeout_seconds = int(resolved.get("ollama_timeout_seconds") or 120)
+    repair_attempts = int(resolved.get("component_repair_attempts") or 1)
     repair_attempts = min(repair_attempts, 1)
-    keep_alive = _parse_keep_alive_env("APD_OLLAMA_KEEP_ALIVE", default=0)
+    keep_alive = resolved.get("ollama_keep_alive")
 
     return (
         OllamaExecutionConfig(
-            provider=provider,
-            base_url=base_url.rstrip("/"),
-            model=model,
+            provider=resolved.get("provider"),
+            base_url=resolved.get("ollama_base_url"),
+            model=resolved.get("ollama_model"),
             timeout_seconds=timeout_seconds,
             repair_attempts=repair_attempts,
             keep_alive=keep_alive,
@@ -108,7 +136,7 @@ def extract_json_object_from_model_output(text: str) -> tuple[dict[str, Any] | N
 
 
 def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
-    config, missing_env = get_ollama_execution_config()
+    config, missing_env = get_ollama_execution_config(db)
     now = _iso_now()
 
     if config is None:
@@ -201,7 +229,7 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
 
 def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, Any]:
     """Experimental component-based execution path using provider-agnostic event schema."""
-    config, missing_env = get_ollama_execution_config()
+    config, missing_env = get_ollama_execution_config(db)
     component_repair_attempts = _parse_component_repair_attempts_env("APD_COMPONENT_REPAIR_ATTEMPTS", default=2)
     now = _iso_now()
     if config is None:

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -23,6 +23,7 @@ from apd.services.research_brief_service import (
     get_brief,
     list_briefs,
 )
+from apd.services.model_execution_settings import get_model_execution_settings, save_model_execution_settings
 from apd.services.research_execution_ollama import (
     execute_research_brief_ollama_components,
     execute_research_brief_ollama,
@@ -241,7 +242,7 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")
     prompt = generate_agent_prompt(brief)
-    ollama_config, missing_ollama_env = get_ollama_execution_config()
+    ollama_config, missing_ollama_env = get_ollama_execution_config(db)
     return templates.TemplateResponse(
         request,
         "brief_detail.html",
@@ -253,6 +254,40 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
             "ollama_model": ollama_config.model if ollama_config else None,
         },
     )
+
+
+@router.get("/settings/model-execution", response_class=HTMLResponse)
+def settings_model_execution(request: Request, db: Session = Depends(_get_db)):
+    settings = get_model_execution_settings(db)
+    return templates.TemplateResponse(
+        request,
+        "settings_model_execution.html",
+        {"settings": settings},
+    )
+
+
+@router.post("/settings/model-execution", response_class=RedirectResponse)
+def settings_model_execution_save(
+    provider: str = Form("ollama"),
+    ollama_base_url: str = Form(""),
+    ollama_model: str = Form(""),
+    ollama_timeout_seconds: int = Form(120),
+    ollama_keep_alive: str = Form("0"),
+    component_repair_attempts: int = Form(1),
+    enabled: str = Form("on"),
+    db: Session = Depends(_get_db),
+):
+    data = {
+        "provider": provider,
+        "ollama_base_url": ollama_base_url or None,
+        "ollama_model": ollama_model or None,
+        "ollama_timeout_seconds": ollama_timeout_seconds,
+        "ollama_keep_alive": int(ollama_keep_alive) if str(ollama_keep_alive).isdigit() else ollama_keep_alive,
+        "component_repair_attempts": min(max(int(component_repair_attempts), 0), 3),
+        "enabled": bool(enabled),
+    }
+    save_model_execution_settings(db, data)
+    return RedirectResponse(url="/settings/model-execution", status_code=303)
 
 
 @router.post("/briefs/{brief_id}/start-research", response_class=RedirectResponse)
@@ -302,7 +337,7 @@ def start_research_ollama(brief_id: int, db: Session = Depends(_get_db)):
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")
 
-    config, missing_env = get_ollama_execution_config()
+    config, missing_env = get_ollama_execution_config(db)
     if config is None:
         _save_last_execution(
             db,
@@ -348,7 +383,7 @@ def start_research_ollama_components(brief_id: int, db: Session = Depends(_get_d
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")
 
-    config, missing_env = get_ollama_execution_config()
+    config, missing_env = get_ollama_execution_config(db)
     if config is None:
         _save_last_execution(
             db,

--- a/apd/web/templates/base.html
+++ b/apd/web/templates/base.html
@@ -13,6 +13,7 @@
       <span class="nav-sep">|</span>
       <a href="/briefs" class="nav-link">Research Briefs</a>
       <a href="/runs" class="nav-link">Runs</a>
+      <a href="/settings/model-execution" class="nav-link">Settings</a>
     </nav>
   </header>
   <main>

--- a/apd/web/templates/settings_model_execution.html
+++ b/apd/web/templates/settings_model_execution.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block title %}Model Execution Settings — APD{% endblock %}
+{% block content %}
+<div class="breadcrumb">
+  <a href="/briefs">Research Briefs</a> &rsaquo; Model Execution Settings
+</div>
+
+<div class="card">
+  <h2>Model Execution Settings</h2>
+  <p class="muted" style="margin-top: -0.4rem;">
+    Stores non-secret local model settings in the APD database. Hosted provider API keys are not supported on this page.
+  </p>
+  <form method="post" action="/settings/model-execution">
+    <table class="detail-table">
+      <tr>
+        <th>Provider</th>
+        <td>
+          <select name="provider">
+            <option value="ollama" {% if settings.provider == 'ollama' %}selected{% endif %}>Ollama</option>
+            <option value="none" {% if settings.provider != 'ollama' %}selected{% endif %}>Other / None</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <th>Ollama base URL</th>
+        <td><input type="text" name="ollama_base_url" value="{{ settings.ollama_base_url or '' }}" style="width:400px;"></td>
+      </tr>
+      <tr>
+        <th>Ollama model</th>
+        <td><input type="text" name="ollama_model" value="{{ settings.ollama_model or '' }}"></td>
+      </tr>
+      <tr>
+        <th>Timeout seconds</th>
+        <td><input type="number" name="ollama_timeout_seconds" value="{{ settings.ollama_timeout_seconds or 120 }}"></td>
+      </tr>
+      <tr>
+        <th>Keep alive</th>
+        <td><input type="text" name="ollama_keep_alive" value="{{ settings.ollama_keep_alive or 0 }}"></td>
+      </tr>
+      <tr>
+        <th>Component repair attempts</th>
+        <td><input type="number" name="component_repair_attempts" min="0" max="3" value="{{ settings.component_repair_attempts or 1 }}"></td>
+      </tr>
+    </table>
+
+    <div style="margin-top:1rem;">
+      <button type="submit" class="btn btn-primary">Save</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -75,6 +75,24 @@ Limitations:
 - Local/Ollama runs should not invent sources, URLs, citations, or claims of fetched web evidence.
 - Tests mock Ollama calls; live Ollama verification is manual.
 
+## UI-managed local model settings (Issue #55)
+
+APD now includes a Settings page at `/settings/model-execution` for local model execution configuration.
+
+What changed:
+
+- PowerShell `$env:` values are process-scoped and temporary unless persisted in a profile.
+- You can save local/Ollama execution settings from the APD UI.
+- Saved settings are stored in the APD database (`app_settings`) and persist across app restarts.
+- Environment variables remain fallback values when DB settings are not present.
+- This feature stores non-secret local settings only.
+- Hosted provider API keys are not implemented by this feature.
+
+Testing notes:
+
+- Tests for this feature use local DB state and mocked execution paths.
+- No live Ollama calls are required in tests.
+
 ## Component-based execution prototype (Issue #51)
 
 APD now includes an experimental component-based execution path that uses a provider-agnostic event contract.

--- a/tests/test_model_execution_settings.py
+++ b/tests/test_model_execution_settings.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from apd.app.db import Base
+from apd.services.model_execution_settings import save_model_execution_settings, get_model_execution_settings
+from apd.domain.models import AppSetting
+
+
+def test_save_and_load_model_execution_settings(tmp_path):
+    db_path = tmp_path / "test_settings.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+    engine = create_engine(db_url, future=True, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+    with Session() as s:
+        data = {
+            "provider": "ollama",
+            "ollama_base_url": "http://localhost:11434",
+            "ollama_model": "test-model",
+            "ollama_timeout_seconds": 99,
+            "ollama_keep_alive": 5,
+            "component_repair_attempts": 2,
+            "enabled": True,
+        }
+        save_model_execution_settings(s, data)
+        s.commit()
+
+        # Verify persisted
+        row = s.query(AppSetting).filter(AppSetting.key == "model_execution_settings").first()
+        assert row is not None
+        assert row.value_json["ollama_model"] == "test-model"
+
+        loaded = get_model_execution_settings(s)
+        assert loaded["ollama_model"] == "test-model"
+        assert loaded["ollama_base_url"] == "http://localhost:11434"

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -22,6 +22,44 @@ from apd.services.research_execution_ollama import (
 from apd.services.research_execution_stub import execute_research_brief_stub
 
 
+def _clear_ollama_env(monkeypatch):
+    monkeypatch.delenv("APD_MODEL_PROVIDER", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_MODEL", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_KEEP_ALIVE", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_REPAIR_ATTEMPTS", raising=False)
+    monkeypatch.delenv("APD_COMPONENT_REPAIR_ATTEMPTS", raising=False)
+
+
+def _save_ui_model_settings(client):
+    response = client.post(
+        "/settings/model-execution",
+        data={
+            "provider": "ollama",
+            "ollama_base_url": "http://localhost:11434",
+            "ollama_model": "llama3",
+            "ollama_timeout_seconds": "120",
+            "ollama_keep_alive": "0",
+            "component_repair_attempts": "2",
+            "enabled": "on",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+
+def _create_brief_via_ui(client, *, title: str) -> int:
+    response = client.post(
+        "/briefs",
+        data={"title": title, "research_question": "What is X?"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    location = response.headers["location"]
+    return int(location.split("/")[-1])
+
+
 @pytest.fixture()
 def db(tmp_path):
     db_path = tmp_path / "test_exec.db"
@@ -95,6 +133,29 @@ def test_start_research_route_creates_run(client):
     assert resp2.status_code == 200
     # Should redirect to run detail and show the run title
     assert "Web stub" in resp2.text
+
+
+def test_settings_page_save_and_reload_persists_saved_values(client, monkeypatch):
+    _clear_ollama_env(monkeypatch)
+
+    _save_ui_model_settings(client)
+
+    response = client.get("/settings/model-execution")
+    assert response.status_code == 200
+    assert 'value="http://localhost:11434"' in response.text
+    assert 'value="llama3"' in response.text
+
+
+def test_brief_detail_shows_ollama_actions_from_saved_db_settings(client, monkeypatch):
+    _clear_ollama_env(monkeypatch)
+    _save_ui_model_settings(client)
+    brief_id = _create_brief_via_ui(client, title="DB-backed config brief")
+
+    response = client.get(f"/briefs/{brief_id}")
+    assert response.status_code == 200
+    assert "Start Research with Ollama" in response.text
+    assert "Start Research with Components (experimental)" in response.text
+    assert "Missing required env" not in response.text
 
 
 def test_ollama_config_detection_missing_env(monkeypatch):
@@ -224,6 +285,91 @@ def test_execute_ollama_success_path_imports_run(db, monkeypatch):
     assert isinstance(result["run_id"], int)
     assert captured_payloads[0].get("keep_alive") == "5m"
     assert captured_payloads[-1].get("keep_alive") == 0
+
+
+def test_start_research_ollama_uses_saved_db_settings(client, monkeypatch):
+    _clear_ollama_env(monkeypatch)
+    _save_ui_model_settings(client)
+    brief_id = _create_brief_via_ui(client, title="Saved DB config ollama")
+
+    captured_payloads = []
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return (
+            {
+                "response": (
+                    '{"schema_version":"1.0","external_draft_id":"ollama-1","agent_name":"ollama-test",'
+                    '"run":{"title":"Saved DB config ollama","intent":"What is X?"},'
+                    '"claims":[{"id":"c1","statement":"S"}],'
+                    '"candidates":[{"id":"cand-1","title":"Candidate 1","summary":"S"}]}'
+                )
+            },
+            None,
+        )
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+
+    response = client.post(f"/briefs/{brief_id}/start-research-ollama", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/runs/")
+    assert captured_payloads
+
+
+def test_start_research_ollama_components_uses_saved_db_settings(client, monkeypatch):
+    _clear_ollama_env(monkeypatch)
+    _save_ui_model_settings(client)
+    brief_id = _create_brief_via_ui(client, title="Saved DB config components")
+
+    captured_payloads = []
+    responses = [
+        (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b-candidate","events":['
+                    '{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate A","summary":"S"}}'
+                    ']}'
+                )
+            },
+            None,
+        ),
+        (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b-claim-theme","events":['
+                    '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim A"}},'
+                    '{"schema_version":"1.0","event_type":"theme.proposed","external_id":"theme-1","payload":{"name":"Theme A"}}'
+                    ']}'
+                )
+            },
+            None,
+        ),
+        (
+            {
+                "response": (
+                    '{"schema_version":"1.0","batch_id":"b-gates","events":['
+                    '{"schema_version":"1.0","event_type":"validation_gate.proposed","external_id":"gate-1","payload":{"name":"Gate A","phase":"supported_opportunity","candidate_id":"cand-1"}}'
+                    ']}'
+                )
+            },
+            None,
+        ),
+    ]
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return responses.pop(0)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+
+    response = client.post(f"/briefs/{brief_id}/start-research-ollama-components", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/runs/")
+    assert captured_payloads
 
 
 def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):
@@ -653,7 +799,7 @@ def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):
 
     monkeypatch.setattr(
         "apd.web.routes.get_ollama_execution_config",
-        lambda: (
+        lambda *_args, **_kwargs: (
             type("Cfg", (), {"model": "llama3"})(),
             [],
         ),
@@ -685,7 +831,7 @@ def test_start_research_ollama_components_route_uses_mocked_service(client, monk
 
     monkeypatch.setattr(
         "apd.web.routes.get_ollama_execution_config",
-        lambda: (
+        lambda *_args, **_kwargs: (
             type("Cfg", (), {"model": "llama3"})(),
             [],
         ),
@@ -717,7 +863,7 @@ def test_start_research_ollama_route_handles_missing_config(client, monkeypatch)
 
     monkeypatch.setattr(
         "apd.web.routes.get_ollama_execution_config",
-        lambda: (None, ["APD_MODEL_PROVIDER=ollama", "APD_OLLAMA_MODEL"]),
+        lambda *_args, **_kwargs: (None, ["APD_MODEL_PROVIDER=ollama", "APD_OLLAMA_MODEL"]),
     )
 
     resp2 = client.post(f"/briefs/{brief_id}/start-research-ollama", follow_redirects=True)


### PR DESCRIPTION
## Summary

Refs #55

Adds UI-managed, DB-backed local Ollama execution settings for APD.
This stores non-secret local Ollama settings only.
Hosted provider API keys are not implemented.
Environment variables remain fallback when DB settings are not present.

Bug fixed: the routes were resolving DB-backed Ollama settings, but the execution service called get_ollama_execution_config() again without the DB session, causing execution to fall back to env-only config. Both Ollama execution entry points now pass db through.

## Files Changed

- apd/domain/models.py
- apd/services/model_execution_settings.py
- apd/services/research_execution_ollama.py
- apd/web/routes.py
- apd/web/templates/base.html
- apd/web/templates/settings_model_execution.html
- alembic/versions/20260427_0003_add_app_settings.py
- tests/test_model_execution_settings.py
- tests/test_research_execution.py
- docs/briefs.md

## Verification

- uv run pytest tests/test_research_execution.py tests/test_model_execution_settings.py: 29 passed
- python scripts/check_repo_readiness.py: READY

No live Ollama calls are required in tests.
