### PR TITLE
Add research brief randomizer for dogfooding

### DIFF
--- a/apd/services/sample_research_briefs.py
+++ b/apd/services/sample_research_briefs.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class SampleResearchBrief(TypedDict, total=False):
+    title: str
+    research_question: str
+    constraints: str
+    desired_depth: str
+    expected_outputs: str
+    notes: str
+
+
+_SAMPLE_RESEARCH_BRIEFS: list[SampleResearchBrief] = [
+    {
+        "title": "Self-hosted maintenance tools for solo developers",
+        "research_question": "Investigate product opportunities for solo developers who self-host small apps and struggle with deployment, monitoring, backups, and maintenance.",
+        "constraints": "Focus on solo operators and very small teams. Exclude enterprise platform tooling.",
+        "desired_depth": "Thorough with candidate wedges, substitutes, and validation gates.",
+    },
+    {
+        "title": "Personal knowledge base for scattered files and notes",
+        "research_question": "Investigate product opportunities for people trying to organize scattered personal notes, emails, and documents into an AI-queryable knowledge base.",
+        "expected_outputs": "At least 3 candidate product wedges, likely user workflows, and evidence-backed risks.",
+    },
+    {
+        "title": "AI research quality tools for small product teams",
+        "research_question": "Investigate product opportunities for small product teams who use AI for research but struggle to distinguish useful insight from plausible slop.",
+        "notes": "Look for review workflows, auditability, traceability, and confidence calibration.",
+    },
+    {
+        "title": "Home appliance maintenance visibility",
+        "research_question": "Investigate product opportunities for homeowners who want better visibility into appliance maintenance, warranties, repairs, and replacement timing.",
+    },
+    {
+        "title": "Project memory for hobbyist builders",
+        "research_question": "Investigate product opportunities for hobbyists who want to track recurring project ideas, research notes, and build artifacts across many experiments.",
+    },
+    {
+        "title": "Semantic layer trust workflows for small data teams",
+        "research_question": "Investigate product opportunities for small data teams who need to validate semantic layers and natural-language analytics before trusting AI-generated answers.",
+        "constraints": "Prioritize workflow validation and explainability over pure dashboarding.",
+    },
+    {
+        "title": "After-tax fixed-income comparison tools",
+        "research_question": "Investigate product opportunities for people comparing taxable bond funds, municipal bonds, and after-tax yield tradeoffs in taxable accounts.",
+        "notes": "Stay product-oriented and focus on decision-support workflows, not investment advice.",
+    },
+    {
+        "title": "Minor-accident repair and claims coordination",
+        "research_question": "Investigate product opportunities for car owners handling repair estimates, insurance claims, and certified-shop requirements after minor accidents.",
+    },
+    {
+        "title": "Contractor CRM for tiny home-service shops",
+        "research_question": "Investigate product opportunities for very small home-service businesses that juggle quotes, scheduling, customer follow-up, and unpaid invoices across text messages and spreadsheets.",
+    },
+    {
+        "title": "Repairable-device ownership tracking",
+        "research_question": "Investigate product opportunities for consumers trying to manage electronics warranties, repair history, replacement timing, and resale value across many devices.",
+    },
+]
+
+
+def get_sample_research_briefs() -> list[SampleResearchBrief]:
+    return [dict(sample) for sample in _SAMPLE_RESEARCH_BRIEFS]

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -23,6 +23,7 @@ from apd.services.research_brief_service import (
     get_brief,
     list_briefs,
 )
