### PR TITLE
Add web-assisted research execution prototype

### DIFF
--- a/apd/services/web_research.py
+++ b/apd/services/web_research.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import html
+import ipaddress
+import json
+import re
+from urllib import error, parse, request
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from apd.domain.models import EvidenceExcerpt, ResearchBrief, Run, RunPhase, Source
+from apd.services.research_execution_ollama import (
+    _build_generate_payload,
+    _ollama_generate,
+    _unload_ollama_model,
+    extract_json_object_from_model_output,
+    get_ollama_execution_config,
+)
+
+SCHEMA_VERSION = "1.0"
+MAX_PROPOSED_QUERIES = 5
+MAX_FETCH_URLS = 5
+FETCH_TIMEOUT_SECONDS = 10
+MAX_RESPONSE_BYTES = 1_000_000
+MAX_EXTRACTED_TEXT_CHARS = 12_000
+MAX_EXCERPT_TEXT_CHARS = 8_000
+WEB_USER_AGENT = "APD local research prototype/1.0"
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_SCRIPT_STYLE_RE = re.compile(r"<(script|style)[^>]*>.*?</\1>", flags=re.IGNORECASE | re.DOTALL)
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", flags=re.IGNORECASE | re.DOTALL)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def get_web_research_limits() -> dict[str, int]:
+    return {
+        "max_queries": MAX_PROPOSED_QUERIES,
+        "max_urls": MAX_FETCH_URLS,
+        "timeout_seconds": FETCH_TIMEOUT_SECONDS,
+        "max_response_bytes": MAX_RESPONSE_BYTES,
+        "max_extracted_text_chars": MAX_EXTRACTED_TEXT_CHARS,
+    }
+
+
+def build_web_research_target_prompt(brief: ResearchBrief) -> str:
+    parts = [
+        "You are helping APD plan a controlled web research loop.",
+        "Return only JSON.",
+        "Do not browse or fetch anything yourself.",
+        "Do not invent citations, source text, or claims of completed research.",
+        "Propose a small list of public web research targets for APD to validate and fetch.",
+        "Include optional queries for future search integration, but APD will only fetch explicit validated URLs in this prototype.",
+        f"Cap yourself to at most {MAX_PROPOSED_QUERIES} queries and {MAX_FETCH_URLS} URLs.",
+        "Only include public http/https URLs likely relevant to the product investigation.",
+        "Do not include localhost, private hosts, file URLs, or authenticated sources.",
+        "",
+        "Return JSON with this shape:",
+        "{",
+        '  "schema_version": "1.0",',
+        '  "queries": [{"query": "string", "rationale": "string"}],',
+        '  "urls": [{"url": "https://example.com", "rationale": "string"}]',
+        "}",
+        "",
+        "Research brief:",
+        f"Title: {brief.title}",
+        f"Research question: {brief.research_question}",
+    ]
+    if brief.constraints:
+        parts.append(f"Constraints: {brief.constraints}")
+    if brief.desired_depth:
+        parts.append(f"Desired depth: {brief.desired_depth}")
+    if brief.expected_outputs:
+        parts.append(f"Expected outputs: {brief.expected_outputs}")
+    if brief.notes:
+        parts.append(f"Notes: {brief.notes}")
+    return "\n".join(parts)
+
+
+def parse_web_research_targets(raw_output: str) -> tuple[dict[str, object] | None, str | None]:
+    parsed, parse_error = extract_json_object_from_model_output(raw_output)
+    if parse_error or parsed is None:
+        return None, parse_error or "parse_failed: invalid_web_research_targets"
+    if not isinstance(parsed, dict):
+        return None, "parse_failed: web_research_targets_not_object"
+
+    queries_raw = parsed.get("queries") or []
+    urls_raw = parsed.get("urls") or []
+    if not isinstance(queries_raw, list):
+        return None, "validation_failed: queries_must_be_list"
+    if not isinstance(urls_raw, list):
+        return None, "validation_failed: urls_must_be_list"
+
+    queries: list[dict[str, str]] = []
+    for item in queries_raw:
+        if not isinstance(item, dict):
+            continue
+        query = str(item.get("query") or "").strip()
+        rationale = str(item.get("rationale") or "").strip()
+        if not query:
+            continue
+        queries.append({"query": query, "rationale": rationale})
+
+    urls: list[dict[str, str]] = []
+    for item in urls_raw:
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        rationale = str(item.get("rationale") or "").strip()
+        if not url:
+            continue
+        urls.append({"url": url, "rationale": rationale})
+
+    return ({"schema_version": str(parsed.get("schema_version") or SCHEMA_VERSION), "queries": queries, "urls": urls}, None)
+
+
+def validate_public_url(url: str) -> tuple[str | None, str | None]:
+    raw = (url or "").strip()
+    if not raw:
+        return None, "empty_url"
+    try:
+        parsed_url = parse.urlparse(raw)
+    except Exception:
+        return None, "malformed_url"
+    if parsed_url.scheme.lower() not in {"http", "https"}:
+        return None, "unsupported_scheme"
+    if not parsed_url.netloc or not parsed_url.hostname:
+        return None, "missing_host"
+    if parsed_url.username or parsed_url.password:
+        return None, "credentials_not_allowed"
+
+    hostname = parsed_url.hostname.strip().lower()
+    if hostname == "localhost" or hostname.endswith(".local"):
+        return None, "local_host_not_allowed"
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip = None
+    if ip is not None:
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return None, "private_or_loopback_ip_not_allowed"
+
+    normalized = parse.urlunparse(
+        (
+            parsed_url.scheme.lower(),
+            parsed_url.netloc,
+            parsed_url.path or "/",
+            parsed_url.params,
+            parsed_url.query,
+            parsed_url.fragment,
+        )
+    )
+    return normalized, None
+
+
+def fetch_public_url(url: str, *, timeout_seconds: int = FETCH_TIMEOUT_SECONDS, max_bytes: int = MAX_RESPONSE_BYTES) -> dict[str, object]:
+    req = request.Request(url=url, headers={"User-Agent": WEB_USER_AGENT}, method="GET")
+    try:
+        with request.urlopen(req, timeout=timeout_seconds) as response:
+            status_code = getattr(response, "status", 200)
+            content_type = response.headers.get("Content-Type", "")
+            raw = response.read(max_bytes + 1)
+    except error.HTTPError as exc:
+        return {"success": False, "error": f"http_{exc.code}", "status_code": exc.code}
+    except error.URLError as exc:
+        return {"success": False, "error": f"url_error: {exc.reason}"}
+    except TimeoutError:
+        return {"success": False, "error": "timeout"}
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+
+    if len(raw) > max_bytes:
+        return {"success": False, "error": "response_too_large", "status_code": status_code, "content_type": content_type}
+
+    return {
+        "success": True,
+        "status_code": status_code,
+        "content_type": content_type,
+        "body": raw,
+    }
+
+
+def extract_title_and_text(body: bytes, content_type: str) -> tuple[str | None, str | None, str | None]:
+    content_type_lower = (content_type or "").lower()
+    if "html" in content_type_lower or not content_type_lower:
+        decoded = body.decode("utf-8", errors="replace")
+        title_match = _TITLE_RE.search(decoded)
+        title = html.unescape(title_match.group(1).strip()) if title_match else None
+        without_scripts = _SCRIPT_STYLE_RE.sub(" ", decoded)
+        without_tags = _TAG_RE.sub(" ", without_scripts)
+        text = html.unescape(_WHITESPACE_RE.sub(" ", without_tags)).strip()
+        return title, text[:MAX_EXTRACTED_TEXT_CHARS] or None, None
+    if content_type_lower.startswith("text/"):
+        text = body.decode("utf-8", errors="replace").strip()
+        return None, text[:MAX_EXTRACTED_TEXT_CHARS] or None, None
+    return None, None, "unsupported_content_type"
+
+
+def _get_or_create_web_research_run(db: Session, brief: ResearchBrief) -> Run:
+    meta = dict(brief.metadata_json or {})
+    existing_run_id = meta.get("web_research_run_id")
+    if existing_run_id:
+        existing_run = db.get(Run, int(existing_run_id))
+        if existing_run is not None:
+            return existing_run
+
+    run = Run(
+        title=f"{brief.title} — Web research capture",
+        intent=brief.research_question,
+        summary="Controlled APD web research capture for a research brief.",
+        mode="web_research_capture",
+        phase=RunPhase.EVIDENCE_COLLECTED,
+        metadata_json={"brief_id": brief.id, "created_by": "apd_web_research"},
+    )
+    db.add(run)
+    db.flush()
+
+    meta["web_research_run_id"] = run.id
+    brief.metadata_json = meta
+    db.add(brief)
+    db.commit()
+    db.refresh(brief)
+    return run
+
+
+def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, object]:
+    config, missing = get_ollama_execution_config(db)
+    started_at = _iso_now()
+    if config is None:
+        return {
+            "success": False,
+            "status": "config_missing",
+            "started_at": started_at,
+            "finished_at": started_at,
+            "errors": [f"Missing required env: {value}" for value in missing],
+            "warnings": [],
+            "proposed_query_count": 0,
+            "proposed_url_count": 0,
+            "fetched_source_count": 0,
+            "skipped_urls": [],
+            "sources": [],
+        }
+
+    prompt = build_web_research_target_prompt(brief)
+    payload = _build_generate_payload(config, prompt, during_execution=True)
+    try:
+        response_data, call_error = _ollama_generate(config, payload)
+        if call_error:
+            finished_at = _iso_now()
+            return {
+                "success": False,
+                "status": "provider_error",
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "errors": [call_error],
+                "warnings": [],
+                "proposed_query_count": 0,
+                "proposed_url_count": 0,
+                "fetched_source_count": 0,
+                "skipped_urls": [],
+                "sources": [],
+            }
+
+        raw_output = str(response_data.get("response") or "")
+        if not raw_output.strip():
+            finished_at = _iso_now()
+            return {
+                "success": False,
+                "status": "parse_failed",
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "errors": ["provider_error: empty_ollama_response"],
+                "warnings": [],
+                "proposed_query_count": 0,
+                "proposed_url_count": 0,
+                "fetched_source_count": 0,
+                "skipped_urls": [],
+                "sources": [],
+            }
+
+        targets, parse_error = parse_web_research_targets(raw_output)
+        if parse_error or targets is None:
+            finished_at = _iso_now()
+            return {
+                "success": False,
+                "status": "parse_failed",
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "errors": [parse_error or "parse_failed: invalid_web_targets"],
+                "warnings": [],
+                "proposed_query_count": 0,
+                "proposed_url_count": 0,
+                "fetched_source_count": 0,
+                "skipped_urls": [],
+                "sources": [],
+            }
+
+        queries = list(targets.get("queries") or [])
+        url_targets = list(targets.get("urls") or [])
+        capped_queries = queries[:MAX_PROPOSED_QUERIES]
+        capped_url_targets = url_targets[:MAX_FETCH_URLS]
+        run = _get_or_create_web_research_run(db, brief)
+        skipped_urls: list[dict[str, str]] = []
+        source_summaries: list[dict[str, object]] = []
+        fetched_source_count = 0
+        seen_urls: set[str] = set()
+
+        for url_target in capped_url_targets:
+            raw_url = str(url_target.get("url") or "").strip()
+            rationale = str(url_target.get("rationale") or "").strip()
+            normalized_url, validation_error = validate_public_url(raw_url)
+            if validation_error or normalized_url is None:
+                skipped_urls.append({"url": raw_url, "reason": validation_error or "invalid_url"})
+                continue
+            if normalized_url in seen_urls:
+                skipped_urls.append({"url": normalized_url, "reason": "duplicate_in_request"})
+                continue
+            seen_urls.add(normalized_url)
+
+            existing_source = db.scalar(
+                select(Source).where(Source.run_id == run.id, Source.url == normalized_url)
+            )
+            if existing_source is not None:
+                skipped_urls.append({"url": normalized_url, "reason": "duplicate_existing_source"})
+                continue
+
+            fetch_result = fetch_public_url(normalized_url)
+            if not fetch_result.get("success"):
+                skipped_urls.append({"url": normalized_url, "reason": str(fetch_result.get("error") or "fetch_failed")})
+                continue
+
+            content_type = str(fetch_result.get("content_type") or "")
+            title, extracted_text, extraction_error = extract_title_and_text(
+                fetch_result.get("body") or b"",
+                content_type,
+            )
+
+            source = Source(
+                run_id=run.id,
+                title=title,
+                source_type="public_web",
+                url=normalized_url,
+                origin=parse.urlparse(normalized_url).hostname,
+                captured_at=datetime.now(timezone.utc),
+                summary=(extracted_text[:400] if extracted_text else None),
+                metadata_json={
+                    "brief_id": brief.id,
+                    "fetched_by": "apd_web_research",
+                    "fetched_at": _iso_now(),
+                    "rationale": rationale,
+                    "status": "fetched",
+                    "content_type": content_type,
+                    "extraction_error": extraction_error,
+                },
+            )
+            db.add(source)
+            db.flush()
+
+            excerpt_id = None
+            if extracted_text:
+                excerpt = EvidenceExcerpt(
+                    run_id=run.id,
+                    source_id=source.id,
+                    excerpt_text=extracted_text[:MAX_EXCERPT_TEXT_CHARS],
+                    location_reference="fetched_page_text",
+                    excerpt_type="web_capture",
+                    metadata_json={"brief_id": brief.id, "fetched_by": "apd_web_research"},
+                )
+                db.add(excerpt)
+                db.flush()
+                excerpt_id = excerpt.id
+
+            fetched_source_count += 1
+            source_summaries.append(
+                {
+                    "source_id": source.id,
+                    "excerpt_id": excerpt_id,
+                    "url": source.url,
+                    "title": source.title,
+                    "content_type": content_type,
+                }
+            )
+
+        run.source_count = db.scalar(select(func.count()).select_from(Source).where(Source.run_id == run.id)) or 0
+        db.add(run)
+        finished_at = _iso_now()
+
+        status = "completed" if fetched_source_count > 0 else "no_valid_urls"
+        warnings: list[str] = []
+        if len(queries) > MAX_PROPOSED_QUERIES:
+            warnings.append(f"capped_queries_at_{MAX_PROPOSED_QUERIES}")
+        if len(url_targets) > MAX_FETCH_URLS:
+            warnings.append(f"capped_urls_at_{MAX_FETCH_URLS}")
+        result = {
+            "success": fetched_source_count > 0,
+            "status": status,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "errors": [],
+            "warnings": warnings,
+            "proposed_query_count": len(capped_queries),
+            "proposed_url_count": len(capped_url_targets),
+            "fetched_source_count": fetched_source_count,
+            "skipped_urls": skipped_urls[:10],
+            "sources": source_summaries[:10],
+            "queries": capped_queries,
+            "web_research_run_id": run.id,
+        }
+        if fetched_source_count == 0:
+            result["errors"] = ["No valid public URLs were fetched. Proposed queries were stored for future work."]
+
+        meta = dict(brief.metadata_json or {})
+        meta["web_research_run_id"] = run.id
+        brief.metadata_json = meta
+        db.add(brief)
+        db.commit()
+        db.refresh(brief)
+        return result
+    finally:
+        _unload_ollama_model(config)

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -32,6 +32,7 @@ from apd.services.research_execution_ollama import (
     get_ollama_execution_config,
 )
 from apd.services.research_execution_stub import execute_research_brief_stub
