### PR TITLE
Add optional model-generated brief ideation

### DIFF
--- a/apd/services/research_brief_ideation.py
+++ b/apd/services/research_brief_ideation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 import re
 
 from sqlalchemy.orm import Session
@@ -14,16 +15,36 @@ from apd.services.research_execution_ollama import (
 
 
 _IDEATION_THEMES = [
-    "AI-assisted product research",
-    "local-first developer tools",
-    "self-hosting and maintenance",
-    "personal knowledge management",
-    "small business operations",
-    "household maintenance and repairs",
-    "personal finance decision support",
-    "car ownership and insurance workflows",
-    "data quality and analytics trust",
-    "hobbyist project management",
+    "Restaurant inventory waste reduction",
+    "Hotel front-desk shift handoff workflows",
+    "Temporary staffing schedule coordination",
+    "Animal rescue foster placement matching",
+    "Small farm equipment maintenance tracking",
+    "Forestry compliance documentation",
+    "Independent theater ticketing and concessions operations",
+    "Youth sports league scheduling",
+    "Construction subcontractor change-order tracking",
+    "Trade school student placement coordination",
+    "Insurance claim documentation for small agencies",
+    "Credit union member onboarding workflows",
+    "Local government parcel mapping updates",
+    "Home health aide visit verification",
+    "Clinic referral leakage tracking",
+    "Local newsroom source and tip management",
+    "Internal approval workflows for field operations",
+    "Holding company portfolio reporting",
+    "Factory floor quality incident tracking",
+    "Machine shop quote-to-production handoff",
+    "Quarry equipment utilization tracking",
+    "Mailbox rental customer lifecycle management",
+    "Consulting firm proposal reuse and knowledge capture",
+    "Municipal permit review queue management",
+    "Property manager maintenance triage",
+    "Independent retailer stockout prediction",
+    "Utility outage customer communications",
+    "Hazardous waste pickup scheduling",
+    "Wholesale distributor backorder visibility",
+    "Small carrier dock appointment coordination",
 ]
 
 _OPTIONAL_FIELDS = ["constraints", "desired_depth", "expected_outputs", "notes"]
@@ -35,6 +56,10 @@ _RESEARCH_CLAIM_PATTERN = re.compile(
 
 def get_brief_ideation_themes() -> list[str]:
     return list(_IDEATION_THEMES)
+
+
+def pick_random_brief_ideation_theme() -> str:
+    return random.choice(_IDEATION_THEMES)
 
 
 def build_brief_ideation_prompt(selected_themes: list[str]) -> str:
@@ -101,15 +126,12 @@ def parse_generated_brief_idea(raw_model_output: str) -> tuple[dict[str, str] | 
 
 def generate_brief_idea_with_ollama(
     db: Session,
-    selected_themes: list[str],
+    selected_themes: list[str] | None,
 ) -> tuple[dict[str, str] | None, str | None]:
-    if not selected_themes:
-        return None, "Select at least one theme before generating a brief idea."
-
     valid_themes = set(_IDEATION_THEMES)
-    normalized_themes = [theme.strip() for theme in selected_themes if theme and theme.strip()]
+    normalized_themes = [theme.strip() for theme in (selected_themes or []) if theme and theme.strip()]
     if not normalized_themes:
-        return None, "Select at least one theme before generating a brief idea."
+        normalized_themes = [pick_random_brief_ideation_theme()]
     invalid_themes = [theme for theme in normalized_themes if theme not in valid_themes]
     if invalid_themes:
         return None, "One or more selected ideation themes are invalid."

--- a/apd/services/research_brief_ideation.py
+++ b/apd/services/research_brief_ideation.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.orm import Session
+
+from apd.services.research_execution_ollama import (
+    _build_generate_payload,
+    _ollama_generate,
+    _unload_ollama_model,
+    extract_json_object_from_model_output,
+    get_ollama_execution_config,
+)
+
+
+_IDEATION_THEMES = [
+    "AI-assisted product research",
+    "local-first developer tools",
+    "self-hosting and maintenance",
+    "personal knowledge management",
+    "small business operations",
+    "household maintenance and repairs",
+    "personal finance decision support",
+    "car ownership and insurance workflows",
+    "data quality and analytics trust",
+    "hobbyist project management",
+]
+
+_OPTIONAL_FIELDS = ["constraints", "desired_depth", "expected_outputs", "notes"]
+_RESEARCH_CLAIM_PATTERN = re.compile(
+    r"https?://|www\.|\b(citation|citations|source url|source urls|sources include|based on research|according to research)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def get_brief_ideation_themes() -> list[str]:
+    return list(_IDEATION_THEMES)
+
+
+def build_brief_ideation_prompt(selected_themes: list[str]) -> str:
+    themes_text = ", ".join(selected_themes)
+    return "\n".join(
+        [
+            "Generate a draft APD research brief form prefill.",
+            "Return only JSON.",
+            "Generate a product-investigation brief, not generic trivia.",
+            "Do not claim to have researched the space yet.",
+            "Do not invent sources, URLs, or citations.",
+            "Keep the brief suitable for APD's component execution workflow.",
+            "The output is only a draft form prefill, not a saved run.",
+            "Use these selected themes: " + themes_text + ".",
+            "",
+            "Required JSON shape:",
+            "{",
+            '  "title": "string",',
+            '  "research_question": "string",',
+            '  "constraints": "string",',
+            '  "desired_depth": "string",',
+            '  "expected_outputs": "string",',
+            '  "notes": "string"',
+            "}",
+            "",
+            "Make the idea product-oriented and plausible for APD dogfooding.",
+        ]
+    )
+
+
+def parse_generated_brief_idea(raw_model_output: str) -> tuple[dict[str, str] | None, str | None]:
+    parsed, parse_error = extract_json_object_from_model_output(raw_model_output)
+    if parse_error or parsed is None:
+        return None, parse_error or "parse_failed: invalid_brief_idea_output"
+
+    if not isinstance(parsed, dict):
+        return None, "parse_failed: brief_idea_not_object"
+
+    result: dict[str, str] = {}
+    for field_name in ["title", "research_question", *_OPTIONAL_FIELDS]:
+        value = parsed.get(field_name)
+        if value is None:
+            result[field_name] = ""
+            continue
+        if isinstance(value, str):
+            result[field_name] = value.strip()
+            continue
+        if isinstance(value, (int, float, bool)):
+            result[field_name] = str(value).strip()
+            continue
+        return None, f"validation_failed: {field_name}_must_be_string"
+
+    if not result["title"]:
+        return None, "validation_failed: missing_title"
+    if not result["research_question"]:
+        return None, "validation_failed: missing_research_question"
+
+    combined = "\n".join(value for value in result.values() if value)
+    if _RESEARCH_CLAIM_PATTERN.search(combined):
+        return None, "validation_failed: generated_idea_claims_researched_sources"
+
+    return result, None
+
+
+def generate_brief_idea_with_ollama(
+    db: Session,
+    selected_themes: list[str],
+) -> tuple[dict[str, str] | None, str | None]:
+    if not selected_themes:
+        return None, "Select at least one theme before generating a brief idea."
+
+    valid_themes = set(_IDEATION_THEMES)
+    normalized_themes = [theme.strip() for theme in selected_themes if theme and theme.strip()]
+    if not normalized_themes:
+        return None, "Select at least one theme before generating a brief idea."
+    invalid_themes = [theme for theme in normalized_themes if theme not in valid_themes]
+    if invalid_themes:
+        return None, "One or more selected ideation themes are invalid."
+
+    config, missing = get_ollama_execution_config(db)
+    if config is None:
+        return None, "Local Ollama is not configured. Save model execution settings first."
+
+    prompt = build_brief_ideation_prompt(normalized_themes)
+    payload = _build_generate_payload(config, prompt, during_execution=True)
+    try:
+        response_data, call_error = _ollama_generate(config, payload)
+        if call_error:
+            return None, call_error
+
+        output_text = str(response_data.get("response") or "")
+        if not output_text.strip():
+            return None, "provider_error: empty_ollama_response"
+
+        return parse_generated_brief_idea(output_text)
+    finally:
+        _unload_ollama_model(config)

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
@@ -23,6 +23,7 @@ from apd.services.research_brief_service import (
     get_brief,
     list_briefs,
 )
+from apd.services.research_brief_ideation import generate_brief_idea_with_ollama, get_brief_ideation_themes
 from apd.services.sample_research_briefs import get_sample_research_briefs
 from apd.services.model_execution_settings import get_model_execution_settings, save_model_execution_settings
 from apd.services.research_execution_ollama import (
@@ -205,12 +206,42 @@ def briefs_list(request: Request, db: Session = Depends(_get_db)):
 
 
 @router.get("/briefs/new", response_class=HTMLResponse)
-def briefs_new(request: Request):
+def briefs_new(request: Request, db: Session = Depends(_get_db)):
+    ollama_config, missing_ollama_env = get_ollama_execution_config(db)
     return templates.TemplateResponse(
         request,
         "brief_new.html",
-        {"sample_briefs": get_sample_research_briefs()},
+        {
+            "sample_briefs": get_sample_research_briefs(),
+            "ideation_themes": get_brief_ideation_themes(),
+            "ideation_enabled": ollama_config is not None,
+            "ideation_disabled_reason": (
+                "Configure local Ollama model settings to enable fresh idea generation."
+                if ollama_config is None
+                else None
+            ),
+            "ideation_model": ollama_config.model if ollama_config else None,
+            "missing_ollama_env": missing_ollama_env,
+        },
     )
+
+
+@router.post("/briefs/ideate")
+async def briefs_ideate(request: Request, db: Session = Depends(_get_db)):
+    payload = await request.json()
+    selected_themes = payload.get("selected_themes") if isinstance(payload, dict) else None
+    if not isinstance(selected_themes, list) or not selected_themes:
+        return JSONResponse(
+            {"success": False, "error": "Select at least one theme before generating a brief idea."},
+            status_code=422,
+        )
+
+    idea, ideation_error = generate_brief_idea_with_ollama(db, [str(value) for value in selected_themes])
+    if ideation_error:
+        status_code = 503 if "not configured" in ideation_error.lower() else 400
+        return JSONResponse({"success": False, "error": ideation_error}, status_code=status_code)
+
+    return JSONResponse({"success": True, **idea})
 
 
 @router.post("/briefs", response_class=RedirectResponse)

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -230,13 +230,16 @@ def briefs_new(request: Request, db: Session = Depends(_get_db)):
 async def briefs_ideate(request: Request, db: Session = Depends(_get_db)):
     payload = await request.json()
     selected_themes = payload.get("selected_themes") if isinstance(payload, dict) else None
-    if not isinstance(selected_themes, list) or not selected_themes:
+    if selected_themes is not None and not isinstance(selected_themes, list):
         return JSONResponse(
-            {"success": False, "error": "Select at least one theme before generating a brief idea."},
+            {"success": False, "error": "Invalid ideation request payload."},
             status_code=422,
         )
 
-    idea, ideation_error = generate_brief_idea_with_ollama(db, [str(value) for value in selected_themes])
+    idea, ideation_error = generate_brief_idea_with_ollama(
+        db,
+        [str(value) for value in selected_themes] if selected_themes is not None else None,
+    )
     if ideation_error:
         status_code = 503 if "not configured" in ideation_error.lower() else 400
         return JSONResponse({"success": False, "error": ideation_error}, status_code=status_code)

--- a/apd/web/templates/brief_new.html
+++ b/apd/web/templates/brief_new.html
@@ -59,19 +59,12 @@
         </span>
       </div>
       <div class="muted" style="font-size: 0.85rem; margin-bottom: 0.75rem;">
+        APD will randomly choose one local ideation theme and ask the model for a draft brief.
         {% if ideation_enabled %}
           Uses configured local model <strong>{{ ideation_model }}</strong>. This does not perform web research or source fetching.
         {% else %}
           {{ ideation_disabled_reason }}
         {% endif %}
-      </div>
-      <div id="ideation-theme-group" style="display: flex; flex-wrap: wrap; gap: 0.5rem 1rem; margin-bottom: 0.75rem;">
-        {% for theme in ideation_themes %}
-        <label style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.9rem;">
-          <input type="checkbox" class="ideation-theme-checkbox" value="{{ theme }}">
-          <span>{{ theme }}</span>
-        </label>
-        {% endfor %}
       </div>
       <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
         <button
@@ -80,7 +73,7 @@
           id="generate-brief-idea-btn"
           style="background: #dbeafe; color: #1e3a8a;"
           {% if not ideation_enabled %}disabled{% endif %}
-        >Generate fresh idea</button>
+        >let an LLM pick</button>
         <span id="ideation-status" class="muted" style="font-size: 0.85rem;"></span>
       </div>
       <div id="ideation-error" style="display: none; margin-top: 0.75rem; color: #991b1b; font-size: 0.9rem;"></div>
@@ -186,21 +179,10 @@ async function generateFreshBriefIdea() {
   var errorEl = document.getElementById("ideation-error");
   var statusEl = document.getElementById("ideation-status");
   var button = document.getElementById("generate-brief-idea-btn");
-  var themeCheckboxes = document.querySelectorAll(".ideation-theme-checkbox:checked");
-  var selectedThemes = [];
-  for (var idx = 0; idx < themeCheckboxes.length; idx++) {
-    selectedThemes.push(themeCheckboxes[idx].value);
-  }
 
   errorEl.style.display = "none";
   errorEl.textContent = "";
   statusEl.textContent = "";
-
-  if (selectedThemes.length === 0) {
-    errorEl.textContent = "Select at least one theme before generating a brief idea.";
-    errorEl.style.display = "block";
-    return;
-  }
 
   button.disabled = true;
   statusEl.textContent = "Generating draft idea...";
@@ -208,7 +190,7 @@ async function generateFreshBriefIdea() {
     var response = await fetch("/briefs/ideate", {
       method: "POST",
       headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({selected_themes: selectedThemes})
+      body: JSON.stringify({})
     });
     var payload = await response.json();
     if (!response.ok || !payload.success) {

--- a/apd/web/templates/brief_new.html
+++ b/apd/web/templates/brief_new.html
@@ -51,6 +51,41 @@
       ></textarea>
     </div>
 
+    <div class="form-field" style="margin-bottom: 1rem; padding: 0.85rem; border: 1px solid #dbe4ee; border-radius: 8px; background: #f8fafc; max-width: 760px;">
+      <div style="display: flex; align-items: baseline; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 0.5rem;">
+        <strong>Generate fresh idea</strong>
+        <span class="muted" style="font-size: 0.85rem;">
+          Optional local Ollama ideation. Generates a draft brief prefill only; nothing is saved until you submit.
+        </span>
+      </div>
+      <div class="muted" style="font-size: 0.85rem; margin-bottom: 0.75rem;">
+        {% if ideation_enabled %}
+          Uses configured local model <strong>{{ ideation_model }}</strong>. This does not perform web research or source fetching.
+        {% else %}
+          {{ ideation_disabled_reason }}
+        {% endif %}
+      </div>
+      <div id="ideation-theme-group" style="display: flex; flex-wrap: wrap; gap: 0.5rem 1rem; margin-bottom: 0.75rem;">
+        {% for theme in ideation_themes %}
+        <label style="display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.9rem;">
+          <input type="checkbox" class="ideation-theme-checkbox" value="{{ theme }}">
+          <span>{{ theme }}</span>
+        </label>
+        {% endfor %}
+      </div>
+      <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
+        <button
+          type="button"
+          class="btn"
+          id="generate-brief-idea-btn"
+          style="background: #dbeafe; color: #1e3a8a;"
+          {% if not ideation_enabled %}disabled{% endif %}
+        >Generate fresh idea</button>
+        <span id="ideation-status" class="muted" style="font-size: 0.85rem;"></span>
+      </div>
+      <div id="ideation-error" style="display: none; margin-top: 0.75rem; color: #991b1b; font-size: 0.9rem;"></div>
+    </div>
+
     <div class="form-field" style="margin-bottom: 1rem;">
       <label for="constraints" style="display: block; font-weight: 600; margin-bottom: 0.25rem;">
         Constraints <span class="muted">(optional)</span>
@@ -114,6 +149,18 @@
 
 <script id="sample-briefs-data" type="application/json">{{ sample_briefs | tojson }}</script>
 <script>
+function fillBriefFormFields(data) {
+  var fieldNames = ["title", "research_question", "constraints", "desired_depth", "expected_outputs", "notes"];
+  for (var idx = 0; idx < fieldNames.length; idx++) {
+    var fieldName = fieldNames[idx];
+    var element = document.getElementById(fieldName);
+    if (!element) {
+      continue;
+    }
+    element.value = data[fieldName] || "";
+  }
+}
+
 function randomizeBriefForm() {
   var dataEl = document.getElementById("sample-briefs-data");
   if (!dataEl) {
@@ -132,20 +179,64 @@ function randomizeBriefForm() {
   }
 
   var sample = samples[Math.floor(Math.random() * samples.length)];
-  var fieldNames = ["title", "research_question", "constraints", "desired_depth", "expected_outputs", "notes"];
-  for (var idx = 0; idx < fieldNames.length; idx++) {
-    var fieldName = fieldNames[idx];
-    var element = document.getElementById(fieldName);
-    if (!element) {
-      continue;
+  fillBriefFormFields(sample);
+}
+
+async function generateFreshBriefIdea() {
+  var errorEl = document.getElementById("ideation-error");
+  var statusEl = document.getElementById("ideation-status");
+  var button = document.getElementById("generate-brief-idea-btn");
+  var themeCheckboxes = document.querySelectorAll(".ideation-theme-checkbox:checked");
+  var selectedThemes = [];
+  for (var idx = 0; idx < themeCheckboxes.length; idx++) {
+    selectedThemes.push(themeCheckboxes[idx].value);
+  }
+
+  errorEl.style.display = "none";
+  errorEl.textContent = "";
+  statusEl.textContent = "";
+
+  if (selectedThemes.length === 0) {
+    errorEl.textContent = "Select at least one theme before generating a brief idea.";
+    errorEl.style.display = "block";
+    return;
+  }
+
+  button.disabled = true;
+  statusEl.textContent = "Generating draft idea...";
+  try {
+    var response = await fetch("/briefs/ideate", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({selected_themes: selectedThemes})
+    });
+    var payload = await response.json();
+    if (!response.ok || !payload.success) {
+      throw new Error(payload.error || "Failed to generate a brief idea.");
     }
-    element.value = sample[fieldName] || "";
+    fillBriefFormFields(payload);
+    statusEl.textContent = "Draft idea generated. Review and edit before saving.";
+  } catch (err) {
+    errorEl.textContent = err && err.message ? err.message : "Failed to generate a brief idea.";
+    errorEl.style.display = "block";
+    statusEl.textContent = "";
+  } finally {
+    {% if ideation_enabled %}
+    button.disabled = false;
+    {% else %}
+    button.disabled = true;
+    {% endif %}
   }
 }
 
 var randomizeButton = document.getElementById("randomize-brief-btn");
 if (randomizeButton) {
   randomizeButton.addEventListener("click", randomizeBriefForm);
+}
+
+var generateIdeaButton = document.getElementById("generate-brief-idea-btn");
+if (generateIdeaButton && !generateIdeaButton.disabled) {
+  generateIdeaButton.addEventListener("click", generateFreshBriefIdea);
 }
 </script>
 {% endblock %}

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -28,6 +28,7 @@ Notes
 
 - APD will import the package as draft/unreviewed research for human inspection and review.
 - The new brief form includes a local sample/randomizer for dogfooding. It does not call a model or save anything until you submit the brief form.
+- APD also supports optional model-generated brief ideation using configured local Ollama settings. These generated ideas are draft form prefills only, are not researched findings, do not perform web/source research, do not use hosted provider API keys, and are not saved until you submit the brief form.
 
 Note: The run review UI is candidate-first — the run detail page surfaces product
 candidates before sources and reasoning so reviewers can prioritize candidate

--- a/tests/test_research_briefs.py
+++ b/tests/test_research_briefs.py
@@ -16,6 +16,7 @@ from apd.services.model_execution_settings import save_model_execution_settings
 from apd.services.research_brief_ideation import (
     build_brief_ideation_prompt,
     get_brief_ideation_themes,
+    pick_random_brief_ideation_theme,
     parse_generated_brief_idea,
 )
 from apd.services.research_brief_service import (
@@ -236,9 +237,13 @@ def test_sample_research_briefs_include_at_least_eight_product_prompts():
 
 def test_brief_ideation_themes_include_expected_options():
     themes = get_brief_ideation_themes()
-    assert "AI-assisted product research" in themes
-    assert "self-hosting and maintenance" in themes
+    assert "Restaurant inventory waste reduction" in themes
+    assert "Property manager maintenance triage" in themes
     assert len(themes) >= 8
+
+
+def test_pick_random_brief_ideation_theme_returns_known_theme():
+    assert pick_random_brief_ideation_theme() in get_brief_ideation_themes()
 
 
 def test_brief_ideation_prompt_includes_selected_themes():
@@ -297,10 +302,9 @@ def test_brief_new_page_shows_ideation_controls(client):
     resp = client.get("/briefs/new")
     assert resp.status_code == 200
     body = resp.text
-    assert "Generate fresh idea" in body
-    assert "AI-assisted product research" in body
-    assert "self-hosting and maintenance" in body
-    assert "Select at least one theme before generating a brief idea." in body
+    assert "let an LLM pick" in body
+    assert "randomly choose one local ideation theme" in body
+    assert 'type="checkbox"' not in body
 
 
 def test_brief_new_page_disables_ideation_when_model_not_configured(client, monkeypatch):
@@ -320,7 +324,7 @@ def test_brief_ideation_route_returns_config_error_without_model_settings(client
     monkeypatch.delenv("APD_OLLAMA_BASE_URL", raising=False)
     monkeypatch.delenv("APD_OLLAMA_MODEL", raising=False)
 
-    response = client.post("/briefs/ideate", json={"selected_themes": ["AI-assisted product research"]})
+    response = client.post("/briefs/ideate", json={})
     assert response.status_code == 503
     assert response.json()["success"] is False
     assert "not configured" in response.json()["error"].lower()
@@ -364,18 +368,22 @@ def test_brief_ideation_route_returns_generated_brief_and_does_not_persist(clien
             None,
         )
 
-    with patch("apd.services.research_brief_ideation._ollama_generate", _fake_generate):
-        response = client.post(
-            "/briefs/ideate",
-            json={"selected_themes": ["AI-assisted product research", "local-first developer tools"]},
-        )
+    with patch(
+        "apd.services.research_brief_ideation.pick_random_brief_ideation_theme",
+        return_value="Restaurant inventory waste reduction",
+    ):
+        with patch("apd.services.research_brief_ideation._ollama_generate", _fake_generate):
+            response = client.post(
+                "/briefs/ideate",
+                json={},
+            )
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["success"] is True
     assert payload["title"] == "Fresh idea title"
     assert any(
-        "AI-assisted product research, local-first developer tools" in value.get("prompt", "")
+        "Use these selected themes: Restaurant inventory waste reduction." in value.get("prompt", "")
         for value in captured_payloads
     )
 
@@ -412,11 +420,15 @@ def test_brief_ideation_route_returns_useful_error_for_bad_model_output(client):
             return ({"response": ""}, None)
         return ({"response": "not json"}, None)
 
-    with patch("apd.services.research_brief_ideation._ollama_generate", _fake_generate):
-        response = client.post(
-            "/briefs/ideate",
-            json={"selected_themes": ["AI-assisted product research"]},
-        )
+    with patch(
+        "apd.services.research_brief_ideation.pick_random_brief_ideation_theme",
+        return_value="Restaurant inventory waste reduction",
+    ):
+        with patch("apd.services.research_brief_ideation._ollama_generate", _fake_generate):
+            response = client.post(
+                "/briefs/ideate",
+                json={},
+            )
 
     assert response.status_code == 400
     payload = response.json()

--- a/tests/test_research_briefs.py
+++ b/tests/test_research_briefs.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import func, select
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from apd.app.db import Base
 from apd.domain.models import ResearchBrief, ResearchBriefStatus
+from apd.services.model_execution_settings import save_model_execution_settings
+from apd.services.research_brief_ideation import (
+    build_brief_ideation_prompt,
+    get_brief_ideation_themes,
+    parse_generated_brief_idea,
+)
 from apd.services.research_brief_service import (
     create_brief,
     generate_agent_prompt,
@@ -225,6 +234,27 @@ def test_sample_research_briefs_include_at_least_eight_product_prompts():
         assert sample["title"].strip()
 
 
+def test_brief_ideation_themes_include_expected_options():
+    themes = get_brief_ideation_themes()
+    assert "AI-assisted product research" in themes
+    assert "self-hosting and maintenance" in themes
+    assert len(themes) >= 8
+
+
+def test_brief_ideation_prompt_includes_selected_themes():
+    prompt = build_brief_ideation_prompt(["AI-assisted product research", "local-first developer tools"])
+    assert "AI-assisted product research, local-first developer tools" in prompt
+    assert "Return only JSON." in prompt
+
+
+def test_parse_generated_brief_idea_rejects_researched_source_claims():
+    data, ideation_error = parse_generated_brief_idea(
+        '{"title":"T","research_question":"Q","notes":"Sources include https://example.com and citations."}'
+    )
+    assert data is None
+    assert ideation_error == "validation_failed: generated_idea_claims_researched_sources"
+
+
 # ── Web UI tests ───────────────────────────────────────────────────────────────
 
 
@@ -261,6 +291,137 @@ def test_brief_new_page_includes_sample_briefs_data(client):
     assert "sample-briefs-data" in body
     assert "Investigate product opportunities for solo developers who self-host small apps" in body
     assert "Math.random()" in body
+
+
+def test_brief_new_page_shows_ideation_controls(client):
+    resp = client.get("/briefs/new")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Generate fresh idea" in body
+    assert "AI-assisted product research" in body
+    assert "self-hosting and maintenance" in body
+    assert "Select at least one theme before generating a brief idea." in body
+
+
+def test_brief_new_page_disables_ideation_when_model_not_configured(client, monkeypatch):
+    monkeypatch.delenv("APD_MODEL_PROVIDER", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_MODEL", raising=False)
+
+    resp = client.get("/briefs/new")
+    assert resp.status_code == 200
+    assert "Configure local Ollama model settings to enable fresh idea generation." in resp.text
+    assert 'id="generate-brief-idea-btn"' in resp.text
+    assert "disabled" in resp.text
+
+
+def test_brief_ideation_route_returns_config_error_without_model_settings(client, monkeypatch):
+    monkeypatch.delenv("APD_MODEL_PROVIDER", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("APD_OLLAMA_MODEL", raising=False)
+
+    response = client.post("/briefs/ideate", json={"selected_themes": ["AI-assisted product research"]})
+    assert response.status_code == 503
+    assert response.json()["success"] is False
+    assert "not configured" in response.json()["error"].lower()
+
+
+def test_brief_ideation_route_returns_generated_brief_and_does_not_persist(client):
+    import apd.app.db as app_db
+
+    db = app_db.SessionLocal()
+    try:
+        save_model_execution_settings(
+            db,
+            {
+                "provider": "ollama",
+                "ollama_base_url": "http://localhost:11434",
+                "ollama_model": "llama3",
+                "ollama_timeout_seconds": 120,
+                "ollama_keep_alive": 0,
+                "component_repair_attempts": 2,
+                "enabled": True,
+            },
+        )
+        brief_count_before = db.scalar(select(func.count()).select_from(ResearchBrief)) or 0
+    finally:
+        db.close()
+
+    captured_payloads = []
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return (
+            {
+                "response": (
+                    '{"title":"Fresh idea title","research_question":"Investigate product opportunities for local-first developer tools that reduce deployment friction.",'
+                    '"constraints":"Focus on solo builders.","desired_depth":"Thorough with candidates and gates.",'
+                    '"expected_outputs":"At least 3 candidate wedges.","notes":"This is a draft idea, not researched output."}'
+                )
+            },
+            None,
+        )
+
+    with patch("apd.services.research_brief_ideation._ollama_generate", _fake_generate):
+        response = client.post(
+            "/briefs/ideate",
+            json={"selected_themes": ["AI-assisted product research", "local-first developer tools"]},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["title"] == "Fresh idea title"
+    assert any(
+        "AI-assisted product research, local-first developer tools" in value.get("prompt", "")
+        for value in captured_payloads
+    )
+
+    db = app_db.SessionLocal()
+    try:
+        brief_count_after = db.scalar(select(func.count()).select_from(ResearchBrief)) or 0
+    finally:
+        db.close()
+    assert brief_count_after == brief_count_before
+
+
+def test_brief_ideation_route_returns_useful_error_for_bad_model_output(client):
+    import apd.app.db as app_db
+
+    db = app_db.SessionLocal()
+    try:
+        save_model_execution_settings(
+            db,
+            {
+                "provider": "ollama",
+                "ollama_base_url": "http://localhost:11434",
+                "ollama_model": "llama3",
+                "ollama_timeout_seconds": 120,
+                "ollama_keep_alive": 0,
+                "component_repair_attempts": 2,
+                "enabled": True,
+            },
+        )
+    finally:
+        db.close()
+
+    def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return ({"response": "not json"}, None)
+
+    with patch("apd.services.research_brief_ideation._ollama_generate", _fake_generate):
+        response = client.post(
+            "/briefs/ideate",
+            json={"selected_themes": ["AI-assisted product research"]},
+        )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["success"] is False
+    assert "parse_failed" in payload["error"]
 
 
 def test_create_brief_via_post_redirects_to_detail(client):


### PR DESCRIPTION
## Summary

Refs #60

Adds an optional model-generated brief ideation workflow on /briefs/new while keeping the static sample picker from #57 as the no-model fallback. Users can select one or more hardcoded themes, ask configured local Ollama for a draft brief prefill, review the generated fields in the form, edit them, and only persist anything if they later submit the brief form.

No hosted APIs are called.
No web or source research is performed.
Generated ideas are draft form prefills only and are not persisted until submit.

## Files Changed

- apd/services/research_brief_ideation.py
- apd/web/routes.py
- apd/web/templates/brief_new.html
- tests/test_research_briefs.py
- docs/briefs.md

## Verification

Tests ran locally in this session:

- uv run pytest tests/test_research_briefs.py — 38 passed
- ./scripts/test.ps1 — passed locally
- python scripts/check_repo_readiness.py — READY

Manual browser verification was not run in this session.

Notes:

- No hosted APIs are called.
- No web/source research is performed.
- Generated brief ideas are not treated as researched findings.
- Generated ideas are not persisted until the user submits the brief form.
- Tests mock the model call; no live Ollama is required in CI.