+from apd.services.sample_research_briefs import get_sample_research_briefs
 from apd.services.model_execution_settings import get_model_execution_settings, save_model_execution_settings
 from apd.services.research_execution_ollama import (
     execute_research_brief_ollama_components,
@@ -208,7 +209,7 @@ def briefs_new(request: Request):
     return templates.TemplateResponse(
         request,
         "brief_new.html",
-        {},
+        {"sample_briefs": get_sample_research_briefs()},
     )
 
 

--- a/apd/web/templates/brief_new.html
+++ b/apd/web/templates/brief_new.html
@@ -35,6 +35,12 @@
       <label for="research_question" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
         Research question / direction <span class="required-mark" style="color: #ef4444;">*</span>
       </label>
+      <div style="margin-bottom: 0.5rem;">
+        <button type="button" class="btn" id="randomize-brief-btn" style="background: #e2e8f0; color: #1a1a1a;">Randomize brief</button>
+        <span class="muted" style="font-size: 0.85rem; margin-left: 0.5rem;">
+          Fills this form with a product-investigation prompt for dogfooding. You can edit before saving.
+        </span>
+      </div>
       <textarea
         id="research_question"
         name="research_question"
@@ -105,4 +111,41 @@
 
   </form>
 </div>
+
+<script id="sample-briefs-data" type="application/json">{{ sample_briefs | tojson }}</script>
+<script>
+function randomizeBriefForm() {
+  var dataEl = document.getElementById("sample-briefs-data");
+  if (!dataEl) {
+    return;
+  }
+
+  var samples = [];
+  try {
+    samples = JSON.parse(dataEl.textContent || "[]");
+  } catch (err) {
+    return;
+  }
+
+  if (!Array.isArray(samples) || samples.length === 0) {
+    return;
+  }
+
+  var sample = samples[Math.floor(Math.random() * samples.length)];
+  var fieldNames = ["title", "research_question", "constraints", "desired_depth", "expected_outputs", "notes"];
+  for (var idx = 0; idx < fieldNames.length; idx++) {
+    var fieldName = fieldNames[idx];
+    var element = document.getElementById(fieldName);
+    if (!element) {
+      continue;
+    }
+    element.value = sample[fieldName] || "";
+  }
+}
+
+var randomizeButton = document.getElementById("randomize-brief-btn");
+if (randomizeButton) {
+  randomizeButton.addEventListener("click", randomizeBriefForm);
+}
+</script>
 {% endblock %}

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -27,6 +27,7 @@ uv run python scripts/import_agent_draft.py --path <normalized.json>
 Notes
 
 - APD will import the package as draft/unreviewed research for human inspection and review.
+- The new brief form includes a local sample/randomizer for dogfooding. It does not call a model or save anything until you submit the brief form.
 
 Note: The run review UI is candidate-first — the run detail page surfaces product
 candidates before sources and reasoning so reviewers can prioritize candidate

--- a/tests/test_research_briefs.py
+++ b/tests/test_research_briefs.py
@@ -15,6 +15,7 @@ from apd.services.research_brief_service import (
     get_brief,
     list_briefs,
 )
+from apd.services.sample_research_briefs import get_sample_research_briefs
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -215,6 +216,15 @@ def test_prompt_references_apd_allowed_phases():
     assert "evidence_collected" in prompt
 
 
+def test_sample_research_briefs_include_at_least_eight_product_prompts():
+    samples = get_sample_research_briefs()
+    assert len(samples) >= 8
+    for sample in samples:
+        question = sample["research_question"]
+        assert "Investigate product opportunities" in question
+        assert sample["title"].strip()
+
+
 # ── Web UI tests ───────────────────────────────────────────────────────────────
 
 
@@ -235,6 +245,22 @@ def test_brief_new_page_loads(client):
     assert resp.status_code == 200
     assert "New Research Brief" in resp.text
     assert "research_question" in resp.text
+
+
+def test_brief_new_page_shows_randomizer_button_and_helper_text(client):
+    resp = client.get("/briefs/new")
+    assert resp.status_code == 200
+    assert "Randomize brief" in resp.text
+    assert "You can edit before saving" in resp.text
+
+
+def test_brief_new_page_includes_sample_briefs_data(client):
+    resp = client.get("/briefs/new")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "sample-briefs-data" in body
+    assert "Investigate product opportunities for solo developers who self-host small apps" in body
+    assert "Math.random()" in body
 
 
 def test_create_brief_via_post_redirects_to_detail(client):


### PR DESCRIPTION
## Summary

Refs #57

Adds a small dogfooding randomizer to the new research brief form. The page now receives a static local list of sample product-investigation briefs and exposes a Randomize brief button that fills the form client-side so the user can edit before saving.

No model, API, or external service is called for this feature.
Content is not persisted until the user submits the brief form.

## Files Changed

- apd/services/sample_research_briefs.py
- apd/web/routes.py
- apd/web/templates/brief_new.html
- tests/test_research_briefs.py
- docs/briefs.md

## Verification

Local verification ran:

- uv run pytest tests/test_research_briefs.py — 30 passed
- ./scripts/test.ps1 — passed locally
- python scripts/check_repo_readiness.py — READY

Manual browser verification was not run in this session.

Notes:

- No model/API/external service is called.
- Randomized content stays client-side and is not persisted until the brief form is submitted.