+from apd.services.web_research import run_web_research_for_brief
 from apd.web.queries import get_recent_runs, get_run_detail
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -59,6 +60,76 @@ def _save_last_execution(db: Session, brief, execution_data: dict) -> None:
     db.add(brief)
     db.commit()
     db.refresh(brief)
+
+
+def _prefixed_messages(prefix: str, values: list[str] | None) -> list[str]:
+    return [f"{prefix}: {value}" for value in (values or [])[:5]]
+
+
+def _web_discovery_phase_data(result: dict) -> dict:
+    return {
+        "status": result.get("status"),
+        "started_at": result.get("started_at"),
+        "finished_at": result.get("finished_at"),
+        "proposed_query_count": result.get("proposed_query_count", 0),
+        "proposed_url_count": result.get("proposed_url_count", 0),
+        "fetched_source_count": result.get("fetched_source_count", 0),
+        "queries": list(result.get("queries") or [])[:10],
+        "sources": list(result.get("sources") or [])[:10],
+        "skipped_urls": list(result.get("skipped_urls") or [])[:10],
+        "errors": [str(value) for value in (result.get("errors") or [])][:5],
+        "warnings": [str(value) for value in (result.get("warnings") or [])][:5],
+        "capture_run_id": result.get("web_research_run_id"),
+    }
+
+
+def _component_execution_phase_data(result: dict) -> dict:
+    return {
+        "status": result.get("status"),
+        "started_at": result.get("started_at"),
+        "finished_at": result.get("finished_at"),
+        "run_id": result.get("run_id"),
+        "last_phase": result.get("last_phase"),
+        "attempts_by_phase": dict(result.get("attempts_by_phase") or {}),
+        "errors": [str(value) for value in (result.get("errors") or [])][:5],
+        "warnings": [str(value) for value in (result.get("warnings") or [])][:5],
+    }
+
+
+def _build_web_assisted_execution_result(
+    *,
+    model: str,
+    started_at: str,
+    web_discovery_result: dict,
+    component_result: dict,
+) -> dict:
+    errors = _prefixed_messages("web_discovery", web_discovery_result.get("errors"))
+    errors.extend(_prefixed_messages("component_execution", component_result.get("errors")))
+
+    warnings = _prefixed_messages("web_discovery", web_discovery_result.get("warnings"))
+    warnings.extend(_prefixed_messages("component_execution", component_result.get("warnings")))
+    warnings.append("captured_sources_not_yet_used_for_grounded_component_generation")
+
+    return {
+        "success": bool(component_result.get("success")),
+        "provider": "ollama-components",
+        "model": model,
+        "mode": "web_assisted_component_execution",
+        "status": component_result.get("status"),
+        "started_at": started_at,
+        "finished_at": _iso_now(),
+        "errors": errors[:5],
+        "warnings": warnings[:5],
+        "run_id": component_result.get("run_id"),
+        "web_discovery": _web_discovery_phase_data(web_discovery_result),
+        "component_execution": _component_execution_phase_data(component_result),
+        "source_grounding_status": "deferred_to_issue_63",
+        "source_grounding_deferred_issue": 63,
+        "source_grounding_note": (
+            "Web discovery captured sources, but the current component execution path is not yet fully source-grounded. "
+            "Grounding those phases to captured sources is follow-up work in issue #63."
+        ),
+    }
 
 
 @router.get("/", response_class=RedirectResponse, include_in_schema=False)
