### PR TITLE
Add grounded component execution from captured sources

### DIFF
--- a/apd/services/research_brief_service.py
+++ b/apd/services/research_brief_service.py
@@ -264,6 +264,7 @@ def generate_ollama_component_phase_prompt(
     phase_name: str,
     *,
     candidate_ids: list[str] | None = None,
+    grounded_source_packet: str | None = None,
 ) -> str:
     """Return a phase-specific component batch prompt."""
     base = generate_ollama_execution_prompt(brief)
@@ -298,7 +299,25 @@ def generate_ollama_component_phase_prompt(
         phase_name,
         "Phase: generic_component_batch\n- Return only ResearchComponentBatch JSON.",
     )
-    return "\n".join([base, "", "---", "", _COMPONENT_EXECUTION_CONSTRAINTS, "", selected, "", "Return only the ResearchComponentBatch JSON object."])
+    grounded_constraints = ""
+    if grounded_source_packet:
+        grounded_constraints = "\n".join(
+            [
+                "## Source-grounded execution constraints (mandatory)",
+                "- Use only the provided APD-captured source packet for factual claims.",
+                "- Do not invent sources, URLs, citations, source IDs, or excerpt IDs.",
+                "- Do not emit source.added or evidence_excerpt.added for provided packet sources.",
+                "- Every factual claim should have at least one evidence_link.added referencing a provided source_id and/or excerpt_id.",
+                "- Unsupported hypotheses may appear only when clearly marked as model-prior assumptions in metadata_json.",
+                "",
+                grounded_source_packet,
+            ]
+        )
+    parts = [base, "", "---", "", _COMPONENT_EXECUTION_CONSTRAINTS]
+    if grounded_constraints:
+        parts.extend(["", grounded_constraints])
+    parts.extend(["", selected, "", "Return only the ResearchComponentBatch JSON object."])
+    return "\n".join(parts)
 
 
 def generate_ollama_component_repair_prompt(
@@ -307,18 +326,33 @@ def generate_ollama_component_repair_prompt(
     phase_name: str,
     validation_errors: list[str],
     invalid_batch_data: dict[str, object] | None,
+    grounded_source_packet: str | None = None,
 ) -> str:
     """Return a phase-specific repair prompt for an invalid component batch."""
     base = generate_ollama_execution_prompt(brief)
     errors_block = "\n".join(f"- {line}" for line in validation_errors[:8]) or "- unknown validation error"
     invalid_json = "{}" if invalid_batch_data is None else json.dumps(invalid_batch_data, ensure_ascii=False)
-    return "\n".join(
+    parts = [
+        base,
+        "",
+        "---",
+        "",
+        _COMPONENT_EXECUTION_CONSTRAINTS,
+    ]
+    if grounded_source_packet:
+        parts.extend(
+            [
+                "",
+                "## Source-grounded execution constraints (mandatory)",
+                "- Use only the provided APD-captured source packet for factual claims.",
+                "- Do not invent sources, URLs, citations, source IDs, or excerpt IDs.",
+                "- Preserve valid source_id and excerpt_id references from the provided packet.",
+                "",
+                grounded_source_packet,
+            ]
+        )
+    parts.extend(
         [
-            base,
-            "",
-            "---",
-            "",
-            _COMPONENT_EXECUTION_CONSTRAINTS,
             "",
             "Phase repair request:",
             f"- Phase name: {phase_name}",
@@ -336,3 +370,4 @@ def generate_ollama_component_repair_prompt(
             "Return only the corrected ResearchComponentBatch JSON object.",
         ]
     )
+    return "\n".join(parts)

--- a/apd/services/research_components.py
+++ b/apd/services/research_components.py
@@ -100,6 +100,37 @@ class ComponentDraftAssembler:
         package["warnings"] = list(self._warnings)
         return package
 
+    def seed_grounding_sources(
+        self,
+        *,
+        sources: list[dict[str, Any]],
+        evidence_excerpts: list[dict[str, Any]],
+    ) -> None:
+        for source in sources:
+            self._data["sources"].append(
+                {
+                    "id": source["id"],
+                    "title": source.get("title"),
+                    "source_type": source.get("source_type") or "public_web",
+                    "url": source.get("url"),
+                    "origin": source.get("origin"),
+                    "summary": source.get("summary"),
+                    "metadata_json": dict(source.get("metadata_json") or {}),
+                }
+            )
+
+        for excerpt in evidence_excerpts:
+            self._data["evidence_excerpts"].append(
+                {
+                    "id": excerpt["id"],
+                    "source_id": excerpt["source_id"],
+                    "excerpt_text": excerpt["excerpt_text"],
+                    "location_reference": excerpt.get("location_reference"),
+                    "excerpt_type": excerpt.get("excerpt_type"),
+                    "metadata_json": dict(excerpt.get("metadata_json") or {}),
+                }
+            )
+
     def _apply_event(self, event: ResearchComponentEvent) -> None:
         payload = dict(event.payload or {})
         metadata = payload.get("metadata_json")

--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -408,6 +408,267 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
         _unload_ollama_model(config)
 
 
+def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dict[str, Any]:
+    from apd.services.web_research import get_grounding_source_packet_for_brief, render_grounding_source_packet
+
+    config, missing_env = get_ollama_execution_config(db)
+    component_repair_attempts = _parse_component_repair_attempts_env("APD_COMPONENT_REPAIR_ATTEMPTS", default=2)
+    now = _iso_now()
+    if config is None:
+        return {
+            "success": False,
+            "provider": "ollama-components-grounded",
+            "status": "config_missing",
+            "started_at": now,
+            "finished_at": now,
+            "errors": [f"Missing required env: {value}" for value in missing_env],
+            "warnings": [],
+            "run_id": None,
+            "grounding_status": "config_missing",
+            "grounding_errors": [f"Missing required env: {value}" for value in missing_env],
+        }
+
+    grounding_packet = get_grounding_source_packet_for_brief(db, brief)
+    if not grounding_packet.sources or not grounding_packet.evidence_excerpts:
+        return {
+            "success": False,
+            "provider": "ollama-components-grounded",
+            "model": config.model,
+            "status": "grounding_missing_sources",
+            "started_at": now,
+            "finished_at": now,
+            "errors": ["No captured web sources are available for grounded component execution. Run web discovery first."],
+            "warnings": [],
+            "run_id": None,
+            "mode": "grounded_component_execution",
+            "grounding_status": "missing_sources",
+            "grounding_errors": ["Run web discovery first to capture sources before grounded component execution."],
+            "grounding_source_count": 0,
+            "grounding_excerpt_count": 0,
+        }
+
+    started_at = now
+    grounded_source_packet = render_grounding_source_packet(grounding_packet)
+    try:
+        run_title = brief.title or (brief.research_question[:120] if brief.research_question else "Grounded Component Research")
+        assembler = ComponentDraftAssembler(
+            run_title=run_title,
+            run_intent=brief.research_question,
+            agent_name="ollama-grounded-component-prototype",
+            external_draft_id=f"brief-{brief.id}-grounded-components-{started_at}",
+        )
+        assembler.seed_grounding_sources(
+            sources=grounding_packet.sources,
+            evidence_excerpts=grounding_packet.evidence_excerpts,
+        )
+
+        attempts_by_phase: dict[str, int] = {}
+        warnings_list: list[str] = []
+        candidate_ids: list[str] = []
+        phases = ["candidate_batch", "claim_theme_batch", "validation_gate_batch"]
+        known_source_ids = grounding_packet.source_ids
+        known_excerpt_ids = grounding_packet.excerpt_ids
+        excerpt_to_source_id = {
+            str(item["id"]): str(item["source_id"]) for item in grounding_packet.evidence_excerpts
+        }
+
+        for phase_name in phases:
+            errors_for_phase: list[str] = []
+            prior_raw_batch: dict[str, Any] | None = None
+            max_attempts = component_repair_attempts + 1
+            attempts_by_phase[phase_name] = 0
+
+            for attempt_index in range(max_attempts):
+                attempts_by_phase[phase_name] = attempt_index + 1
+                if attempt_index == 0:
+                    prompt = generate_ollama_component_phase_prompt(
+                        brief,
+                        phase_name,
+                        candidate_ids=candidate_ids,
+                        grounded_source_packet=grounded_source_packet,
+                    )
+                else:
+                    prompt = generate_ollama_component_repair_prompt(
+                        brief,
+                        phase_name=phase_name,
+                        validation_errors=errors_for_phase,
+                        invalid_batch_data=prior_raw_batch,
+                        grounded_source_packet=grounded_source_packet,
+                    )
+
+                raw_batch_data, parse_error = _call_ollama_for_component_batch(config, prompt)
+                if parse_error:
+                    errors_for_phase = [f"{phase_name}: {parse_error}"]
+                    prior_raw_batch = None
+                    continue
+
+                prior_raw_batch = raw_batch_data
+                batch, batch_errors = parse_component_batch_from_data(raw_batch_data)
+                if batch is None:
+                    errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(batch_errors, limit=5)]
+                    continue
+
+                phase_errors = _validate_component_phase_batch(phase_name, batch)
+                if phase_errors:
+                    errors_for_phase = phase_errors
+                    continue
+
+                grounding_errors = _validate_component_grounding(
+                    phase_name,
+                    batch,
+                    known_source_ids=known_source_ids,
+                    known_excerpt_ids=known_excerpt_ids,
+                    excerpt_to_source_id=excerpt_to_source_id,
+                )
+                if grounding_errors:
+                    errors_for_phase = grounding_errors
+                    continue
+
+                assembly_result = assembler.apply_batch(batch)
+                if not assembly_result.success:
+                    errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(assembly_result.errors, limit=5)]
+                    continue
+
+                if phase_name == "candidate_batch":
+                    candidate_ids = [
+                        event.external_id
+                        for event in batch.events
+                        if event.event_type == ResearchComponentEventType.CANDIDATE_PROPOSED
+                    ]
+                warnings_list.extend(_first_errors(assembly_result.warnings, limit=5))
+                break
+            else:
+                finished_at = _iso_now()
+                failure_status = "quality_failed_no_candidates" if phase_name == "candidate_batch" else "component_validation_failed"
+                if phase_name == "candidate_batch":
+                    errors_for_phase = [
+                        (
+                            "The model returned no product candidates. Refine the brief toward a product/problem/opportunity, "
+                            "or try a stronger model."
+                        )
+                    ]
+                return {
+                    **_build_result(
+                        config,
+                        failure_status,
+                        started_at,
+                        finished_at,
+                        None,
+                        _first_errors(errors_for_phase or [f"{phase_name}: failed"], limit=5),
+                        _first_errors(warnings_list, limit=5),
+                        provider_override="ollama-components-grounded",
+                        mode="grounded_component_execution",
+                        last_phase=phase_name,
+                        attempts_by_phase=attempts_by_phase,
+                    ),
+                    "grounding_status": "failed",
+                    "grounding_errors": _first_errors(errors_for_phase or [f"{phase_name}: failed"], limit=5),
+                    "grounding_source_count": len(grounding_packet.sources),
+                    "grounding_excerpt_count": len(grounding_packet.evidence_excerpts),
+                }
+
+        assembled_package = assembler.package_dict()
+        report = validate_agent_draft_data(Path("<ollama-grounded-components-output>"), assembled_package)
+        if not report.is_valid or report.package is None:
+            finished_at = _iso_now()
+            return {
+                **_build_result(
+                    config,
+                    "validation_failed",
+                    started_at,
+                    finished_at,
+                    None,
+                    _first_errors(report.errors, limit=5),
+                    _first_errors(warnings_list, limit=5),
+                    provider_override="ollama-components-grounded",
+                    mode="grounded_component_execution",
+                    last_phase="final_validation",
+                    attempts_by_phase=attempts_by_phase,
+                ),
+                "grounding_status": "passed",
+                "grounding_errors": [],
+                "grounding_source_count": len(grounding_packet.sources),
+                "grounding_excerpt_count": len(grounding_packet.evidence_excerpts),
+            }
+
+        quality_result = _evaluate_product_quality_gate(report.package)
+        warnings_list.extend(quality_result.warnings)
+        if quality_result.error:
+            finished_at = _iso_now()
+            return {
+                **_build_result(
+                    config,
+                    quality_result.status,
+                    started_at,
+                    finished_at,
+                    None,
+                    [quality_result.error],
+                    _first_errors(warnings_list, limit=5),
+                    provider_override="ollama-components-grounded",
+                    mode="grounded_component_execution",
+                    last_phase="quality_gate",
+                    attempts_by_phase=attempts_by_phase,
+                ),
+                "grounding_status": "passed",
+                "grounding_errors": [],
+                "grounding_source_count": len(grounding_packet.sources),
+                "grounding_excerpt_count": len(grounding_packet.evidence_excerpts),
+            }
+
+        try:
+            import_result = import_agent_draft_package(
+                db,
+                report.package,
+                package_path=None,
+                allow_duplicate_external_id=False,
+            )
+        except Exception as exc:
+            finished_at = _iso_now()
+            return {
+                **_build_result(
+                    config,
+                    "import_failed",
+                    started_at,
+                    finished_at,
+                    None,
+                    [f"import_failed: {exc}"],
+                    _first_errors(warnings_list, limit=5),
+                    provider_override="ollama-components-grounded",
+                    mode="grounded_component_execution",
+                    last_phase="import",
+                    attempts_by_phase=attempts_by_phase,
+                ),
+                "grounding_status": "passed",
+                "grounding_errors": [],
+                "grounding_source_count": len(grounding_packet.sources),
+                "grounding_excerpt_count": len(grounding_packet.evidence_excerpts),
+            }
+
+        finished_at = _iso_now()
+        warnings_list.extend(import_result.warnings)
+        return {
+            **_build_result(
+                config,
+                "imported",
+                started_at,
+                finished_at,
+                import_result.run_db_id,
+                [],
+                _first_errors(warnings_list, limit=5),
+                provider_override="ollama-components-grounded",
+                mode="grounded_component_execution",
+                last_phase="import",
+                attempts_by_phase=attempts_by_phase,
+            ),
+            "grounding_status": "passed",
+            "grounding_errors": [],
+            "grounding_source_count": len(grounding_packet.sources),
+            "grounding_excerpt_count": len(grounding_packet.evidence_excerpts),
+        }
+    finally:
+        _unload_ollama_model(config)
+
+
 def _build_result(
     config: OllamaExecutionConfig,
     status: str,
@@ -600,7 +861,10 @@ def _evaluate_product_quality_gate(package: AgentDraftPackage) -> ProductQuality
             warnings=[],
         )
 
-    has_source_urls = any(bool(source.url and str(source.url).strip()) for source in package.sources)
+    has_source_urls = any(
+        bool(source.url and str(source.url).strip()) and not bool((source.metadata_json or {}).get("grounding_source"))
+        for source in package.sources
+    )
     warnings: list[str] = []
     if has_source_urls:
         warnings.append("quality_warning_unprovided_source_urls")
@@ -682,6 +946,61 @@ def _validate_component_phase_batch(phase_name: str, batch: ResearchComponentBat
             return [f"{phase_name}: batch must include validation_gate.proposed"]
         return []
     return []
+
+
+def _validate_component_grounding(
+    phase_name: str,
+    batch: ResearchComponentBatch,
+    *,
+    known_source_ids: set[str],
+    known_excerpt_ids: set[str],
+    excerpt_to_source_id: dict[str, str],
+) -> list[str]:
+    errors: list[str] = []
+    claim_ids = {
+        event.external_id
+        for event in batch.events
+        if event.event_type == ResearchComponentEventType.CLAIM_PROPOSED
+    }
+    grounded_claim_links: set[str] = set()
+
+    for event in batch.events:
+        if event.event_type in {ResearchComponentEventType.SOURCE_ADDED, ResearchComponentEventType.EVIDENCE_EXCERPT_ADDED}:
+            errors.append(f"{phase_name}: do not add new source or excerpt events in grounded mode")
+            continue
+
+        payload = dict(event.payload or {})
+        for key in ("url", "source_url", "citation_url"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip().lower().startswith(("http://", "https://")):
+                errors.append(f"{phase_name}: do not invent source URLs in {event.event_type.value}")
+
+        if event.event_type != ResearchComponentEventType.EVIDENCE_LINK_ADDED:
+            continue
+
+        source_id = str(payload.get("source_id") or "").strip()
+        excerpt_id = str(payload.get("excerpt_id") or "").strip()
+        target_type = str(payload.get("target_type") or "").strip()
+        target_id = str(payload.get("target_id") or "").strip()
+        relationship = str(payload.get("relationship") or "").strip()
+
+        if not source_id and not excerpt_id:
+            errors.append(f"{phase_name}: grounded evidence links must reference source_id and/or excerpt_id")
+        if source_id and source_id not in known_source_ids:
+            errors.append(f"{phase_name}: unknown grounded source_id '{source_id}'")
+        if excerpt_id and excerpt_id not in known_excerpt_ids:
+            errors.append(f"{phase_name}: unknown grounded excerpt_id '{excerpt_id}'")
+        if source_id and excerpt_id and excerpt_to_source_id.get(excerpt_id) != source_id:
+            errors.append(f"{phase_name}: excerpt_id '{excerpt_id}' does not belong to source_id '{source_id}'")
+        if target_type == "claim" and target_id:
+            if target_id not in claim_ids:
+                errors.append(f"{phase_name}: evidence link references unknown claim target_id '{target_id}'")
+            if relationship == "supports" and (source_id or excerpt_id):
+                grounded_claim_links.add(target_id)
+
+    if phase_name == "claim_theme_batch" and claim_ids and not grounded_claim_links:
+        errors.append(f"{phase_name}: at least one claim needs a supporting grounded evidence link")
+    return errors
 
 
 def _safe_normalize_near_miss(raw_data: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:

--- a/apd/services/web_research.py
+++ b/apd/services/web_research.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from dataclasses import dataclass
 import html
 import ipaddress
 import json
@@ -26,12 +27,39 @@ FETCH_TIMEOUT_SECONDS = 10
 MAX_RESPONSE_BYTES = 1_000_000
 MAX_EXTRACTED_TEXT_CHARS = 12_000
 MAX_EXCERPT_TEXT_CHARS = 8_000
+MAX_GROUNDED_PACKET_SOURCES = 5
+MAX_GROUNDED_PACKET_EXCERPTS = 10
+MAX_GROUNDED_PACKET_EXCERPT_CHARS = 1500
+MAX_GROUNDED_PACKET_TOTAL_CHARS = 10000
 WEB_USER_AGENT = "APD local research prototype/1.0"
 
 _TAG_RE = re.compile(r"<[^>]+>")
 _SCRIPT_STYLE_RE = re.compile(r"<(script|style)[^>]*>.*?</\1>", flags=re.IGNORECASE | re.DOTALL)
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", flags=re.IGNORECASE | re.DOTALL)
 _WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class GroundingSourcePacket:
+    sources: list[dict[str, object]]
+    evidence_excerpts: list[dict[str, object]]
+    total_chars: int
+
+    @property
+    def source_ids(self) -> set[str]:
+        return {str(item["id"]) for item in self.sources}
+
+    @property
+    def excerpt_ids(self) -> set[str]:
+        return {str(item["id"]) for item in self.evidence_excerpts}
+
+
+def _grounding_source_external_id(source_id: int) -> str:
+    return f"captured-source-{source_id}"
+
+
+def _grounding_excerpt_external_id(excerpt_id: int) -> str:
+    return f"captured-excerpt-{excerpt_id}"
 
 
 def _iso_now() -> str:
@@ -234,6 +262,131 @@ def _get_or_create_web_research_run(db: Session, brief: ResearchBrief) -> Run:
     db.commit()
     db.refresh(brief)
     return run
+
+
+def get_grounding_source_packet_for_brief(
+    db: Session,
+    brief: ResearchBrief,
+    *,
+    max_sources: int = MAX_GROUNDED_PACKET_SOURCES,
+    max_excerpts: int = MAX_GROUNDED_PACKET_EXCERPTS,
+    max_excerpt_chars: int = MAX_GROUNDED_PACKET_EXCERPT_CHARS,
+    max_total_chars: int = MAX_GROUNDED_PACKET_TOTAL_CHARS,
+) -> GroundingSourcePacket:
+    meta = dict(brief.metadata_json or {})
+    source_rows: list[Source] = []
+
+    web_research_run_id = meta.get("web_research_run_id")
+    if web_research_run_id:
+        source_rows = list(
+            db.scalars(
+                select(Source)
+                .where(Source.run_id == int(web_research_run_id))
+                .order_by(Source.id.asc())
+                .limit(max_sources)
+            )
+        )
+
+    if not source_rows:
+        source_rows = list(
+            db.scalars(
+                select(Source)
+                .where(Source.metadata_json["brief_id"].as_integer() == int(brief.id))
+                .order_by(Source.id.asc())
+                .limit(max_sources)
+            )
+        )
+
+    selected_sources = source_rows[:max_sources]
+    if not selected_sources:
+        return GroundingSourcePacket(sources=[], evidence_excerpts=[], total_chars=0)
+
+    source_id_map = {source.id: _grounding_source_external_id(source.id) for source in selected_sources}
+    source_packet: list[dict[str, object]] = []
+    for source in selected_sources:
+        source_packet.append(
+            {
+                "id": source_id_map[source.id],
+                "title": source.title,
+                "source_type": source.source_type,
+                "url": source.url,
+                "origin": source.origin,
+                "summary": source.summary,
+                "metadata_json": {
+                    "grounding_source": True,
+                    "captured_source_db_id": source.id,
+                    "brief_id": brief.id,
+                },
+            }
+        )
+
+    excerpt_rows = list(
+        db.scalars(
+            select(EvidenceExcerpt)
+            .where(EvidenceExcerpt.source_id.in_([source.id for source in selected_sources]))
+            .order_by(EvidenceExcerpt.id.asc())
+            .limit(max_excerpts * 2)
+        )
+    )
+
+    total_chars = 0
+    excerpt_packet: list[dict[str, object]] = []
+    for excerpt in excerpt_rows:
+        if excerpt.source_id not in source_id_map:
+            continue
+        excerpt_text = (excerpt.excerpt_text or "").strip()[:max_excerpt_chars]
+        if not excerpt_text:
+            continue
+        next_total = total_chars + len(excerpt_text)
+        if excerpt_packet and next_total > max_total_chars:
+            break
+        excerpt_packet.append(
+            {
+                "id": _grounding_excerpt_external_id(excerpt.id),
+                "source_id": source_id_map[excerpt.source_id],
+                "excerpt_text": excerpt_text,
+                "location_reference": excerpt.location_reference,
+                "excerpt_type": excerpt.excerpt_type,
+                "metadata_json": {
+                    "grounding_source": True,
+                    "captured_excerpt_db_id": excerpt.id,
+                    "captured_source_db_id": excerpt.source_id,
+                    "brief_id": brief.id,
+                },
+            }
+        )
+        total_chars = next_total
+        if len(excerpt_packet) >= max_excerpts:
+            break
+
+    return GroundingSourcePacket(
+        sources=source_packet,
+        evidence_excerpts=excerpt_packet,
+        total_chars=total_chars,
+    )
+
+
+def render_grounding_source_packet(packet: GroundingSourcePacket) -> str:
+    if not packet.sources or not packet.evidence_excerpts:
+        return "(no captured web source packet available)"
+
+    lines = ["## Captured source packet", "", "Use only these APD-captured sources for factual claims.", ""]
+    for source in packet.sources:
+        lines.append(f"Source ID: {source['id']}")
+        if source.get("title"):
+            lines.append(f"Title: {source['title']}")
+        if source.get("url"):
+            lines.append(f"URL: {source['url']}")
+        source_excerpts = [
+            excerpt
+            for excerpt in packet.evidence_excerpts
+            if excerpt.get("source_id") == source["id"]
+        ]
+        for excerpt in source_excerpts:
+            lines.append(f"Excerpt ID: {excerpt['id']}")
+            lines.append(f"Excerpt: {excerpt['excerpt_text']}")
+        lines.append("")
+    return "\n".join(lines).strip()
 
 
 def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, object]:

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -28,11 +28,12 @@ from apd.services.sample_research_briefs import get_sample_research_briefs
 from apd.services.model_execution_settings import get_model_execution_settings, save_model_execution_settings
 from apd.services.research_execution_ollama import (
     execute_research_brief_ollama_components,
+    execute_research_brief_ollama_components_grounded,
     execute_research_brief_ollama,
     get_ollama_execution_config,
 )
 from apd.services.research_execution_stub import execute_research_brief_stub
-from apd.services.web_research import run_web_research_for_brief
+from apd.services.web_research import get_grounding_source_packet_for_brief, run_web_research_for_brief
 from apd.web.queries import get_recent_runs, get_run_detail
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -93,6 +94,10 @@ def _component_execution_phase_data(result: dict) -> dict:
         "attempts_by_phase": dict(result.get("attempts_by_phase") or {}),
         "errors": [str(value) for value in (result.get("errors") or [])][:5],
         "warnings": [str(value) for value in (result.get("warnings") or [])][:5],
+        "grounding_status": result.get("grounding_status"),
+        "grounding_errors": [str(value) for value in (result.get("grounding_errors") or [])][:5],
+        "grounding_source_count": result.get("grounding_source_count"),
+        "grounding_excerpt_count": result.get("grounding_excerpt_count"),
     }
 
 
@@ -108,7 +113,6 @@ def _build_web_assisted_execution_result(
 
     warnings = _prefixed_messages("web_discovery", web_discovery_result.get("warnings"))
     warnings.extend(_prefixed_messages("component_execution", component_result.get("warnings")))
-    warnings.append("captured_sources_not_yet_used_for_grounded_component_generation")
 
     return {
         "success": bool(component_result.get("success")),
@@ -123,11 +127,11 @@ def _build_web_assisted_execution_result(
         "run_id": component_result.get("run_id"),
         "web_discovery": _web_discovery_phase_data(web_discovery_result),
         "component_execution": _component_execution_phase_data(component_result),
-        "source_grounding_status": "deferred_to_issue_63",
+        "source_grounding_status": component_result.get("grounding_status") or "unknown",
         "source_grounding_deferred_issue": 63,
         "source_grounding_note": (
-            "Web discovery captured sources, but the current component execution path is not yet fully source-grounded. "
-            "Grounding those phases to captured sources is follow-up work in issue #63."
+            "APD used captured sources as grounding context and validated source/excerpt IDs, "
+            "but this does not prove grounded claims are true. Human review is still required."
         ),
     }
 
@@ -349,6 +353,7 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
         raise HTTPException(status_code=404, detail="Research brief not found")
     prompt = generate_agent_prompt(brief)
     ollama_config, missing_ollama_env = get_ollama_execution_config(db)
+    grounding_packet = get_grounding_source_packet_for_brief(db, brief)
     return templates.TemplateResponse(
         request,
         "brief_detail.html",
@@ -358,6 +363,8 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
             "ollama_ready": ollama_config is not None,
             "missing_ollama_env": missing_ollama_env,
             "ollama_model": ollama_config.model if ollama_config else None,
+            "grounded_source_count": len(grounding_packet.sources),
+            "grounded_excerpt_count": len(grounding_packet.evidence_excerpts),
         },
     )
 
@@ -460,14 +467,64 @@ def research_web_sources(brief_id: int, db: Session = Depends(_get_db)):
             "warnings": _prefixed_messages("web_discovery", result.get("warnings"))[:5],
             "run_id": None,
             "web_discovery": _web_discovery_phase_data(result),
-            "source_grounding_status": "deferred_to_issue_63",
+            "source_grounding_status": "not_started",
             "source_grounding_deferred_issue": 63,
             "source_grounding_note": (
-                "This capture-only route reflects the web discovery phase of future research execution. "
-                "Source-grounded component generation remains follow-up work in issue #63."
+                "Web discovery captured sources for later grounded component execution. "
+                "APD validates source and excerpt IDs during grounded execution, but does not verify truth."
             ),
         },
     )
+    return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+
+@router.post("/briefs/{brief_id}/start-grounded-research-ollama-components", response_class=RedirectResponse)
+def start_research_ollama_components_grounded(brief_id: int, db: Session = Depends(_get_db)):
+    brief = get_brief(db, brief_id)
+    if brief is None:
+        raise HTTPException(status_code=404, detail="Research brief not found")
+
+    config, missing_env = get_ollama_execution_config(db)
+    if config is None:
+        _save_last_execution(
+            db,
+            brief,
+            {
+                "provider": "ollama-components-grounded",
+                "status": "config_missing",
+                "started_at": _iso_now(),
+                "finished_at": _iso_now(),
+                "errors": [f"Missing required env: {value}" for value in missing_env],
+                "warnings": [],
+                "run_id": None,
+                "source_grounding_status": "config_missing",
+            },
+        )
+        return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
+
+    started_at = _iso_now()
+    _save_last_execution(
+        db,
+        brief,
+        {
+            "provider": "ollama-components-grounded",
+            "model": config.model,
+            "status": "running",
+            "started_at": started_at,
+            "errors": [],
+            "warnings": [],
+            "run_id": None,
+            "mode": "grounded_component_execution",
+            "component_execution": {"status": "pending"},
+            "source_grounding_status": "running",
+        },
+    )
+
+    result = execute_research_brief_ollama_components_grounded(db, brief)
+    _save_last_execution(db, brief, result)
+
+    if result.get("success") and result.get("run_id"):
+        return RedirectResponse(url=f"/runs/{result.get('run_id')}", status_code=303)
     return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 
 
@@ -560,7 +617,7 @@ def start_research_ollama_components(brief_id: int, db: Session = Depends(_get_d
     )
 
     web_discovery_result = run_web_research_for_brief(db, brief)
-    component_result = execute_research_brief_ollama_components(db, brief)
+    component_result = execute_research_brief_ollama_components_grounded(db, brief)
     result = _build_web_assisted_execution_result(
         model=config.model,
         started_at=started_at,

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -157,10 +157,24 @@
       <form method="post" action="/briefs/{{ brief.id }}/start-research-ollama-components" style="display:inline; margin-left:0.5rem;">
         <button type="submit" class="btn btn-sm btn-primary">Start web-assisted research (prototype)</button>
       </form>
+      {% if grounded_source_count and grounded_excerpt_count %}
+      <form method="post" action="/briefs/{{ brief.id }}/start-grounded-research-ollama-components" style="display:inline; margin-left:0.5rem;">
+        <button type="submit" class="btn btn-sm btn-primary">Start grounded component research</button>
+      </form>
+      {% endif %}
       <div style="margin-top:0.5rem;">
-        This prototype runs a web discovery phase first, captures validated public sources, then continues into component execution.
-        Captured sources are not yet fully used to ground component generation; that grounding step is deferred to issue #63.
+        This prototype can run a web discovery phase first, capture validated public sources, then continue into grounded component execution.
+        APD validates source and excerpt IDs used in grounded evidence links, but does not verify claims as true.
       </div>
+      {% if grounded_source_count and grounded_excerpt_count %}
+      <div style="margin-top:0.35rem;">
+        Captured web grounding context available: {{ grounded_source_count }} sources, {{ grounded_excerpt_count }} excerpts.
+      </div>
+      {% else %}
+      <div style="margin-top:0.35rem;">
+        No captured web sources are available yet for grounded component execution. Run web-assisted discovery first.
+      </div>
+      {% endif %}
     {% else %}
       Configure all required env vars to enable this path:
       <code>APD_MODEL_PROVIDER=ollama</code>,
@@ -250,6 +264,24 @@
         <th>Component execution phase</th>
         <td>{{ component_status.get('status', '—') }}</td>
       </tr>
+      {% if component_status.get('grounding_status') %}
+      <tr>
+        <th>Grounding status</th>
+        <td>{{ component_status.get('grounding_status') }}</td>
+      </tr>
+      {% endif %}
+      {% if component_status.get('grounding_source_count') %}
+      <tr>
+        <th>Grounding packet</th>
+        <td>{{ component_status.get('grounding_source_count') }} sources, {{ component_status.get('grounding_excerpt_count', 0) }} excerpts</td>
+      </tr>
+      {% endif %}
+      {% if component_status.get('grounding_errors') %}
+      <tr>
+        <th>Grounding errors</th>
+        <td>{{ component_status.get('grounding_errors') | join('; ') }}</td>
+      </tr>
+      {% endif %}
       {% if component_status.get('run_id') %}
       <tr>
         <th>Imported run</th>

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -94,10 +94,13 @@ Intended workflow:
 Current prototype behavior:
 
 - The brief detail page exposes a `Start web-assisted research (prototype)` action.
+- When captured sources already exist, the brief detail page also exposes `Start grounded component research`.
 - Execution metadata records web discovery and component execution as separate phases under `metadata_json.last_execution`.
 - Captured sources are shown as part of execution status, not as a separate user prerequisite step.
-- The current component generation path is still not fully source-grounded.
-- Source-grounded component generation is follow-up work in issue #63.
+- Grounded component execution builds a bounded source packet from APD-captured `Source` and `EvidenceExcerpt` rows.
+- APD validates that model-generated `evidence_link.added` events only reference known captured `source_id` and `excerpt_id` values.
+- APD rejects grounded batches that invent source URLs, invent source/excerpt IDs, or produce claims without at least one supporting grounded evidence link.
+- This is grounding-by-reference only. APD does not verify that captured excerpts make generated claims true.
 
 Safety and budget controls:
 
@@ -148,6 +151,7 @@ Why this exists:
 What this is:
 
 - A synchronous website-first prototype path (`Start web-assisted research (prototype)`).
+- A follow-on grounded execution path that reuses APD-captured web sources (`Start grounded component research`).
 - Provider-agnostic schema names (`ResearchComponentEvent`, `ResearchComponentBatch`, `ComponentDraftAssembler`).
 - Ollama is the first adapter implementation.
 
@@ -162,6 +166,8 @@ Current component minimum:
 
 - Supports candidate, claim, and theme events (plus optional source/excerpt/gate/link events).
 - Rejects zero-candidate assembled output before import.
+- In grounded mode, seeds captured sources/excerpts into the assembled package so evidence links resolve through normal draft import.
+- In grounded mode, allows only APD-provided source/excerpt identifiers and blocks invented URL-like citations.
 - Uses the same keep-alive behavior (`keep_alive: 0` default) to free local model resources after execution.
 
 ## Component repair and retry loop (Issue #53)

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import sessionmaker
 import pytest
 
 from apd.app.db import Base
+from apd.domain.models import EvidenceExcerpt, Run, RunPhase, Source
 from apd.services.research_components import (
     ComponentDraftAssembler,
     parse_component_batch_from_data,
@@ -15,6 +16,7 @@ from apd.services.research_components import (
 from apd.services.research_brief_service import create_brief, get_brief
 from apd.services.research_execution_ollama import (
     execute_research_brief_ollama_components,
+    execute_research_brief_ollama_components_grounded,
     execute_research_brief_ollama,
     extract_json_object_from_model_output,
     get_ollama_execution_config,
@@ -58,6 +60,45 @@ def _create_brief_via_ui(client, *, title: str) -> int:
     assert response.status_code == 303
     location = response.headers["location"]
     return int(location.split("/")[-1])
+
+
+def _seed_captured_web_source(db, brief, *, title: str = "Captured source"):
+    capture_run = Run(
+        title=f"{brief.title} capture",
+        intent=brief.research_question,
+        mode="web_research_capture",
+        phase=RunPhase.EVIDENCE_COLLECTED,
+        metadata_json={"brief_id": brief.id, "created_by": "apd_web_research"},
+    )
+    db.add(capture_run)
+    db.flush()
+
+    source = Source(
+        run_id=capture_run.id,
+        title=title,
+        source_type="public_web",
+        url="https://example.com/captured",
+        origin="example.com",
+        metadata_json={"brief_id": brief.id},
+    )
+    db.add(source)
+    db.flush()
+
+    excerpt = EvidenceExcerpt(
+        run_id=capture_run.id,
+        source_id=source.id,
+        excerpt_text="Teams keep losing time because handoff context is missing.",
+        excerpt_type="web_capture",
+        metadata_json={"brief_id": brief.id},
+    )
+    db.add(excerpt)
+    db.flush()
+
+    brief.metadata_json = {"web_research_run_id": capture_run.id}
+    db.add(brief)
+    db.commit()
+    db.refresh(brief)
+    return source, excerpt
 
 
 @pytest.fixture()
@@ -323,9 +364,13 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
     _save_ui_model_settings(client)
     brief_id = _create_brief_via_ui(client, title="Saved DB config components")
 
-    monkeypatch.setattr(
-        "apd.web.routes.run_web_research_for_brief",
-        lambda db, brief: {
+    grounded_ids: dict[str, str] = {}
+
+    def _fake_run_web_research_for_brief(db, brief):
+        source, excerpt = _seed_captured_web_source(db, brief)
+        grounded_ids["source_id"] = f"captured-source-{source.id}"
+        grounded_ids["excerpt_id"] = f"captured-excerpt-{excerpt.id}"
+        return {
             "success": True,
             "status": "completed",
             "started_at": "2026-04-28T00:00:00+00:00",
@@ -339,8 +384,9 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
             "sources": [{"url": "https://example.com/article", "title": "Example article"}],
             "skipped_urls": [],
             "web_research_run_id": 11,
-        },
-    )
+        }
+
+    monkeypatch.setattr("apd.web.routes.run_web_research_for_brief", _fake_run_web_research_for_brief)
 
     captured_payloads = []
     responses = [
@@ -358,8 +404,9 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
             {
                 "response": (
                     '{"schema_version":"1.0","batch_id":"b-claim-theme","events":['
-                    '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim A"}},'
-                    '{"schema_version":"1.0","event_type":"theme.proposed","external_id":"theme-1","payload":{"name":"Theme A"}}'
+                        '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim A"}},'
+                        '{"schema_version":"1.0","event_type":"theme.proposed","external_id":"theme-1","payload":{"name":"Theme A"}},'
+                    '{"schema_version":"1.0","event_type":"evidence_link.added","external_id":"link-1","payload":{"source_id":"__SOURCE_ID__","excerpt_id":"__EXCERPT_ID__","target_type":"claim","target_id":"claim-1","relationship":"supports"}}'
                     ']}'
                 )
             },
@@ -381,7 +428,15 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
         captured_payloads.append(payload)
         if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
             return ({"response": ""}, None)
-        return responses.pop(0)
+        response, error = responses.pop(0)
+        if response.get("response") and grounded_ids:
+            response = {
+                **response,
+                "response": response["response"].replace("__SOURCE_ID__", grounded_ids["source_id"]).replace(
+                    "__EXCERPT_ID__", grounded_ids["excerpt_id"]
+                ),
+            }
+        return response, error
 
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
 
@@ -389,6 +444,24 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
     assert response.status_code == 303
     assert response.headers["location"].startswith("/runs/")
     assert captured_payloads
+    assert "Use only the provided APD-captured source packet" in captured_payloads[0]["prompt"]
+
+
+def test_brief_detail_shows_grounded_action_when_captured_sources_exist(client, monkeypatch):
+    _clear_ollama_env(monkeypatch)
+    _save_ui_model_settings(client)
+    brief_id = _create_brief_via_ui(client, title="Grounded action brief")
+
+    import apd.app.db as app_db
+    from apd.services.research_brief_service import get_brief as _get_brief
+
+    with app_db.SessionLocal() as db:
+        brief = _get_brief(db, brief_id)
+        _seed_captured_web_source(db, brief)
+
+    response = client.get(f"/briefs/{brief_id}")
+    assert response.status_code == 200
+    assert "Start grounded component research" in response.text
 
 
 def test_web_assisted_research_records_web_discovery_phase_in_last_execution(client, monkeypatch):
@@ -415,19 +488,23 @@ def test_web_assisted_research_records_web_discovery_phase_in_last_execution(cli
         },
     )
     monkeypatch.setattr(
-        "apd.web.routes.execute_research_brief_ollama_components",
+        "apd.web.routes.execute_research_brief_ollama_components_grounded",
         lambda db, brief: {
             "success": False,
-            "provider": "ollama-components",
+            "provider": "ollama-components-grounded",
             "status": "component_validation_failed",
             "started_at": "2026-04-28T00:00:03+00:00",
             "finished_at": "2026-04-28T00:00:04+00:00",
             "errors": ["component phase failed"],
             "warnings": [],
             "run_id": None,
-            "mode": "component_execution",
+            "mode": "grounded_component_execution",
             "last_phase": "claim_theme_batch",
             "attempts_by_phase": {"candidate_batch": 1, "claim_theme_batch": 2},
+            "grounding_status": "failed",
+            "grounding_errors": ["claim_theme_batch: unknown grounded source_id 'captured-source-9999'"],
+            "grounding_source_count": 1,
+            "grounding_excerpt_count": 1,
         },
     )
 
@@ -438,7 +515,159 @@ def test_web_assisted_research_records_web_discovery_phase_in_last_execution(cli
     assert "Captured source" in response.text
     assert "solo operator maintenance pain" in response.text
     assert "Web discovery succeeded; component generation failed validation." in response.text
-    assert "not yet fully source-grounded" in response.text
+    assert "Grounding status" in response.text
+    assert "unknown grounded source_id" in response.text
+
+
+def test_execute_grounded_components_requires_captured_sources(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+
+    brief = create_brief(db, title="No grounded sources", research_question="Q")
+    brief = get_brief(db, brief.id)
+
+    result = execute_research_brief_ollama_components_grounded(db, brief)
+
+    assert result["success"] is False
+    assert result["status"] == "grounding_missing_sources"
+    assert result["grounding_status"] == "missing_sources"
+    assert any("Run web discovery first" in err for err in result["grounding_errors"])
+
+
+def test_execute_grounded_components_imports_run_with_grounded_evidence_links(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "1")
+
+    brief = create_brief(db, title="Grounded success", research_question="Q")
+    brief = get_brief(db, brief.id)
+    source, excerpt = _seed_captured_web_source(db, brief)
+    grounded_source_id = f"captured-source-{source.id}"
+    grounded_excerpt_id = f"captured-excerpt-{excerpt.id}"
+    captured_payloads: list[dict] = []
+    responses = [
+        ({"response": '{"schema_version":"1.0","batch_id":"b-candidate","events":[{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Grounded candidate","summary":"S"}}]}'}, None),
+        ({"response": (
+            '{"schema_version":"1.0","batch_id":"b-claim-theme","events":['
+            '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Teams lose time during handoffs."}},'
+            '{"schema_version":"1.0","event_type":"theme.proposed","external_id":"theme-1","payload":{"name":"Handoff context loss"}},'
+            '{"schema_version":"1.0","event_type":"evidence_link.added","external_id":"link-1","payload":{"source_id":"' + grounded_source_id + '","excerpt_id":"' + grounded_excerpt_id + '","target_type":"claim","target_id":"claim-1","relationship":"supports","strength":"strong"}}'
+            ']}'
+        )}, None),
+        ({"response": '{"schema_version":"1.0","batch_id":"b-gates","events":[{"schema_version":"1.0","event_type":"validation_gate.proposed","external_id":"gate-1","payload":{"name":"Confirm repeated buyer urgency","phase":"supported_opportunity","candidate_id":"cand-1"}}]}'}, None),
+    ]
+
+    def _fake_generate(config, payload):
+        captured_payloads.append(payload)
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return responses.pop(0)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+
+    result = execute_research_brief_ollama_components_grounded(db, brief)
+
+    assert result["success"] is True
+    assert result["status"] == "imported"
+    assert result["grounding_status"] == "passed"
+    assert isinstance(result["run_id"], int)
+    assert grounded_source_id in captured_payloads[0]["prompt"]
+    assert "Use only the provided APD-captured source packet" in captured_payloads[0]["prompt"]
+
+
+def test_execute_grounded_components_rejects_unknown_source_id(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Grounded bad source", research_question="Q")
+    brief = get_brief(db, brief.id)
+    _, excerpt = _seed_captured_web_source(db, brief)
+    grounded_excerpt_id = f"captured-excerpt-{excerpt.id}"
+
+    responses = [
+        ({"response": '{"schema_version":"1.0","batch_id":"b-candidate","events":[{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate","summary":"S"}}]}'}, None),
+        ({"response": (
+            '{"schema_version":"1.0","batch_id":"b-claim-theme","events":['
+            '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim text"}},'
+            '{"schema_version":"1.0","event_type":"evidence_link.added","external_id":"link-1","payload":{"source_id":"captured-source-9999","excerpt_id":"' + grounded_excerpt_id + '","target_type":"claim","target_id":"claim-1","relationship":"supports"}}'
+            ']}'
+        )}, None),
+    ]
+
+    def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return responses.pop(0)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components_grounded(db, brief)
+    assert result["success"] is False
+    assert result["grounding_status"] == "failed"
+    assert any("unknown grounded source_id" in err for err in result["grounding_errors"])
+
+
+def test_execute_grounded_components_rejects_unknown_excerpt_id(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Grounded bad excerpt", research_question="Q")
+    brief = get_brief(db, brief.id)
+    source, _ = _seed_captured_web_source(db, brief)
+    grounded_source_id = f"captured-source-{source.id}"
+
+    responses = [
+        ({"response": '{"schema_version":"1.0","batch_id":"b-candidate","events":[{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate","summary":"S"}}]}'}, None),
+        ({"response": (
+            '{"schema_version":"1.0","batch_id":"b-claim-theme","events":['
+            '{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim text"}},'
+            '{"schema_version":"1.0","event_type":"evidence_link.added","external_id":"link-1","payload":{"source_id":"' + grounded_source_id + '","excerpt_id":"captured-excerpt-9999","target_type":"claim","target_id":"claim-1","relationship":"supports"}}'
+            ']}'
+        )}, None),
+    ]
+
+    def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return responses.pop(0)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components_grounded(db, brief)
+    assert result["success"] is False
+    assert result["grounding_status"] == "failed"
+    assert any("unknown grounded excerpt_id" in err for err in result["grounding_errors"])
+
+
+def test_execute_grounded_components_requires_supporting_claim_evidence(db, monkeypatch):
+    monkeypatch.setenv("APD_MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("APD_OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("APD_OLLAMA_MODEL", "llama3")
+    monkeypatch.setenv("APD_COMPONENT_REPAIR_ATTEMPTS", "0")
+
+    brief = create_brief(db, title="Grounded unsupported claim", research_question="Q")
+    brief = get_brief(db, brief.id)
+    _seed_captured_web_source(db, brief)
+
+    responses = [
+        ({"response": '{"schema_version":"1.0","batch_id":"b-candidate","events":[{"schema_version":"1.0","event_type":"candidate.proposed","external_id":"cand-1","payload":{"title":"Candidate","summary":"S"}}]}'}, None),
+        ({"response": '{"schema_version":"1.0","batch_id":"b-claim-theme","events":[{"schema_version":"1.0","event_type":"claim.proposed","external_id":"claim-1","payload":{"statement":"Claim text"}}]}'}, None),
+    ]
+
+    def _fake_generate(config, payload):
+        if payload.get("keep_alive") == 0 and not str(payload.get("prompt", "")).strip():
+            return ({"response": ""}, None)
+        return responses.pop(0)
+
+    monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
+    result = execute_research_brief_ollama_components_grounded(db, brief)
+    assert result["success"] is False
+    assert result["grounding_status"] == "failed"
+    assert any("at least one claim needs a supporting grounded evidence link" in err for err in result["grounding_errors"])
 
 
 def test_execute_ollama_components_success_path_imports_run(db, monkeypatch):
@@ -874,6 +1103,23 @@ def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):
         ),
     )
     monkeypatch.setattr(
+        "apd.web.routes.run_web_research_for_brief",
+        lambda db, brief: {
+            "success": True,
+            "status": "completed",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "finished_at": "2026-01-01T00:00:01+00:00",
+            "errors": [],
+            "warnings": [],
+            "proposed_query_count": 1,
+            "proposed_url_count": 1,
+            "fetched_source_count": 0,
+            "queries": [],
+            "sources": [],
+            "skipped_urls": [],
+        },
+    )
+    monkeypatch.setattr(
         "apd.web.routes.execute_research_brief_ollama",
         lambda db, brief: {
             "success": False,
@@ -906,10 +1152,10 @@ def test_start_research_ollama_components_route_uses_mocked_service(client, monk
         ),
     )
     monkeypatch.setattr(
-        "apd.web.routes.execute_research_brief_ollama_components",
+        "apd.web.routes.execute_research_brief_ollama_components_grounded",
         lambda db, brief: {
             "success": False,
-            "provider": "ollama-components",
+            "provider": "ollama-components-grounded",
             "model": "llama3",
             "status": "component_validation_failed",
             "started_at": "2026-01-01T00:00:00+00:00",
@@ -917,6 +1163,8 @@ def test_start_research_ollama_components_route_uses_mocked_service(client, monk
             "errors": ["mocked components failure"],
             "warnings": [],
             "run_id": None,
+            "grounding_status": "failed",
+            "grounding_errors": ["mocked components failure"],
         },
     )
 

--- a/tests/test_web_research.py
+++ b/tests/test_web_research.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from apd.app.db import Base
-from apd.domain.models import EvidenceExcerpt, ResearchBrief, Run, Source
+from apd.domain.models import EvidenceExcerpt, ResearchBrief, Run, RunPhase, Source
 from apd.services.model_execution_settings import save_model_execution_settings
 from apd.services.research_brief_service import create_brief
 from apd.services import web_research
@@ -126,6 +126,56 @@ def test_run_web_research_stores_source_and_excerpt(db, monkeypatch):
     assert saved_excerpt is not None
     assert "backup checks" in saved_excerpt.excerpt_text
     assert saved_brief.metadata_json["web_research_run_id"] == result["web_research_run_id"]
+
+
+def test_get_grounding_source_packet_for_brief_includes_captured_ids_and_text(db):
+    brief = create_brief(db, title="Grounded packet", research_question="Q")
+
+    capture_run = Run(
+        title="Grounding capture",
+        intent="Q",
+        mode="web_research_capture",
+        phase=RunPhase.EVIDENCE_COLLECTED,
+        metadata_json={"brief_id": brief.id, "created_by": "apd_web_research"},
+    )
+    db.add(capture_run)
+    db.flush()
+
+    source = Source(
+        run_id=capture_run.id,
+        title="Example source",
+        source_type="public_web",
+        url="https://example.com/source",
+        origin="example.com",
+        metadata_json={"brief_id": brief.id},
+    )
+    db.add(source)
+    db.flush()
+
+    excerpt = EvidenceExcerpt(
+        run_id=capture_run.id,
+        source_id=source.id,
+        excerpt_text="Operators describe losing hours every week to manual incident triage.",
+        excerpt_type="web_capture",
+        metadata_json={"brief_id": brief.id},
+    )
+    db.add(excerpt)
+    db.flush()
+
+    brief.metadata_json = {"web_research_run_id": capture_run.id}
+    db.add(brief)
+    db.commit()
+
+    packet = web_research.get_grounding_source_packet_for_brief(db, brief)
+    rendered = web_research.render_grounding_source_packet(packet)
+
+    assert len(packet.sources) == 1
+    assert len(packet.evidence_excerpts) == 1
+    assert packet.sources[0]["id"] == f"captured-source-{source.id}"
+    assert packet.evidence_excerpts[0]["id"] == f"captured-excerpt-{excerpt.id}"
+    assert packet.evidence_excerpts[0]["source_id"] == f"captured-source-{source.id}"
+    assert "Example source" in rendered
+    assert "manual incident triage" in rendered
 
 
 @pytest.mark.parametrize(
@@ -282,4 +332,5 @@ def test_capture_only_web_discovery_route_renders_phase_status(client_and_sessio
     assert "Web discovery phase" in response.text
     assert "Example article" in response.text
     assert "support escalation pain" in response.text
-    assert "issue #63" in response.text
+    assert "grounded component execution" in response.text
+    assert "does not verify truth" in response.text


### PR DESCRIPTION
Refs #63

## Summary
- add a bounded grounding packet built from APD-captured web `Source` and `EvidenceExcerpt` rows
- run component execution against that packet, seed captured source/excerpt IDs into the assembled package, and reject invented or unknown grounding references
- wire the brief UI to support grounded component execution after web discovery or from existing captured sources, and document the validation limits

## Files Changed
- `apd/services/web_research.py`: build and render bounded grounding source packets from captured sources/excerpts
- `apd/services/research_components.py`: seed captured grounding sources/excerpts into the component assembler
- `apd/services/research_brief_service.py`: add grounded source packet constraints to phase and repair prompts
- `apd/services/research_execution_ollama.py`: add grounded component execution, grounding validation, and quality-gate handling for seeded sources
- `apd/web/routes.py`: route web-assisted execution through grounded components and add a grounded-only action
- `apd/web/templates/brief_detail.html`: surface grounded execution actions and grounding status/errors
- `docs/briefs.md`: document grounded execution behavior and its limits
- `tests/test_research_execution.py`, `tests/test_web_research.py`: cover packet building, grounded success/failure paths, and updated UI behavior

## Verification
- `uv run pytest tests/test_web_research.py tests/test_research_execution.py -q`
- `.\scripts\test.ps1`
- `uv run python scripts/check_repo_readiness.py`

## Notes
- this uses APD-captured web sources as grounding context for component execution
- APD validates source/excerpt IDs and blocks invented URL-like citations, but does not verify grounded claims as true
- tests do not require live web access or a live Ollama instance; model and network behavior remain mocked in test coverage
- broader local repo tests passed before opening this PR; GitHub checks have not run yet