### PR TITLE
Clean up brief detail UI around single Start Research action

### DIFF
--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -19,7 +19,6 @@ from apd.web.mutations import (
 from apd.services.report_export import export_run_markdown_report
 from apd.services.research_brief_service import (
     create_brief,
-    generate_agent_prompt,
     get_brief,
     list_briefs,
 )
@@ -351,7 +350,6 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
     brief = get_brief(db, brief_id)
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")
-    prompt = generate_agent_prompt(brief)
     ollama_config, missing_ollama_env = get_ollama_execution_config(db)
     grounding_packet = get_grounding_source_packet_for_brief(db, brief)
     return templates.TemplateResponse(
@@ -359,7 +357,6 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
         "brief_detail.html",
         {
             "brief": brief,
-            "agent_prompt": prompt,
             "ollama_ready": ollama_config is not None,
             "missing_ollama_env": missing_ollama_env,
             "ollama_model": ollama_config.model if ollama_config else None,
@@ -405,6 +402,11 @@ def settings_model_execution_save(
 
 @router.post("/briefs/{brief_id}/start-research", response_class=RedirectResponse)
 def start_research(brief_id: int, db: Session = Depends(_get_db)):
+    return start_research_ollama_components(brief_id, db)
+
+
+@router.post("/briefs/{brief_id}/start-research-stub", response_class=RedirectResponse)
+def start_research_stub(brief_id: int, db: Session = Depends(_get_db)):
     brief = get_brief(db, brief_id)
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")

--- a/apd/web/static/style.css
+++ b/apd/web/static/style.css
@@ -319,6 +319,91 @@ tr.gate-weak td { background: #fffbeb; }
 }
 .review-form-details > summary:hover { text-decoration: underline; }
 
+.execution-helper-copy {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.execution-settings-notice {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #1d4ed8;
+}
+
+.execution-settings-notice a {
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.execution-summary-card {
+  margin-top: 1rem;
+}
+
+.execution-summary-table {
+  max-width: 900px;
+  margin-bottom: 1rem;
+}
+
+.execution-summary-table td {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.execution-error-notice {
+  background: #fff7ed;
+  border: 1px solid #fdba74;
+  color: #9a3412;
+  margin-bottom: 1rem;
+}
+
+.execution-messages {
+  margin-top: 1rem;
+}
+
+.execution-messages h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+}
+
+.execution-message-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.execution-message-list li + li {
+  margin-top: 0.35rem;
+}
+
+.execution-warnings {
+  color: #92400e;
+}
+
+.execution-raw-details {
+  margin-top: 1rem;
+}
+
+.execution-raw-details > summary {
+  cursor: pointer;
+  color: #1d4ed8;
+  font-size: 0.875rem;
+}
+
+.execution-raw-json {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-top: 0.75rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 /* shared form row */
 .form-row {
   display: flex;

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -50,173 +50,61 @@
     {% endif %}
   </table>
 </div>
-
-<!-- Generated agent prompt -->
-<div class="card" id="agent-prompt">
-  <h2>Generated agent prompt</h2>
-
-  <div class="notice-box" style="
-    background: #fef9c3;
-    border: 1px solid #fde68a;
-    border-radius: 6px;
-    padding: 0.75rem 1rem;
-    margin-bottom: 1rem;
-    font-size: 0.85rem;
-  ">
-    <strong>Manual mode — APD is not yet running the model.</strong>
-    Copy the prompt below and paste it into an external research agent (e.g. Claude, GPT-4).
-    The agent will return an APD draft JSON package that you can validate and import.
-    This manual copy-paste step is temporary; automated execution is planned for a future release.
-  </div>
-
-  <div style="margin-bottom: 0.75rem;">
-    <button
-      type="button"
-      class="btn btn-primary btn-sm"
-      onclick="copyPrompt()"
-      id="copy-btn"
-    >Copy prompt</button>
-    <span id="copy-confirm" style="display:none; margin-left: 0.5rem; color: #065f46; font-size: 0.8rem;">Copied!</span>
-  </div>
-
-  <pre id="prompt-text" style="
-    background: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 6px;
-    padding: 1rem;
-    font-size: 0.78rem;
-    line-height: 1.5;
-    white-space: pre-wrap;
-    word-break: break-word;
-    max-height: 600px;
-    overflow-y: auto;
-  ">{{ agent_prompt }}</pre>
-</div>
-
-<!-- Next steps -->
-<div class="card" id="next-steps">
-  <h2>Next steps</h2>
-  <ol style="font-size: 0.875rem; line-height: 1.8; padding-left: 1.25rem;">
-    <li>Copy the prompt above and run it in your external research agent.</li>
-    <li>
-      Save the returned JSON to a local file, then validate it:
-      <br>
-      <code style="background:#f1f5f9; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.8rem;">
-        uv run python scripts/validate_agent_draft.py --path &lt;draft.json&gt; --repair-hints
-      </code>
-    </li>
-    <li>
-      If validation fails, normalize common near-miss fields:
-      <br>
-      <code style="background:#f1f5f9; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.8rem;">
-        uv run python scripts/normalize_agent_draft.py --path &lt;draft.json&gt; --out &lt;normalized.json&gt;
-      </code>
-    </li>
-    <li>
-      Import the validated draft:
-      <br>
-      <code style="background:#f1f5f9; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.8rem;">
-        uv run python scripts/import_agent_draft.py --path &lt;normalized.json&gt;
-      </code>
-    </li>
-    <li>Open the imported run in <a href="/runs">Runs</a> and review the evidence chain.</li>
-  </ol>
-
-  <div class="notice-box" style="
-    background: #f0f9ff;
-    border: 1px solid #bae6fd;
-    border-radius: 6px;
-    padding: 0.75rem 1rem;
-    margin-top: 1rem;
-    font-size: 0.8rem;
-    color: #0369a1;
-  ">
-    <strong>Website-first prototype:</strong>
-    This page can run a deterministic stub research runner that produces a clearly labeled synthetic APD draft.
-    It does not call any model or external service. Use the <em>Start Research (stub)</em> button below to run it.
-    <form method="post" action="/briefs/{{ brief.id }}/start-research" style="display:inline; margin-left:0.5rem;">
-      <button type="submit" class="btn btn-sm btn-primary">Start Research (stub)</button>
-    </form>
-  </div>
-
-  <div class="notice-box" style="
-    background: #ecfeff;
-    border: 1px solid #a5f3fc;
-    border-radius: 6px;
-    padding: 0.75rem 1rem;
-    margin-top: 0.75rem;
-    font-size: 0.8rem;
-    color: #155e75;
-  ">
-    <strong>Local Ollama execution (Issue #46):</strong>
-    {% if ollama_ready %}
-      APD is configured for Ollama model <code>{{ ollama_model }}</code>.
-      <form method="post" action="/briefs/{{ brief.id }}/start-research-ollama" style="display:inline; margin-left:0.5rem;">
-        <button type="submit" class="btn btn-sm btn-primary">Start Research with Ollama</button>
-      </form>
-      <form method="post" action="/briefs/{{ brief.id }}/start-research-ollama-components" style="display:inline; margin-left:0.5rem;">
-        <button type="submit" class="btn btn-sm btn-primary">Start web-assisted research (prototype)</button>
-      </form>
-      {% if grounded_source_count and grounded_excerpt_count %}
-      <form method="post" action="/briefs/{{ brief.id }}/start-grounded-research-ollama-components" style="display:inline; margin-left:0.5rem;">
-        <button type="submit" class="btn btn-sm btn-primary">Start grounded component research</button>
-      </form>
-      {% endif %}
-      <div style="margin-top:0.5rem;">
-        This prototype can run a web discovery phase first, capture validated public sources, then continue into grounded component execution.
-        APD validates source and excerpt IDs used in grounded evidence links, but does not verify claims as true.
-      </div>
-      {% if grounded_source_count and grounded_excerpt_count %}
-      <div style="margin-top:0.35rem;">
-        Captured web grounding context available: {{ grounded_source_count }} sources, {{ grounded_excerpt_count }} excerpts.
-      </div>
-      {% else %}
-      <div style="margin-top:0.35rem;">
-        No captured web sources are available yet for grounded component execution. Run web-assisted discovery first.
-      </div>
-      {% endif %}
-    {% else %}
-      Configure all required env vars to enable this path:
-      <code>APD_MODEL_PROVIDER=ollama</code>,
-      <code>APD_OLLAMA_BASE_URL=http://localhost:11434</code>,
-      <code>APD_OLLAMA_MODEL=&lt;installed-model-name&gt;</code>.
-      {% if missing_ollama_env and missing_ollama_env|length > 0 %}
-        Missing now:
-        <code>{{ missing_ollama_env | join(", ") }}</code>.
-      {% endif %}
+<div class="card">
+  <h2>Start research</h2>
+  {% if ollama_ready %}
+  <p class="execution-helper-copy">Uses your configured local model to run APD's current autonomous research path.</p>
+  <p class="muted" style="margin-top: -0.25rem; margin-bottom: 1rem;">
+    APD runs web discovery first, then continues into grounded component execution using captured sources when available.
+  </p>
+  <form method="post" action="/briefs/{{ brief.id }}/start-research">
+    <button type="submit" class="btn btn-primary">Start Research</button>
+  </form>
+  {% if grounded_source_count and grounded_excerpt_count %}
+  <p class="muted" style="margin-top: 0.75rem; margin-bottom: 0;">
+    Captured grounding context available: {{ grounded_source_count }} sources, {{ grounded_excerpt_count }} excerpts.
+  </p>
+  {% endif %}
+  {% else %}
+  <div class="notice-box execution-settings-notice">
+    <strong>Configure a local model to start research.</strong>
+    APD uses your saved local model settings for autonomous research runs.
+    <a href="/settings/model-execution">Open model execution settings</a>.
+    {% if missing_ollama_env and missing_ollama_env|length > 0 %}
+    <div class="muted" style="margin-top: 0.5rem;">
+      Missing now: {{ missing_ollama_env | join(", ") }}
+    </div>
     {% endif %}
   </div>
-  
+  {% endif %}
+
   {% if brief.metadata_json and brief.metadata_json.get('last_execution') %}
   {% set execution = brief.metadata_json.get('last_execution') %}
   {% set web_status = execution.get('web_discovery') %}
   {% set component_status = execution.get('component_execution') %}
   {% set component_failed_after_web_success = web_status and web_status.get('status') == 'completed' and component_status and component_status.get('status') in ['validation_failed', 'component_validation_failed', 'failed'] %}
-  <div class="card" style="margin-top:1rem;">
+  <div class="execution-summary-card">
     <h3>Last execution</h3>
 
     {% if component_failed_after_web_success %}
-    <div class="notice-box" style="
-      background: #fff7ed;
-      border: 1px solid #fdba74;
-      border-radius: 6px;
-      padding: 0.75rem 1rem;
-      margin-bottom: 1rem;
-      font-size: 0.85rem;
-      color: #9a3412;
-    ">
+    <div class="notice-box execution-error-notice">
       <strong>Web discovery succeeded; component generation failed validation.</strong>
       APD captured sources during the web discovery phase, but the later component generation step did not pass validation.
-      The raw execution JSON and detailed phase errors remain available below.
+      The detailed raw execution payload remains available below if needed.
     </div>
     {% endif %}
 
-    {% if execution.get('mode') == 'web_assisted_component_execution' or web_status %}
-    <table class="detail-table" style="max-width: 900px; margin-bottom: 1rem;">
+    <table class="detail-table execution-summary-table">
       <tr>
         <th style="width: 240px;">Overall status</th>
         <td>{{ execution.get('status', '—') }}</td>
       </tr>
+      {% if execution.get('provider') %}
+      <tr>
+        <th>Execution path</th>
+        <td>{{ execution.get('provider') }}</td>
+      </tr>
+      {% endif %}
       {% if web_status %}
       <tr>
         <th>Web discovery phase</th>
@@ -291,43 +179,39 @@
       {% endif %}
       {% if execution.get('source_grounding_note') %}
       <tr>
-        <th>Grounding status</th>
+        <th>Grounding note</th>
         <td>{{ execution.get('source_grounding_note') }}</td>
       </tr>
       {% endif %}
-      {% if execution.get('errors') %}
-      <tr>
-        <th>Errors</th>
-        <td>{{ execution.get('errors') | join('; ') }}</td>
-      </tr>
-      {% endif %}
-      {% if execution.get('warnings') %}
-      <tr>
-        <th>Warnings</th>
-        <td>{{ execution.get('warnings') | join('; ') }}</td>
-      </tr>
-      {% endif %}
     </table>
+
+    {% if execution.get('errors') %}
+    <div class="execution-messages">
+      <h4>Error summary</h4>
+      <ul class="execution-message-list">
+        {% for error in execution.get('errors') %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    </div>
     {% endif %}
 
-    <pre style="background:#fff; padding:0.75rem; border-radius:6px;">{{ execution | tojson }}</pre>
+    {% if execution.get('warnings') %}
+    <div class="execution-messages execution-warnings">
+      <h4>Warnings</h4>
+      <ul class="execution-message-list">
+        {% for warning in execution.get('warnings') %}
+        <li>{{ warning }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <details class="execution-raw-details">
+      <summary>Show raw execution details</summary>
+      <pre class="execution-raw-json">{{ execution | tojson(indent=2) }}</pre>
+    </details>
   </div>
   {% endif %}
 </div>
-
-<script>
-function copyPrompt() {
-  var text = document.getElementById("prompt-text").textContent;
-  navigator.clipboard.writeText(text).then(function() {
-    var btn = document.getElementById("copy-btn");
-    var confirm = document.getElementById("copy-confirm");
-    btn.textContent = "Copied!";
-    confirm.style.display = "inline";
-    setTimeout(function() {
-      btn.textContent = "Copy prompt";
-      confirm.style.display = "none";
-    }, 2000);
-  });
-}
-</script>
 {% endblock %}

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -1,41 +1,30 @@
 # Research Briefs
 
-APD supports creating a small research brief that generates a copyable agent prompt.
+APD supports creating a small research brief and starting research directly from the brief detail page.
 
 Purpose
 
-- Reduce friction between a research question and the manual agent handoff.
+- Reduce friction between a research question and APD's autonomous local research workflow.
 
 Workflow
 
 1. Create a research brief in the APD UI under `/briefs`.
-2. Copy the generated agent prompt shown on the brief detail page and paste it into an external research agent (e.g. GPT-4, Claude).
-3. Save the agent's JSON output to a local file.
-4. Validate the JSON using APD's validation tooling:
-
-```bash
-uv run python scripts/validate_agent_draft.py --path <draft.json> --repair-hints
-uv run python scripts/normalize_agent_draft.py --path <draft.json> --out <normalized.json>
-```
-
-5. After validation passes, import the draft:
-
-```bash
-uv run python scripts/import_agent_draft.py --path <normalized.json>
-```
+2. Open the brief detail page and click `Start Research`.
+3. APD uses the configured local model to run the current autonomous research path internally.
+4. APD shows concise execution status on the brief detail page, including web discovery and component execution phases when applicable.
+5. If execution succeeds, APD redirects to the imported run. If execution fails, APD keeps the raw execution payload available behind a collapsed details disclosure.
 
 Notes
 
 - APD will import the package as draft/unreviewed research for human inspection and review.
 - The new brief form includes a local sample/randomizer for dogfooding. It does not call a model or save anything until you submit the brief form.
 - APD also supports optional model-generated brief ideation using configured local Ollama settings. These generated ideas are draft form prefills only, are not researched findings, do not perform web/source research, do not use hosted provider API keys, and are not saved until you submit the brief form.
+- The older prompt-copy / validate / normalize / import workflow is legacy/debug fallback only. It is no longer the normal brief-detail experience.
 
 Note: The run review UI is candidate-first — the run detail page surfaces product
 candidates before sources and reasoning so reviewers can prioritize candidate
 inspection and then trace claims/themes/gates back to supporting evidence.
-- The current workflow is manual: APD does not run models itself yet. Automation is tracked in issue #44.
- - A website-first prototype (Issue #44) is available that demonstrates an in-process, deterministic "stub" runner. The stub does not call external models or services; it builds a synthetic agent draft package, validates it with APD's validators, and imports it locally so you can exercise the end-to-end import and run creation flow without external network calls.
-- The generated prompt includes reminders about APD's expected field names and schema. Use them to avoid common near-miss errors (e.g. `sources.source_type`, `evidence_excerpts.excerpt_text`, `claims.statement`).
+- A deterministic stub runner still exists for tests and debugging, but it is no longer the normal user-facing brief workflow.
 
 ## Local Ollama execution (Issue #46)
 
@@ -93,14 +82,15 @@ Intended workflow:
 
 Current prototype behavior:
 
-- The brief detail page exposes a `Start web-assisted research (prototype)` action.
-- When captured sources already exist, the brief detail page also exposes `Start grounded component research`.
+- The brief detail page exposes one primary `Start Research` action for normal users.
+- `Start Research` routes to APD's current best local execution path: web discovery followed by grounded component execution.
 - Execution metadata records web discovery and component execution as separate phases under `metadata_json.last_execution`.
 - Captured sources are shown as part of execution status, not as a separate user prerequisite step.
 - Grounded component execution builds a bounded source packet from APD-captured `Source` and `EvidenceExcerpt` rows.
 - APD validates that model-generated `evidence_link.added` events only reference known captured `source_id` and `excerpt_id` values.
 - APD rejects grounded batches that invent source URLs, invent source/excerpt IDs, or produce claims without at least one supporting grounded evidence link.
 - This is grounding-by-reference only. APD does not verify that captured excerpts make generated claims true.
+- Brief execution status now prioritizes readable phase summaries and error summaries, with raw execution JSON collapsed behind a disclosure.
 
 Safety and budget controls:
 
@@ -150,8 +140,8 @@ Why this exists:
 
 What this is:
 
-- A synchronous website-first prototype path (`Start web-assisted research (prototype)`).
-- A follow-on grounded execution path that reuses APD-captured web sources (`Start grounded component research`).
+- A synchronous brief workflow exposed as `Start Research`.
+- A web-assisted grounded execution path that reuses APD-captured web sources internally.
 - Provider-agnostic schema names (`ResearchComponentEvent`, `ResearchComponentBatch`, `ComponentDraftAssembler`).
 - Ollama is the first adapter implementation.
 

--- a/tests/test_research_briefs.py
+++ b/tests/test_research_briefs.py
@@ -469,7 +469,7 @@ def test_brief_detail_page_loads(client):
     assert "No enterprise tools." in body
 
 
-def test_brief_detail_shows_generated_prompt(client):
+def test_brief_detail_hides_legacy_manual_prompt_flow(client):
     resp = client.post(
         "/briefs",
         data={
@@ -480,14 +480,16 @@ def test_brief_detail_shows_generated_prompt(client):
     )
     assert resp.status_code == 200
     body = resp.text
-    assert "Generated agent prompt" in body
+    assert "Configure a local model to start research." in body
     assert "What ops pain do small teams have?" in body
-    # Schema reminders should appear in the rendered prompt
-    assert "source_type" in body
-    assert "excerpt_text" in body
+    assert "Generated agent prompt" not in body
+    assert "Copy prompt" not in body
+    assert "validate_agent_draft.py" not in body
+    assert "normalize_agent_draft.py" not in body
+    assert "import_agent_draft.py" not in body
 
 
-def test_brief_detail_states_apd_not_running_model(client):
+def test_brief_detail_shows_concise_model_settings_prompt_when_missing(client):
     resp = client.post(
         "/briefs",
         data={
@@ -497,11 +499,11 @@ def test_brief_detail_states_apd_not_running_model(client):
         follow_redirects=True,
     )
     assert resp.status_code == 200
-    # Must clearly say APD is not running the model
-    assert "not yet running the model" in resp.text.lower() or "APD is not yet running" in resp.text
+    assert "Configure a local model to start research." in resp.text
+    assert "/settings/model-execution" in resp.text
 
 
-def test_brief_detail_shows_future_start_research_disabled(client):
+def test_brief_detail_shows_single_primary_start_research_action(client):
     resp = client.post(
         "/briefs",
         data={
@@ -512,9 +514,13 @@ def test_brief_detail_shows_future_start_research_disabled(client):
     )
     assert resp.status_code == 200
     body = resp.text
-    assert "Start Research" in body
-    # Website-first prototype now exposes Start Research (stub) — it should not be disabled
-    assert "not yet available" not in body
+    assert "Configure a local model to start research." in body
+    assert "/settings/model-execution" in body
+    assert "Start Research (stub)" not in body
+    assert "Start Research with Ollama" not in body
+    assert "Start web-assisted research (prototype)" not in body
+    assert "Start grounded component research" not in body
+    assert "Website-first prototype" not in body
 
 
 def test_brief_list_shows_created_brief(client):

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fastapi.responses import RedirectResponse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -160,19 +161,30 @@ def test_execute_stub_service_imports_run(db):
     assert isinstance(result.get("run_id"), int)
 
 
-def test_start_research_route_creates_run(client):
-    # create brief via web route then start research
+def test_start_research_route_uses_current_best_path(client, monkeypatch):
+    resp = client.post("/briefs", data={"title": "Web path", "research_question": "What is X?"}, follow_redirects=False)
+    assert resp.status_code == 303
+    brief_id = int(resp.headers["location"].split("/")[-1])
+
+    monkeypatch.setattr(
+        "apd.web.routes.start_research_ollama_components",
+        lambda brief_id, db: RedirectResponse(url="/runs/123", status_code=303),
+    )
+
+    resp2 = client.post(f"/briefs/{brief_id}/start-research", follow_redirects=False)
+    assert resp2.status_code == 303
+    assert resp2.headers["location"] == "/runs/123"
+
+
+def test_start_research_stub_route_creates_run(client):
     resp = client.post("/briefs", data={"title": "Web stub", "research_question": "What is X?"}, follow_redirects=False)
     assert resp.status_code == 303
     location = resp.headers["location"]
-    # get brief id from redirect
     assert location.startswith("/briefs/")
     brief_id = int(location.split("/")[-1])
 
-    # invoke start research
-    resp2 = client.post(f"/briefs/{brief_id}/start-research", follow_redirects=True)
+    resp2 = client.post(f"/briefs/{brief_id}/start-research-stub", follow_redirects=True)
     assert resp2.status_code == 200
-    # Should redirect to run detail and show the run title
     assert "Web stub" in resp2.text
 
 
@@ -187,15 +199,17 @@ def test_settings_page_save_and_reload_persists_saved_values(client, monkeypatch
     assert 'value="llama3"' in response.text
 
 
-def test_brief_detail_shows_ollama_actions_from_saved_db_settings(client, monkeypatch):
+def test_brief_detail_shows_single_start_research_action_from_saved_db_settings(client, monkeypatch):
     _clear_ollama_env(monkeypatch)
     _save_ui_model_settings(client)
     brief_id = _create_brief_via_ui(client, title="DB-backed config brief")
 
     response = client.get(f"/briefs/{brief_id}")
     assert response.status_code == 200
-    assert "Start Research with Ollama" in response.text
-    assert "Start web-assisted research (prototype)" in response.text
+    assert response.text.count("Start Research") == 1
+    assert "Uses your configured local model to run APD's current autonomous research path." in response.text
+    assert "Start Research with Ollama" not in response.text
+    assert "Start web-assisted research (prototype)" not in response.text
     assert "Missing required env" not in response.text
 
 
@@ -447,7 +461,7 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
     assert "Use only the provided APD-captured source packet" in captured_payloads[0]["prompt"]
 
 
-def test_brief_detail_shows_grounded_action_when_captured_sources_exist(client, monkeypatch):
+def test_brief_detail_shows_grounding_context_without_extra_action_buttons(client, monkeypatch):
     _clear_ollama_env(monkeypatch)
     _save_ui_model_settings(client)
     brief_id = _create_brief_via_ui(client, title="Grounded action brief")
@@ -461,7 +475,8 @@ def test_brief_detail_shows_grounded_action_when_captured_sources_exist(client, 
 
     response = client.get(f"/briefs/{brief_id}")
     assert response.status_code == 200
-    assert "Start grounded component research" in response.text
+    assert "Captured grounding context available: 1 sources, 1 excerpts." in response.text
+    assert "Start grounded component research" not in response.text
 
 
 def test_web_assisted_research_records_web_discovery_phase_in_last_execution(client, monkeypatch):
@@ -515,8 +530,10 @@ def test_web_assisted_research_records_web_discovery_phase_in_last_execution(cli
     assert "Captured source" in response.text
     assert "solo operator maintenance pain" in response.text
     assert "Web discovery succeeded; component generation failed validation." in response.text
+    assert "Error summary" in response.text
     assert "Grounding status" in response.text
     assert "unknown grounded source_id" in response.text
+    assert "Show raw execution details" in response.text
 
 
 def test_execute_grounded_components_requires_captured_sources(db, monkeypatch):
@@ -1171,6 +1188,7 @@ def test_start_research_ollama_components_route_uses_mocked_service(client, monk
     resp2 = client.post(f"/briefs/{brief_id}/start-research-ollama-components", follow_redirects=True)
     assert resp2.status_code == 200
     assert "mocked components failure" in resp2.text
+    assert "Show raw execution details" in resp2.text
 
 
 def test_start_research_ollama_route_handles_missing_config(client, monkeypatch):
@@ -1194,7 +1212,7 @@ def test_stub_route_still_works_when_ollama_path_exists(client):
     assert resp.status_code == 303
     brief_id = int(resp.headers["location"].split("/")[-1])
 
-    resp2 = client.post(f"/briefs/{brief_id}/start-research", follow_redirects=True)
+    resp2 = client.post(f"/briefs/{brief_id}/start-research-stub", follow_redirects=True)
     assert resp2.status_code == 200
     assert "Stub still works" in resp2.text
 


### PR DESCRIPTION
Refs #65

## Summary
- simplify the brief detail page to one normal-user `Start Research` action with concise local-model helper copy
- route the primary brief action to the existing web-assisted grounded execution path while retaining older routes for debug/test use
- replace noisy inline execution JSON with readable phase summaries, wrapped error text, and collapsed raw details

## Files Changed
- `apd/web/routes.py`: route the primary `POST /briefs/{brief_id}/start-research` action to the current best existing execution path and keep the stub path on a separate retained debug route
- `apd/web/templates/brief_detail.html`: remove manual prompt/import workflow from the normal page, expose one primary action, and clean up last-execution rendering
- `apd/web/static/style.css`: add wrapped execution-summary and raw-details styling for the brief page
- `docs/briefs.md`: update the documented normal workflow to `Start Research` and move manual prompt/import flow to legacy/debug positioning
- `tests/test_research_briefs.py`: assert the simplified single-action brief detail UI and missing-settings prompt
- `tests/test_research_execution.py`: cover the primary route alias, retained stub debug route, and cleaned execution detail rendering

## Verification
Local:
- `uv run pytest tests/test_research_briefs.py tests/test_research_execution.py tests/test_web_research.py -q`
- `./scripts/test.ps1`
- `uv run python scripts/check_repo_readiness.py`

Manual local verification:
- created a brief in the browser and confirmed the brief detail page shows one obvious `Start Research` action when local model settings are configured
- confirmed the unconfigured brief page shows a concise prompt linking to `/settings/model-execution`
- confirmed manual prompt/import sections and extra execution buttons are gone from the normal brief detail flow
- triggered `Start Research` locally and confirmed the page shows readable phase/error summaries with raw details behind `Show raw execution details`

Notes:
- this PR is UI/workflow cleanup only
- no new model/provider capability was added
- old services/routes were retained unless explicitly repointed for the normal user-facing alias
- GitHub Actions had not completed at PR creation time