@@ -366,6 +437,40 @@ def start_research(brief_id: int, db: Session = Depends(_get_db)):
     return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 
 
+@router.post("/briefs/{brief_id}/research-web", response_class=RedirectResponse)
+def research_web_sources(brief_id: int, db: Session = Depends(_get_db)):
+    brief = get_brief(db, brief_id)
+    if brief is None:
+        raise HTTPException(status_code=404, detail="Research brief not found")
+
+    result = run_web_research_for_brief(db, brief)
+    config, _ = get_ollama_execution_config(db)
+    _save_last_execution(
+        db,
+        brief,
+        {
+            "success": bool(result.get("success")),
+            "provider": "ollama-web-discovery",
+            "model": config.model if config is not None else None,
+            "mode": "web_discovery_phase",
+            "status": result.get("status"),
+            "started_at": result.get("started_at") or _iso_now(),
+            "finished_at": result.get("finished_at") or _iso_now(),
+            "errors": _prefixed_messages("web_discovery", result.get("errors"))[:5],
+            "warnings": _prefixed_messages("web_discovery", result.get("warnings"))[:5],
+            "run_id": None,
+            "web_discovery": _web_discovery_phase_data(result),
+            "source_grounding_status": "deferred_to_issue_63",
+            "source_grounding_deferred_issue": 63,
+            "source_grounding_note": (
+                "This capture-only route reflects the web discovery phase of future research execution. "
+                "Source-grounded component generation remains follow-up work in issue #63."
+            ),
+        },
+    )
+    return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+
 @router.post("/briefs/{brief_id}/start-research-ollama", response_class=RedirectResponse)
 def start_research_ollama(brief_id: int, db: Session = Depends(_get_db)):
     brief = get_brief(db, brief_id)
@@ -435,6 +540,7 @@ def start_research_ollama_components(brief_id: int, db: Session = Depends(_get_d
         )
         return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 
+    started_at = _iso_now()
     _save_last_execution(
         db,
         brief,
@@ -442,14 +548,25 @@ def start_research_ollama_components(brief_id: int, db: Session = Depends(_get_d
             "provider": "ollama-components",
             "model": config.model,
             "status": "running",
-            "started_at": _iso_now(),
+            "started_at": started_at,
             "errors": [],
             "warnings": [],
             "run_id": None,
+            "mode": "web_assisted_component_execution",
+            "web_discovery": {"status": "pending"},
+            "component_execution": {"status": "pending"},
+            "source_grounding_status": "pending",
         },
     )
 
-    result = execute_research_brief_ollama_components(db, brief)
+    web_discovery_result = run_web_research_for_brief(db, brief)
+    component_result = execute_research_brief_ollama_components(db, brief)
+    result = _build_web_assisted_execution_result(
+        model=config.model,
+        started_at=started_at,
+        web_discovery_result=web_discovery_result,
+        component_result=component_result,
+    )
     _save_last_execution(db, brief, result)
 
     if result.get("success") and result.get("run_id"):

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -177,8 +177,25 @@
   {% set execution = brief.metadata_json.get('last_execution') %}
   {% set web_status = execution.get('web_discovery') %}
   {% set component_status = execution.get('component_execution') %}
+  {% set component_failed_after_web_success = web_status and web_status.get('status') == 'completed' and component_status and component_status.get('status') in ['validation_failed', 'component_validation_failed', 'failed'] %}
   <div class="card" style="margin-top:1rem;">
     <h3>Last execution</h3>
+
+    {% if component_failed_after_web_success %}
+    <div class="notice-box" style="
+      background: #fff7ed;
+      border: 1px solid #fdba74;
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+      font-size: 0.85rem;
+      color: #9a3412;
+    ">
+      <strong>Web discovery succeeded; component generation failed validation.</strong>
+      APD captured sources during the web discovery phase, but the later component generation step did not pass validation.
+      The raw execution JSON and detailed phase errors remain available below.
+    </div>
+    {% endif %}
 
     {% if execution.get('mode') == 'web_assisted_component_execution' or web_status %}
     <table class="detail-table" style="max-width: 900px; margin-bottom: 1rem;">

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -155,8 +155,12 @@
         <button type="submit" class="btn btn-sm btn-primary">Start Research with Ollama</button>
       </form>
       <form method="post" action="/briefs/{{ brief.id }}/start-research-ollama-components" style="display:inline; margin-left:0.5rem;">
-        <button type="submit" class="btn btn-sm btn-primary">Start Research with Components (experimental)</button>
+        <button type="submit" class="btn btn-sm btn-primary">Start web-assisted research (prototype)</button>
       </form>
+      <div style="margin-top:0.5rem;">
+        This prototype runs a web discovery phase first, captures validated public sources, then continues into component execution.
+        Captured sources are not yet fully used to ground component generation; that grounding step is deferred to issue #63.
+      </div>
     {% else %}
       Configure all required env vars to enable this path:
       <code>APD_MODEL_PROVIDER=ollama</code>,
@@ -170,9 +174,94 @@
   </div>
   
   {% if brief.metadata_json and brief.metadata_json.get('last_execution') %}
+  {% set execution = brief.metadata_json.get('last_execution') %}
+  {% set web_status = execution.get('web_discovery') %}
+  {% set component_status = execution.get('component_execution') %}
   <div class="card" style="margin-top:1rem;">
     <h3>Last execution</h3>
-    <pre style="background:#fff; padding:0.75rem; border-radius:6px;">{{ brief.metadata_json.get('last_execution') | tojson }}</pre>
+
+    {% if execution.get('mode') == 'web_assisted_component_execution' or web_status %}
+    <table class="detail-table" style="max-width: 900px; margin-bottom: 1rem;">
+      <tr>
+        <th style="width: 240px;">Overall status</th>
+        <td>{{ execution.get('status', '—') }}</td>
+      </tr>
+      {% if web_status %}
+      <tr>
+        <th>Web discovery phase</th>
+        <td>{{ web_status.get('status', '—') }}</td>
+      </tr>
+      <tr>
+        <th>Captured sources</th>
+        <td>{{ web_status.get('fetched_source_count', 0) }}</td>
+      </tr>
+      {% if web_status.get('sources') %}
+      <tr>
+        <th>Fetched sources</th>
+        <td>
+          {% for source in web_status.get('sources', []) %}
+            <div>
+              {% if source.get('url') %}<a href="{{ source.get('url') }}">{{ source.get('title') or source.get('url') }}</a>{% else %}{{ source.get('title') or 'Source' }}{% endif %}
+            </div>
+          {% endfor %}
+        </td>
+      </tr>
+      {% endif %}
+      {% if web_status.get('queries') %}
+      <tr>
+        <th>Model-proposed queries</th>
+        <td>
+          {% for query in web_status.get('queries', []) %}
+            <div>{{ query.get('query') }}</div>
+          {% endfor %}
+        </td>
+      </tr>
+      {% endif %}
+      {% if web_status.get('skipped_urls') %}
+      <tr>
+        <th>Rejected or skipped URLs</th>
+        <td>
+          {% for item in web_status.get('skipped_urls', []) %}
+            <div>{{ item.get('url') }}{% if item.get('reason') %} ({{ item.get('reason') }}){% endif %}</div>
+          {% endfor %}
+        </td>
+      </tr>
+      {% endif %}
+      {% endif %}
+      {% if component_status %}
+      <tr>
+        <th>Component execution phase</th>
+        <td>{{ component_status.get('status', '—') }}</td>
+      </tr>
+      {% if component_status.get('run_id') %}
+      <tr>
+        <th>Imported run</th>
+        <td><a href="/runs/{{ component_status.get('run_id') }}">Open run {{ component_status.get('run_id') }}</a></td>
+      </tr>
+      {% endif %}
+      {% endif %}
+      {% if execution.get('source_grounding_note') %}
+      <tr>
+        <th>Grounding status</th>
+        <td>{{ execution.get('source_grounding_note') }}</td>
+      </tr>
+      {% endif %}
+      {% if execution.get('errors') %}
+      <tr>
+        <th>Errors</th>
+        <td>{{ execution.get('errors') | join('; ') }}</td>
+      </tr>
+      {% endif %}
+      {% if execution.get('warnings') %}
+      <tr>
+        <th>Warnings</th>
+        <td>{{ execution.get('warnings') | join('; ') }}</td>
+      </tr>
+      {% endif %}
+    </table>
+    {% endif %}
+
+    <pre style="background:#fff; padding:0.75rem; border-radius:6px;">{{ execution | tojson }}</pre>
   </div>
   {% endif %}
 </div>

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -77,6 +77,46 @@ Limitations:
 - Local/Ollama runs should not invent sources, URLs, citations, or claims of fetched web evidence.
 - Tests mock Ollama calls; live Ollama verification is manual.
 
+## APD-orchestrated web discovery phase (Issue #62)
+
+APD now includes a controlled web discovery phase inside the website execution prototype.
+
+Intended workflow:
+
+1. Create a research brief.
+2. Start one research execution.
+3. APD runs an internal web discovery phase.
+4. The local model proposes a small JSON list of search queries and direct public URLs.
+5. APD validates and fetches only explicit public URLs that pass safety checks.
+6. APD stores captured pages as APD-owned `Source` and `EvidenceExcerpt` records where feasible.
+7. Execution continues into component generation.
+
+Current prototype behavior:
+
+- The brief detail page exposes a `Start web-assisted research (prototype)` action.
+- Execution metadata records web discovery and component execution as separate phases under `metadata_json.last_execution`.
+- Captured sources are shown as part of execution status, not as a separate user prerequisite step.
+- The current component generation path is still not fully source-grounded.
+- Source-grounded component generation is follow-up work in issue #63.
+
+Safety and budget controls:
+
+- This is not free browsing.
+- No crawling beyond explicit proposed URLs.
+- No authenticated or private sources.
+- No localhost, loopback, or private-network targets.
+- Only validated public `http` or `https` URLs are fetched.
+- Max model-proposed queries: `5`
+- Max fetched URLs per run: `5`
+- Small fixed timeout and response/text caps are enforced in code.
+
+Notes:
+
+- Proposed queries are stored in execution status for future search-provider integration, but this issue only fetches direct validated URLs.
+- Captured web sources remain draft research material for later human review.
+- Because sources are still run-scoped in the current schema, APD creates a small capture run for the brief and records the originating `brief_id` in metadata.
+- Tests mock both model output and HTTP fetches; no live network access is required.
+
 ## UI-managed local model settings (Issue #55)
 
 APD now includes a Settings page at `/settings/model-execution` for local model execution configuration.
@@ -107,7 +147,7 @@ Why this exists:
 
 What this is:
 
-- A synchronous website-first prototype path (`Start Research with Components (experimental)`).
+- A synchronous website-first prototype path (`Start web-assisted research (prototype)`).
 - Provider-agnostic schema names (`ResearchComponentEvent`, `ResearchComponentBatch`, `ComponentDraftAssembler`).
 - Ollama is the first adapter implementation.
 

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -437,6 +437,7 @@ def test_web_assisted_research_records_web_discovery_phase_in_last_execution(cli
     assert "Web discovery phase" in response.text
     assert "Captured source" in response.text
     assert "solo operator maintenance pain" in response.text
+    assert "Web discovery succeeded; component generation failed validation." in response.text
     assert "not yet fully source-grounded" in response.text
 
 

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -154,7 +154,7 @@ def test_brief_detail_shows_ollama_actions_from_saved_db_settings(client, monkey
     response = client.get(f"/briefs/{brief_id}")
     assert response.status_code == 200
     assert "Start Research with Ollama" in response.text
-    assert "Start Research with Components (experimental)" in response.text
+    assert "Start web-assisted research (prototype)" in response.text
     assert "Missing required env" not in response.text
 
 
@@ -323,6 +323,25 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
     _save_ui_model_settings(client)
     brief_id = _create_brief_via_ui(client, title="Saved DB config components")
 
+    monkeypatch.setattr(
+        "apd.web.routes.run_web_research_for_brief",
+        lambda db, brief: {
+            "success": True,
+            "status": "completed",
+            "started_at": "2026-04-28T00:00:00+00:00",
+            "finished_at": "2026-04-28T00:00:01+00:00",
+            "errors": [],
+            "warnings": [],
+            "proposed_query_count": 1,
+            "proposed_url_count": 1,
+            "fetched_source_count": 1,
+            "queries": [{"query": "support escalation pain", "rationale": "seed"}],
+            "sources": [{"url": "https://example.com/article", "title": "Example article"}],
+            "skipped_urls": [],
+            "web_research_run_id": 11,
+        },
+    )
+
     captured_payloads = []
     responses = [
         (
@@ -370,6 +389,55 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
     assert response.status_code == 303
     assert response.headers["location"].startswith("/runs/")
     assert captured_payloads
+
+
+def test_web_assisted_research_records_web_discovery_phase_in_last_execution(client, monkeypatch):
+    _clear_ollama_env(monkeypatch)
+    _save_ui_model_settings(client)
+    brief_id = _create_brief_via_ui(client, title="Web-assisted prototype")
+
+    monkeypatch.setattr(
+        "apd.web.routes.run_web_research_for_brief",
+        lambda db, brief: {
+            "success": True,
+            "status": "completed",
+            "started_at": "2026-04-28T00:00:00+00:00",
+            "finished_at": "2026-04-28T00:00:02+00:00",
+            "errors": [],
+            "warnings": [],
+            "proposed_query_count": 1,
+            "proposed_url_count": 1,
+            "fetched_source_count": 1,
+            "queries": [{"query": "solo operator maintenance pain", "rationale": "seed"}],
+            "sources": [{"url": "https://example.com/source", "title": "Captured source"}],
+            "skipped_urls": [],
+            "web_research_run_id": 12,
+        },
+    )
+    monkeypatch.setattr(
+        "apd.web.routes.execute_research_brief_ollama_components",
+        lambda db, brief: {
+            "success": False,
+            "provider": "ollama-components",
+            "status": "component_validation_failed",
+            "started_at": "2026-04-28T00:00:03+00:00",
+            "finished_at": "2026-04-28T00:00:04+00:00",
+            "errors": ["component phase failed"],
+            "warnings": [],
+            "run_id": None,
+            "mode": "component_execution",
+            "last_phase": "claim_theme_batch",
+            "attempts_by_phase": {"candidate_batch": 1, "claim_theme_batch": 2},
+        },
+    )
+
+    response = client.post(f"/briefs/{brief_id}/start-research-ollama-components", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert "Web discovery phase" in response.text
+    assert "Captured source" in response.text
+    assert "solo operator maintenance pain" in response.text
+    assert "not yet fully source-grounded" in response.text
 
 
 def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):

--- a/tests/test_web_research.py
+++ b/tests/test_web_research.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from apd.app.db import Base
+from apd.domain.models import EvidenceExcerpt, ResearchBrief, Run, Source
+from apd.services.model_execution_settings import save_model_execution_settings
+from apd.services.research_brief_service import create_brief
+from apd.services import web_research
+
+
+@pytest.fixture()
+def db(tmp_path):
+    db_path = tmp_path / "test_web_research.db"
+    engine = create_engine(
+        f"sqlite+pysqlite:///{db_path}",
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    with Session() as session:
+        yield session
+
+
+@pytest.fixture()
+def client_and_session(tmp_path, monkeypatch):
+    db_path = tmp_path / "test_web_research_client.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+    test_engine = create_engine(
+        db_url,
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(test_engine)
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, autocommit=False, future=True)
+
+    import apd.app.db as app_db
+    import apd.web.routes as web_routes
+
+    monkeypatch.setattr(app_db, "engine", test_engine)
+    monkeypatch.setattr(app_db, "SessionLocal", TestSession)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+    from fastapi.testclient import TestClient
+
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client, TestSession
+
+    app.dependency_overrides.clear()
+
+
+def _save_ui_model_settings(db):
+    save_model_execution_settings(
+        db,
+        {
+            "provider": "ollama",
+            "ollama_base_url": "http://localhost:11434",
+            "ollama_model": "llama3",
+            "ollama_timeout_seconds": 120,
+            "ollama_keep_alive": 0,
+            "component_repair_attempts": 2,
+            "enabled": True,
+        },
+    )
+
+
+def test_run_web_research_stores_source_and_excerpt(db, monkeypatch):
+    _save_ui_model_settings(db)
+    brief = create_brief(db, title="Maintenance pain", research_question="What public evidence exists?")
+
+    monkeypatch.setattr(
+        web_research,
+        "_ollama_generate",
+        lambda config, payload: (
+            {
+                "response": json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "queries": [{"query": "self host maintenance pain", "rationale": "Find public complaints"}],
+                        "urls": [{"url": "https://example.com/thread", "rationale": "Relevant public thread"}],
+                    }
+                )
+            },
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        web_research,
+        "fetch_public_url",
+        lambda url, **kwargs: {
+            "success": True,
+            "status_code": 200,
+            "content_type": "text/html; charset=utf-8",
+            "body": b"<html><title>Public thread</title><body>Solo operators keep losing a day each month to backup checks.</body></html>",
+        },
+    )
+
+    result = web_research.run_web_research_for_brief(db, brief)
+
+    assert result["status"] == "completed"
+    assert result["fetched_source_count"] == 1
+
+    saved_run = db.scalar(select(Run).where(Run.id == result["web_research_run_id"]))
+    saved_source = db.scalar(select(Source).where(Source.run_id == saved_run.id))
+    saved_excerpt = db.scalar(select(EvidenceExcerpt).where(EvidenceExcerpt.source_id == saved_source.id))
+    saved_brief = db.get(ResearchBrief, brief.id)
+
+    assert saved_run is not None
+    assert saved_source is not None
+    assert saved_source.source_type == "public_web"
+    assert saved_source.url == "https://example.com/thread"
+    assert saved_excerpt is not None
+    assert "backup checks" in saved_excerpt.excerpt_text
+    assert saved_brief.metadata_json["web_research_run_id"] == result["web_research_run_id"]
+
+
+@pytest.mark.parametrize(
+    ("url", "reason"),
+    [
+        ("file:///tmp/nope", "unsupported_scheme"),
+        ("http://localhost:8080/test", "local_host_not_allowed"),
+        ("http://127.0.0.1/test", "private_or_loopback_ip_not_allowed"),
+    ],
+)
+def test_validate_public_url_rejects_private_or_non_http_targets(url, reason):
+    normalized, error = web_research.validate_public_url(url)
+    assert normalized is None
+    assert error == reason
+
+
+
+def test_run_web_research_caps_url_fetches(db, monkeypatch):
+    _save_ui_model_settings(db)
+    brief = create_brief(db, title="Cap URLs", research_question="How many URLs are fetched?")
+    fetch_calls: list[str] = []
+
+    urls = [{"url": f"https://example.com/{index}", "rationale": "candidate"} for index in range(7)]
+    monkeypatch.setattr(
+        web_research,
+        "_ollama_generate",
+        lambda config, payload: ({"response": json.dumps({"schema_version": "1.0", "queries": [], "urls": urls})}, None),
+    )
+    monkeypatch.setattr(
+        web_research,
+        "fetch_public_url",
+        lambda url, **kwargs: fetch_calls.append(url) or {
+            "success": True,
+            "status_code": 200,
+            "content_type": "text/plain",
+            "body": b"public text",
+        },
+    )
+
+    result = web_research.run_web_research_for_brief(db, brief)
+
+    assert result["status"] == "completed"
+    assert len(fetch_calls) == web_research.MAX_FETCH_URLS
+    assert f"capped_urls_at_{web_research.MAX_FETCH_URLS}" in result["warnings"]
+
+
+
+def test_run_web_research_rejects_invalid_urls_without_fetching(db, monkeypatch):
+    _save_ui_model_settings(db)
+    brief = create_brief(db, title="Reject bad URLs", research_question="Reject invalid URLs")
+
+    monkeypatch.setattr(
+        web_research,
+        "_ollama_generate",
+        lambda config, payload: (
+            {
+                "response": json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "queries": [{"query": "backup toil forums", "rationale": "future search"}],
+                        "urls": [
+                            {"url": "file:///tmp/private", "rationale": "bad"},
+                            {"url": "http://localhost:9999/admin", "rationale": "bad"},
+                        ],
+                    }
+                )
+            },
+            None,
+        ),
+    )
+
+    def _should_not_fetch(url, **kwargs):
+        raise AssertionError(f"fetch_public_url should not be called for {url}")
+
+    monkeypatch.setattr(web_research, "fetch_public_url", _should_not_fetch)
+
+    result = web_research.run_web_research_for_brief(db, brief)
+
+    assert result["status"] == "no_valid_urls"
+    assert result["fetched_source_count"] == 0
+    reasons = {item["reason"] for item in result["skipped_urls"]}
+    assert "unsupported_scheme" in reasons
+    assert "local_host_not_allowed" in reasons
+
+
+
+def test_run_web_research_records_fetch_failures_without_crashing(db, monkeypatch):
+    _save_ui_model_settings(db)
+    brief = create_brief(db, title="Fetch failures", research_question="Handle failed fetches")
+
+    monkeypatch.setattr(
+        web_research,
+        "_ollama_generate",
+        lambda config, payload: (
+            {
+                "response": json.dumps(
+                    {
+                        "schema_version": "1.0",
+                        "queries": [],
+                        "urls": [{"url": "https://example.com/fail", "rationale": "probe"}],
+                    }
+                )
+            },
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        web_research,
+        "fetch_public_url",
+        lambda url, **kwargs: {"success": False, "error": "timeout"},
+    )
+
+    result = web_research.run_web_research_for_brief(db, brief)
+
+    assert result["status"] == "no_valid_urls"
+    assert result["fetched_source_count"] == 0
+    assert result["skipped_urls"] == [{"url": "https://example.com/fail", "reason": "timeout"}]
+
+
+
+def test_capture_only_web_discovery_route_renders_phase_status(client_and_session, monkeypatch):
+    client, TestSession = client_and_session
+
+    response = client.post(
+        "/briefs",
+        data={"title": "UI brief", "research_question": "What is the signal?"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    brief_id = int(response.headers["location"].split("/")[-1])
+
+    def _fake_run_web_research_for_brief(db, brief):
+        return {
+            "status": "completed",
+            "started_at": "2026-04-28T00:00:00+00:00",
+            "finished_at": "2026-04-28T00:00:02+00:00",
+            "success": True,
+            "proposed_query_count": 1,
+            "proposed_url_count": 1,
+            "fetched_source_count": 1,
+            "errors": [],
+            "warnings": [],
+            "queries": [{"query": "support escalation pain", "rationale": "seed"}],
+            "sources": [{"url": "https://example.com/article", "title": "Example article"}],
+            "skipped_urls": [],
+        }
+
+    import apd.web.routes as web_routes
+
+    monkeypatch.setattr(web_routes, "run_web_research_for_brief", _fake_run_web_research_for_brief)
+
+    response = client.post(f"/briefs/{brief_id}/research-web", follow_redirects=True)
+    assert response.status_code == 200
+    assert "Web discovery phase" in response.text
+    assert "Example article" in response.text
+    assert "support escalation pain" in response.text
+    assert "issue #63" in response.text


### PR DESCRIPTION
## Summary
- add a controlled web discovery service that validates and captures public URLs as APD sources and excerpts
- reframe the prototype as a single web-assisted execution flow with web discovery and component execution phases recorded in `last_execution`
- update brief UI, docs, and mocked tests to present captured sources as part of execution results and defer full source grounding to #63

## Verification
- `uv run pytest tests/test_research_execution.py tests/test_web_research.py -q`
- `.\scripts\test.ps1`
- `uv run python scripts/check_repo_readiness.py`

Closes #62