### PR TITLE
Document APD research harness architecture

### DIFF
--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -1,196 +1,150 @@
 # Research Briefs
 
-APD supports creating a small research brief and starting research directly from the brief detail page.
+Research briefs are the normal starting point for APD's local product-research workflow.
 
-Purpose
+The brief is where a user defines the product investigation direction. From there, the expected path is simple: configure local model settings if needed, click `Start Research`, let APD run the current bounded research flow, and then review the imported run.
 
-- Reduce friction between a research question and APD's autonomous local research workflow.
+## Overview
 
-Workflow
+Use a research brief when you want APD to investigate a product space, pain pattern, workflow, substitute, or opportunity question.
 
-1. Create a research brief in the APD UI under `/briefs`.
-2. Open the brief detail page and click `Start Research`.
-3. APD uses the configured local model to run the current autonomous research path internally.
-4. APD shows concise execution status on the brief detail page, including web discovery and component execution phases when applicable.
-5. If execution succeeds, APD redirects to the imported run. If execution fails, APD keeps the raw execution payload available behind a collapsed details disclosure.
+The brief should give APD:
 
-Notes
+- a clear research question
+- optional constraints
+- optional desired depth
+- optional expected outputs
+- optional notes or prior context
 
-- APD will import the package as draft/unreviewed research for human inspection and review.
-- The new brief form includes a local sample/randomizer for dogfooding. It does not call a model or save anything until you submit the brief form.
-- APD also supports optional model-generated brief ideation using configured local Ollama settings. These generated ideas are draft form prefills only, are not researched findings, do not perform web/source research, do not use hosted provider API keys, and are not saved until you submit the brief form.
-- The older prompt-copy / validate / normalize / import workflow is legacy/debug fallback only. It is no longer the normal brief-detail experience.
+APD treats the resulting research as draft and unreviewed until a person inspects it.
 
-Note: The run review UI is candidate-first — the run detail page surfaces product
-candidates before sources and reasoning so reviewers can prioritize candidate
-inspection and then trace claims/themes/gates back to supporting evidence.
-- A deterministic stub runner still exists for tests and debugging, but it is no longer the normal user-facing brief workflow.
+## Normal workflow
 
-## Local Ollama execution (Issue #46)
+1. Create a brief under `/briefs`.
+2. Configure local model settings at `/settings/model-execution` if they are not already saved.
+3. Open the brief detail page and click `Start Research`.
+4. Watch the brief detail page for concise execution status.
+5. If the run imports successfully, APD redirects to the new run.
+6. Review the run through the candidate-first review UI.
 
-APD now supports a local Ollama execution path from brief detail pages.
+This is the normal product path.
 
-Required environment variables:
+Manual prompt copy/paste and manual import still exist as legacy or debug support paths. They are not the main workflow.
+
+## Model settings
+
+APD currently supports a local Ollama-backed execution path.
+
+You can configure it at `/settings/model-execution`.
+
+Saved settings are stored in the APD database and are used by the brief-detail `Start Research` action. Environment variables still act as fallback values when database-backed settings are not present.
+
+Required settings for the current local path:
 
 - `APD_MODEL_PROVIDER=ollama`
 - `APD_OLLAMA_BASE_URL=http://localhost:11434`
 - `APD_OLLAMA_MODEL=<installed-model-name>`
 
-Optional:
+Optional settings include timeout, keep-alive, and component repair attempts.
 
-- `APD_OLLAMA_TIMEOUT_SECONDS` (default: `120`)
-- `APD_OLLAMA_REPAIR_ATTEMPTS` (default: `1`, capped at one repair call)
-- `APD_OLLAMA_KEEP_ALIVE` (default: `0`, unload model after each APD run to free GPU/VRAM)
+If required settings are missing, the brief detail page shows a concise prompt linking to the settings page instead of trying to run a research execution.
 
-Behavior:
+## What `Start Research` does
 
-- APD calls local Ollama `POST /api/generate` with `stream=false`.
-- APD extracts JSON from the model output using a narrow parser:
-  1) full output as JSON,
-  2) fenced ```json block,
-  3) substring from first `{` to last `}`,
-  4) otherwise parse failure.
-- APD validates strictly, applies safe normalization for common near-miss fields, and attempts at most one repair call.
-- APD imports only when strict validation and a minimal product-quality gate pass.
-- Schema-valid output is not automatically product-useful. APD rejects zero-candidate local runs with `quality_failed_no_candidates`.
-- If local output includes source URLs without provided source context, APD records a quality warning (`quality_warning_unprovided_source_urls`).
-- Brief metadata stores concise execution diagnostics under `metadata_json.last_execution`.
-- APD sends Ollama requests with `keep_alive: 0` by default so local model resources are released after execution.
- - APD keeps the model warm during a single execution (generation/repair/component phases), then unloads at the end by default.
- - If `APD_OLLAMA_KEEP_ALIVE` is explicitly set to a non-zero value, APD respects that and does not force an unload.
+`Start Research` routes to APD's current best local autonomous path.
 
-Limitations:
+Today that means:
 
-- Ollama only. No other provider integrations are included in this path.
-- No streaming, background jobs, source fetching, or external publishing.
-- Local/Ollama runs should not invent sources, URLs, citations, or claims of fetched web evidence.
-- Tests mock Ollama calls; live Ollama verification is manual.
+1. APD sends the brief to the local model for web discovery planning.
+2. The model proposes a small JSON list of search queries and direct URLs.
+3. APD validates the proposed URLs and fetches only safe public targets.
+4. APD stores captured material as APD-owned `Source` and `EvidenceExcerpt` records.
+5. APD builds a bounded grounding packet from captured sources.
+6. APD runs grounded component execution against that packet.
+7. APD validates, repairs, and imports the result only if it passes schema, quality, and grounding checks.
 
-## APD-orchestrated web discovery phase (Issue #62)
+This path is synchronous and local-first. It does not do unrestricted browsing, background jobs, or hosted provider calls.
 
-APD now includes a controlled web discovery phase inside the website execution prototype.
+## Execution results and failure states
 
-Intended workflow:
+The brief detail page stores and displays a concise `last_execution` summary.
 
-1. Create a research brief.
-2. Start one research execution.
-3. APD runs an internal web discovery phase.
-4. The local model proposes a small JSON list of search queries and direct public URLs.
-5. APD validates and fetches only explicit public URLs that pass safety checks.
-6. APD stores captured pages as APD-owned `Source` and `EvidenceExcerpt` records where feasible.
-7. Execution continues into component generation.
+The page prioritizes:
 
-Current prototype behavior:
+- overall status
+- web discovery phase status
+- captured source count
+- component execution phase status
+- grounding status when relevant
+- readable error summaries
 
-- The brief detail page exposes one primary `Start Research` action for normal users.
-- `Start Research` routes to APD's current best local execution path: web discovery followed by grounded component execution.
-- Execution metadata records web discovery and component execution as separate phases under `metadata_json.last_execution`.
-- Captured sources are shown as part of execution status, not as a separate user prerequisite step.
-- Grounded component execution builds a bounded source packet from APD-captured `Source` and `EvidenceExcerpt` rows.
-- APD validates that model-generated `evidence_link.added` events only reference known captured `source_id` and `excerpt_id` values.
-- APD rejects grounded batches that invent source URLs, invent source/excerpt IDs, or produce claims without at least one supporting grounded evidence link.
-- This is grounding-by-reference only. APD does not verify that captured excerpts make generated claims true.
-- Brief execution status now prioritizes readable phase summaries and error summaries, with raw execution JSON collapsed behind a disclosure.
+Raw execution JSON is secondary debug material. It remains available behind a collapsed details disclosure.
 
-Safety and budget controls:
+Common execution outcomes include:
 
-- This is not free browsing.
-- No crawling beyond explicit proposed URLs.
-- No authenticated or private sources.
-- No localhost, loopback, or private-network targets.
-- Only validated public `http` or `https` URLs are fetched.
-- Max model-proposed queries: `5`
-- Max fetched URLs per run: `5`
-- Small fixed timeout and response/text caps are enforced in code.
+- configuration missing
+- provider error
+- parse failure
+- validation failure
+- grounded validation failure
+- import success
 
-Notes:
+When web discovery succeeds but component execution fails later, the brief detail page should still make that phase split clear rather than forcing the user to read raw JSON.
 
-- Proposed queries are stored in execution status for future search-provider integration, but this issue only fetches direct validated URLs.
-- Captured web sources remain draft research material for later human review.
-- Because sources are still run-scoped in the current schema, APD creates a small capture run for the brief and records the originating `brief_id` in metadata.
-- Tests mock both model output and HTTP fetches; no live network access is required.
+## Candidate-first review
 
-## UI-managed local model settings (Issue #55)
+If APD imports the run successfully, the main next step is run review.
 
-APD now includes a Settings page at `/settings/model-execution` for local model execution configuration.
+APD's run detail UI is candidate-first. The intent is that the reviewer starts with candidate product wedges, then drills down into claims, themes, gates, and evidence links.
 
-What changed:
+This matters because APD is trying to support product judgment, not just source collection. Research is only useful if the user can decide what to believe, what to validate next, and what to reject or park.
 
-- PowerShell `$env:` values are process-scoped and temporary unless persisted in a profile.
-- You can save local/Ollama execution settings from the APD UI.
-- Saved settings are stored in the APD database (`app_settings`) and persist across app restarts.
-- Environment variables remain fallback values when DB settings are not present.
-- This feature stores non-secret local settings only.
-- Hosted provider API keys are not implemented by this feature.
+## Legacy or debug manual import
 
-Testing notes:
+APD still supports a manual draft-import workflow for debugging and external-agent experiments.
 
-- Tests for this feature use local DB state and mocked execution paths.
-- No live Ollama calls are required in tests.
+That path is useful when you want to:
 
-## Component-based execution prototype (Issue #51)
+- import a hand-authored or externally generated APD draft package
+- inspect validation behavior directly
+- exercise import tooling without running the local model path
 
-APD now includes an experimental component-based execution path that uses a provider-agnostic event contract.
+The rough flow is:
 
-Why this exists:
+1. create or obtain an APD draft JSON package
+2. validate it with APD tooling
+3. optionally normalize near-miss fields
+4. import it into APD
 
-- Monolithic draft JSON generation is brittle across models.
-- Component batches let APD validate smaller typed events before final import.
-- APD still assembles a standard APD draft package and uses strict draft validation/import as the final gate.
+Validation commands:
 
-What this is:
+```bash
+uv run python scripts/validate_agent_draft.py --path <draft.json> --repair-hints
+uv run python scripts/normalize_agent_draft.py --path <draft.json> --out <normalized.json>
+uv run python scripts/import_agent_draft.py --path <normalized.json>
+```
 
-- A synchronous brief workflow exposed as `Start Research`.
-- A web-assisted grounded execution path that reuses APD-captured web sources internally.
-- Provider-agnostic schema names (`ResearchComponentEvent`, `ResearchComponentBatch`, `ComponentDraftAssembler`).
-- Ollama is the first adapter implementation.
+This is a legacy or debug-support path. It should not be treated as the main brief-detail experience.
 
-What this is not:
+## Safety notes
 
-- Not browser streaming.
-- Not WebSockets or SSE.
-- Not background jobs.
-- Not a provider registry.
+The current brief-driven execution path follows these rules:
 
-Current component minimum:
+- APD fetches only validated public `http` and `https` URLs
+- APD does not allow localhost, loopback, private IPs, or credentialed URLs
+- APD does not crawl beyond explicit proposed URLs
+- APD does not bypass authentication, paywalls, or access controls
+- grounded source references are validation signals, not truth verification
+- imported research remains draft until a human reviews it
 
-- Supports candidate, claim, and theme events (plus optional source/excerpt/gate/link events).
-- Rejects zero-candidate assembled output before import.
-- In grounded mode, seeds captured sources/excerpts into the assembled package so evidence links resolve through normal draft import.
-- In grounded mode, allows only APD-provided source/excerpt identifiers and blocks invented URL-like citations.
-- Uses the same keep-alive behavior (`keep_alive: 0` default) to free local model resources after execution.
+## Testing notes
 
-## Component repair and retry loop (Issue #53)
+Automated tests for the brief workflow mock:
 
-Component execution now runs as small APD-orchestrated phases instead of trusting a single batch:
+- local model output
+- web-fetch behavior
+- execution success and failure paths
 
-- `candidate_batch` (required, must include at least one `candidate.proposed`)
-- `claim_theme_batch` (must include `claim.proposed` and/or `theme.proposed`)
-- `validation_gate_batch` (must include `validation_gate.proposed`)
+Tests do not require live Ollama or live web access.
 
-For each phase APD:
-
-- sends a phase-specific component prompt,
-- parses and validates the `ResearchComponentBatch`,
-- checks phase-specific required content,
-- retries with a repair prompt when invalid, including concise validation errors,
-- applies only valid batches to the assembler.
-
-Retry cap:
-
-- `APD_COMPONENT_REPAIR_ATTEMPTS` (default `2`, capped at `3`)
-- total attempts per phase are `1 + repair_attempts`
-
-Execution diagnostics in `ResearchBrief.metadata_json.last_execution` include:
-
-- `mode: component_execution`
-- `status`
-- `last_phase`
-- `attempts_by_phase`
-- concise `errors` and `warnings`
-
-This remains a synchronous prototype path:
-
-- no browser streaming
-- no WebSockets/SSE
-- no background jobs
+Manual verification remains useful for UI sanity checks, but raw execution details should only be needed when debugging a failure rather than understanding the normal user workflow.

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -7,8 +7,8 @@ Its job is not to be a generic research archive or a generic coding agent wrappe
 The central product loop is:
 
 1. A user enters a product investigation direction.
-2. An agent produces a draft research map: sources, excerpts, claims, themes, candidates, validation gates, and evidence links.
-3. APD imports that draft as unreviewed structured research.
+2. APD runs or imports a structured research flow that produces sources, excerpts, claims, themes, candidates, validation gates, and evidence links.
+3. APD imports that result as unreviewed structured research.
 4. The user reviews the reasoning chain from product candidates back to evidence.
 5. The user accepts, disputes, dismisses, or requests follow-up on parts of the map.
 6. APD converts that review into next actions: follow-up research, candidate validation, prototype brief, no-go decision, or build approval.
@@ -26,6 +26,10 @@ The differentiation is not simply that an LLM can research or write code. The di
 - It preserves decisions and follow-up needs.
 - It can eventually turn a validated candidate into a prototype brief or scaffolded project.
 
+APD should therefore be understood as the research harness around the model, not as a thin wrapper over model output. The model is one worker inside APD's loop. The product value comes from the harness: phase progression, constrained tool use, validation, persistence, observability, and human review.
+
+For the concrete harness view, see [Research Harness Architecture](research-harness-architecture.md).
+
 ## Primary user job
 
 The user starts from a question like:
@@ -42,6 +46,8 @@ APD should help them:
 - trace claims back to sources and evidence excerpts
 - separate supported claims from weak or disputed ones
 - decide which candidate deserves more validation or prototyping
+
+The normal product path should therefore feel like a guided investigation workflow. A user should not need to assemble their own prompts, source permissions, or agent graph in order to get useful product research out of APD.
 
 ## Product scope
 
@@ -84,3 +90,12 @@ The key is that build-forward work should be grounded in reviewed product reason
 ## Current constraint
 
 APD is currently local-first and single-user. It should continue to support dogfooding locally while avoiding design choices that block future hosted or multi-user versions.
+
+Current runtime direction:
+
+- the user creates a brief
+- APD starts research from that brief
+- APD owns the outer loop for web discovery, source capture, grounded generation, validation, and import
+- the user reviews the resulting run through candidate-first UI surfaces
+
+Manual prompt copy/paste and direct draft import may remain as legacy or debug paths, but they should not define the main product story.

--- a/docs/explanation/research-harness-architecture.md
+++ b/docs/explanation/research-harness-architecture.md
@@ -1,0 +1,529 @@
+# APD Research Harness Architecture
+
+APD is becoming a guided product-research harness.
+
+That means APD is not just a UI around model output, and it is not a generic agent framework that asks the user to wire together prompts, tools, permissions, and review flow. APD owns the working research loop for product investigation: it frames the job, constrains the tools, assembles the context, validates the outputs, persists the evidence, and presents the results for human review.
+
+The model is a worker inside that harness. It is not the whole product.
+
+## What APD is becoming
+
+APD should help a user move from a product investigation question to a structured, evidence-linked product opportunity map.
+
+In practical repo terms, the intended loop is:
+
+1. A user creates a research brief.
+2. APD starts a bounded research execution from that brief.
+3. APD runs controlled web discovery and source capture.
+4. APD uses captured sources to drive grounded component generation.
+5. APD validates, repairs, and imports structured research objects.
+6. The user reviews candidates, claims, themes, gates, and evidence links.
+7. APD preserves review outcomes and turns them into next actions later.
+
+APD is not becoming:
+
+- a generic browser automation tool
+- a generic RAG workspace
+- a generic notes app
+- a free-form agent graph builder
+- a generic coding agent shell
+
+APD may eventually use skills, evals, traces, and provider abstractions that resemble broader agent systems, but those capabilities should stay in service of product research rather than turn APD into a general-purpose orchestration framework.
+
+## Harness vs framework
+
+A framework gives a developer parts to assemble.
+
+A harness gives a user or implementer an already-working execution environment with a fixed loop, fixed boundaries, and clear observability.
+
+For APD, that distinction matters.
+
+A framework-style product would expect the user to choose or assemble:
+
+- the research phases
+- the prompts
+- the tools
+- the safety rules
+- the source permissions
+- the validation logic
+- the repair loop
+- the review model
+
+A harness-style product should already provide those things.
+
+APD should therefore own:
+
+- the outer research loop
+- phase progression and state handoff
+- tool boundaries and budgets
+- context assembly for each phase
+- skill discovery and injection
+- model/provider calls
+- validation and repair
+- source and evidence persistence
+- execution traces and replay context
+- evals and model scorecards
+- the human review surface
+
+The practical test is simple: a user should not have to invent an agent architecture in order to do product research inside APD. The harness should already know how product research runs.
+
+## Current product loop
+
+Today, the concrete product loop in the repo is:
+
+1. Create a research brief.
+2. Click `Start Research`.
+3. APD runs web discovery.
+4. APD validates and fetches safe public URLs.
+5. APD stores `Source` and `EvidenceExcerpt` records.
+6. APD runs grounded component execution against a bounded source packet.
+7. APD validates, repairs, and imports draft research objects.
+8. The user reviews the imported run through the candidate-first run detail UI.
+
+That loop is still early, but it is already harness behavior. The runtime is no longer just "copy a prompt into another tool and import a JSON file later."
+
+Manual draft import still exists as a legacy or debug path. It should not define the main architectural story anymore.
+
+## Intended research phases
+
+The current implementation groups some work into broader runtime steps such as web discovery and three component batches. The longer-term harness should still think in more explicit research phases, even when multiple phases are currently collapsed into one prompt or one service call.
+
+These phases are conceptual harness phases, not a promise that every phase maps 1:1 to a separate function or model call today.
+
+### `brief_framing`
+
+Purpose:
+- turn a raw product curiosity into a bounded research brief with a clear question, constraints, expected outputs, and non-goals
+
+Model role:
+- optionally help refine wording, sharpen ambiguity, or propose a better framing
+
+APD harness role:
+- persist the brief, keep the user-visible framing surface simple, and decide whether the brief is strong enough to start research
+
+Expected output objects:
+- `ResearchBrief`
+- optional brief clarification metadata later
+
+Validation and safety checks:
+- title and research question present
+- product-investigation orientation remains clear
+- no external actions or source access yet
+
+### `research_planning`
+
+Purpose:
+- decide what kinds of evidence the run should seek before synthesis begins
+
+Model role:
+- propose research directions, target source types, and likely evidence needs
+
+APD harness role:
+- constrain planning to product research, select relevant skills, and keep the plan bounded by time, source, and context budgets
+
+Expected output objects:
+- planning summary metadata
+- future trace events and skill selections
+
+Validation and safety checks:
+- no tool execution yet
+- plan stays within allowed source and budget boundaries
+
+### `web_discovery`
+
+Purpose:
+- identify explicit public web targets relevant to the brief
+
+Model role:
+- propose search queries and direct URLs
+
+APD harness role:
+- request JSON only, validate structure, reject unsafe URLs, enforce caps, and decide what actually gets fetched
+
+Expected output objects:
+- proposed query list
+- proposed URL list
+- web discovery execution metadata
+
+Validation and safety checks:
+- public `http` or `https` only
+- no localhost, loopback, private IPs, credentials, or authenticated sources
+- no uncontrolled crawling
+- small fixed budgets for query count, URL count, timeouts, and response size
+
+### `source_triage`
+
+Purpose:
+- decide which fetched material is relevant enough to keep in the run context
+
+Model role:
+- later: help identify high-value or low-value sources
+
+APD harness role:
+- persist all captured material that passed safety checks, track fetch failures and rejected targets, and later choose which sources enter the active source packet
+
+Expected output objects:
+- `Source`
+- source-level summaries or triage annotations later
+
+Validation and safety checks:
+- source metadata remains APD-owned
+- rejected or failed fetches remain observable
+- triage does not silently discard safety-relevant history
+
+### `evidence_extraction`
+
+Purpose:
+- turn fetched source text into bounded, reusable evidence snippets
+
+Model role:
+- later: propose better excerpt selection or evidence clustering
+
+APD harness role:
+- extract readable text deterministically at first, create excerpts, and keep excerpt size within prompt budgets
+
+Expected output objects:
+- `EvidenceExcerpt`
+- bounded source packet material for later phases
+
+Validation and safety checks:
+- excerpt size caps
+- excerpt-to-source linkage preserved
+- extraction is traceable back to the captured source
+
+### `grounded_claim_generation`
+
+Purpose:
+- produce specific claims about pains, workflows, substitutes, and opportunity conditions using captured evidence
+
+Model role:
+- generate claims and evidence-link events grounded in the source packet
+
+APD harness role:
+- inject only the relevant source packet and skills, require structured component output, reject invented citations, and require grounded support for claims in grounded mode
+
+Expected output objects:
+- `Claim`
+- `EvidenceLink`
+
+Validation and safety checks:
+- known `source_id` and `excerpt_id` only
+- no invented URLs
+- at least some grounded supporting evidence in grounded mode
+
+### `theme_synthesis`
+
+Purpose:
+- cluster repeated pains, needs, and behavior patterns into reviewable themes
+
+Model role:
+- synthesize recurring patterns from grounded claims and excerpts
+
+APD harness role:
+- keep theme prompts bounded, preserve traceability to claims and evidence, and avoid letting themes become detached from support
+
+Expected output objects:
+- `Theme`
+- supporting `EvidenceLink` and relationship objects later
+
+Validation and safety checks:
+- themes remain connected to grounded claims or evidence
+- synthesis does not replace traceability
+
+### `candidate_generation`
+
+Purpose:
+- propose concrete product wedges the user can review, reject, park, validate, or promote later
+
+Model role:
+- generate candidate wedges from grounded patterns, workflows, and user pains
+
+APD harness role:
+- enforce a candidate-first output shape, require at least one candidate for product-oriented runs, and keep candidate metadata structured enough for later review and build-forward handoff
+
+Expected output objects:
+- `Candidate`
+
+Validation and safety checks:
+- zero-candidate runs fail the product-quality gate
+- candidates must stay product-investigation oriented rather than generic summaries
+
+### `validation_gate_generation`
+
+Purpose:
+- identify what must still be learned before a candidate can credibly advance
+
+Model role:
+- propose concrete validation gates tied to candidates and research maturity
+
+APD harness role:
+- keep gates phase-aware, candidate-linked where possible, and reviewable later
+
+Expected output objects:
+- `ValidationGate`
+
+Validation and safety checks:
+- phase values stay within APD's maturity model
+- gate output remains structured and specific
+
+### `audit_gap_analysis`
+
+Purpose:
+- identify missing evidence, overreach, unsupported synthesis, or next research gaps before import or promotion
+
+Model role:
+- later: summarize uncertainty and evidence gaps explicitly
+
+APD harness role:
+- compare outputs against grounding, validation errors, trace data, and future eval expectations
+
+Expected output objects:
+- gap analysis metadata
+- follow-up recommendations later
+
+Validation and safety checks:
+- unsupported claims are not silently treated as reliable research
+- audit findings stay attached to the run and can feed follow-up work
+
+### `import`
+
+Purpose:
+- convert validated structured output into APD's durable domain objects
+
+Model role:
+- none; import is a harness boundary
+
+APD harness role:
+- validate schema, run quality gates, map source and excerpt IDs, import objects transactionally, and fail clearly when the package is invalid
+
+Expected output objects:
+- `Run`
+- imported `Source`, `EvidenceExcerpt`, `Claim`, `Theme`, `Candidate`, `ValidationGate`, and `EvidenceLink` rows
+
+Validation and safety checks:
+- strict schema validation
+- import only after quality and grounding checks pass
+- duplicate handling and import warnings remain visible
+
+### `human_review`
+
+Purpose:
+- turn model-generated research into reviewed product judgment
+
+Model role:
+- none by default; human review is first-class, not an optional cleanup step
+
+APD harness role:
+- present candidate-first reasoning, preserve review notes and decisions, and distinguish unreviewed draft output from accepted knowledge
+
+Expected output objects:
+- review notes
+- review statuses
+- run and candidate decisions
+
+Validation and safety checks:
+- no generated output is treated as accepted truth by default
+- review state becomes durable product memory later
+
+### `follow_up_generation`
+
+Purpose:
+- turn review outcomes into concrete next actions
+
+Model role:
+- later: propose follow-up research, validation plans, or prototype-brief seeds
+
+APD harness role:
+- ensure follow-up work is grounded in reviewed outcomes rather than raw synthesis
+
+Expected output objects:
+- follow-up tasks
+- validation briefs later
+- prototype briefs later
+
+Validation and safety checks:
+- build-forward outputs depend on human decisions, not just model enthusiasm
+
+## Research tools
+
+APD-controlled research tools are constrained capabilities, not model freedoms.
+
+Current or near-term tools include:
+
+- propose search queries
+- propose direct URLs
+- validate public URLs
+- fetch public URLs
+- extract title and readable text
+- create `Source`
+- create `EvidenceExcerpt`
+- build bounded grounding packets
+- generate component batches
+- validate grounding references
+- validate and import a run
+- export reports later
+
+The key rule is consistent across all of them:
+
+- the model proposes
+- APD validates and executes
+- APD persists the result
+- APD decides what becomes usable context for later phases
+
+The model should not browse freely, fetch arbitrary URLs, or decide its own permissions. APD should enforce budgets, safety, and persistence around every tool boundary.
+
+## Skills
+
+In APD, skills should be operational instructions, not passive documentation.
+
+That means a skill should describe how to perform a specific research task inside a specific phase, with concrete inputs, output contracts, quality checks, and failure modes.
+
+Future skill work should follow these rules:
+
+- skills are small and phase-specific
+- skills are discoverable through a manifest
+- skills declare their expected inputs and outputs
+- skills are injected only when relevant to the current phase
+- APD does not dump the entire skill tree into every prompt
+
+Issue #69 introduces the initial skill tree and manifest. Issue #70 should make skill selection and prompt injection part of the harness runtime.
+
+## Context assembly
+
+The harness is responsible for assembling prompt context for each phase.
+
+That context should be compact and targeted. At a minimum, APD should be able to assemble some combination of:
+
+- brief data
+- the current phase objective
+- selected skills
+- bounded source packet or excerpts
+- prior phase summary
+- validation errors and repair feedback
+- output schema or component contract
+- safety constraints and tool limits
+
+Context assembly should be phase-aware and budget-aware.
+
+APD should not:
+
+- dump the full corpus into every prompt
+- dump the whole skill tree into every prompt
+- include every prior artifact by default
+- let repair prompts grow without bounds
+
+Compact prompts are not just a cost concern. They are part of harness correctness. They reduce confusion, make failures easier to interpret, and create cleaner traces for later evals.
+
+## Permission and safety layer
+
+The harness should own a strict permission and safety posture.
+
+Current rules already visible in the repo include:
+
+- only APD-validated public `http` and `https` URLs may be fetched
+- no localhost, loopback, private-network targets, or credentialed URLs
+- no authenticated or paywalled bypass behavior
+- no crawling beyond explicit URLs by default
+- no hosted APIs unless they are intentionally added later
+- no source-grounding claim should be treated as truth verification
+
+Safety in APD should be practical and enforceable.
+
+The harness should never rely on prompt text alone to stop unsafe behavior. Prompts can ask the model to behave, but APD must still validate tool requests, reject unsafe inputs, and persist the rejection reasons where useful.
+
+## Trace and session persistence
+
+Every meaningful research execution should become observable.
+
+Traces matter because they make it possible to:
+
+- debug failures
+- inspect why the model or harness made a choice
+- reproduce or replay parts of a run later
+- compare harness changes across versions
+- support evals and model scorecards
+- make research generation auditable rather than mystical
+
+Issue #71 should add a durable research trace or event log for phase starts, tool calls, model calls, validation failures, repair attempts, source capture, and import outcomes.
+
+The architecture point is larger than one storage choice: APD should treat traces as first-class harness data, not as incidental debug printouts.
+
+## Evals and scorecards
+
+APD should eventually measure research quality across separate dimensions instead of treating "looked good in dogfooding" as enough.
+
+Important dimensions include:
+
+- source discovery and retrieval quality
+- source safety and rejection behavior
+- source triage quality
+- evidence extraction quality
+- grounding and citation faithfulness
+- schema reliability
+- synthesis quality
+- product usefulness
+- review and actionability quality
+- runtime cost, latency, and retry rate
+
+Issue #72 should add a controlled eval harness with fixture sources or a mini-web. Issue #73 should add model and harness scorecards that summarize those results across runs or configurations.
+
+The harness should therefore be designed so that phases, tool boundaries, validation outcomes, and trace data can feed evals later without re-architecting the whole runtime.
+
+## Human review inside the harness
+
+Human review is not outside the harness. It is part of the harness.
+
+Generated research in APD remains draft and unreviewed until a person evaluates it.
+
+Human review should therefore:
+
+- accept, dispute, weaken, or dismiss claims
+- evaluate themes and candidates in context
+- set run and candidate dispositions
+- drive follow-up research rather than just annotate reports
+- eventually become a signal for evals and accepted knowledge
+
+This matters because APD is not trying to produce a final answer and hide its uncertainty. It is trying to produce structured research that a person can inspect and decide what to do with.
+
+## Near-term architecture map
+
+### Current baseline
+
+APD already has:
+
+- local model settings
+- a single `Start Research` UI entry point
+- controlled web discovery
+- safe public URL validation and fetch
+- source and excerpt capture
+- grounded component execution using captured sources
+- validation, repair, and import gates
+- candidate-first run review
+
+### Next harness-maturity steps
+
+The next architectural work should focus on making that loop more explicit, observable, and reusable:
+
+- research harness architecture docs (#68)
+- research skill tree and manifest (#69)
+- skill discovery and phase prompt injection (#70)
+- research trace and event log (#71)
+- controlled research eval harness (#72)
+- model and harness scorecards (#73)
+- deterministic browser smoke coverage for the primary brief workflow (#74)
+- broader corpus, review, follow-up, and build-forward workflows after the harness core is stable
+
+## Design posture
+
+When extending APD from here, prefer changes that make the harness more explicit rather than more magical.
+
+Good questions to ask before implementation work:
+
+- Which phase is this change part of?
+- What tool boundary does APD own here?
+- What context should the model see, and what should it not see?
+- What validation or repair gate protects this step?
+- What data should be persisted for traceability or evals?
+- How will a human inspect the result later?
+
+If a proposed feature makes the runtime harder to audit, harder to bound, or more reliant on model vibes, it is probably pushing APD away from the harness architecture rather than toward it.

--- a/docs/planning/open-questions.md
+++ b/docs/planning/open-questions.md
@@ -109,11 +109,11 @@ Current leaning:
 
 ### Should APD run the model, or only coordinate external agents?
 
-Near-term workflow:
+Current state:
 
-- APD creates a research brief and generated prompt.
-- The user runs an external agent manually.
-- The user imports or pastes the returned draft package.
+- APD already runs a local-first harness path from a brief.
+- The normal flow is brief -> `Start Research` -> controlled web discovery -> source capture -> grounded component execution -> import.
+- Manual prompt/import remains a legacy or debug-support workflow, not the primary product loop.
 
 Future options:
 
@@ -123,9 +123,11 @@ Future options:
 
 Open questions:
 
-- What is the first model provider worth integrating?
-- Should users bring their own API keys?
-- How should APD enforce source permissions before it has real multi-user auth?
+- How much of the runtime should stay in a fixed APD-owned harness versus becoming provider-pluggable?
+- What is the first additional provider worth integrating, if any?
+- Should users bring their own API keys, or should APD stay local-first longer?
+- How should APD enforce source permissions and tool boundaries before it has real multi-user auth?
+- Which execution details must become durable traces in order to support replay and evals later?
 
 ## Source access and integrations
 

--- a/docs/planning/post-mvp-roadmap.md
+++ b/docs/planning/post-mvp-roadmap.md
@@ -1,144 +1,135 @@
 # Post-MVP roadmap
 
-This roadmap starts from the current local APD cockpit: a single-user app that can import structured agent drafts, display runs, support human review, record decisions, export reports, and link legacy artifacts.
+This roadmap starts from APD's current local-first baseline: a product-research harness that can start from a brief, run a bounded research loop, import structured output, and present the results for candidate-first review.
 
-The next phase is to turn that cockpit into a product investigation workflow.
+The roadmap should no longer treat manual prompt copy/paste as the main product path. That workflow still exists as a legacy or debug fallback, but the architectural direction is now harness maturity: APD owns the research loop, the tool boundaries, the validation gates, and the review surface.
 
 ## North star
 
-APD should help a user move from a product research question to a reviewed product opportunity and then, when appropriate, to a prototype brief or scaffolded project.
+APD should help a user move from a product research question to a reviewed product opportunity and then, when appropriate, to follow-up research, a validation brief, or a build-forward handoff.
 
-The product loop is:
+The target loop is:
 
-1. Create a research direction.
-2. Generate or import an agent draft.
-3. Review the candidate-centered reasoning chain.
-4. Accept, dispute, dismiss, or request follow-up on claims and themes.
-5. Promote, park, or reject candidates.
-6. Generate follow-up research tasks or a prototype brief.
-7. Preserve reviewed knowledge in the corpus.
+1. Create a research brief.
+2. Click `Start Research`.
+3. Let APD run a bounded research harness with explicit phases, tools, and safety checks.
+4. Review the resulting candidate-centered reasoning chain.
+5. Accept, dispute, dismiss, or request follow-up on the generated research.
+6. Preserve reviewed knowledge in the corpus.
+7. Generate follow-up tasks or build-forward artifacts only after review.
 
-## Phase 1: Make the dogfood loop ergonomic
+## Current baseline
 
-Goal: reduce friction between research question, agent output, and APD review.
+APD already has the minimum viable harness loop for local dogfooding:
 
-Relevant issues:
+- single `Start Research` brief workflow (#65)
+- local model settings (#55)
+- controlled web discovery and source capture (#62)
+- grounded component execution from captured sources (#63)
+- candidate-first run review (#35)
 
-- #31 Add research brief creation UI and generated agent prompt
-- #32 Add browser-based agent draft import flow
-- #34 Add agent draft validation and repair workflow
+That means the next phase is not "make APD run models at all." The next phase is to make the existing harness architecture explicit, observable, and extensible.
 
-Expected result:
+## Near-term harness maturity order
 
-A user can create a research brief in APD, copy a generated prompt to an external agent, paste the returned draft JSON back into APD, repair/validate it when needed, and immediately review the imported run.
+The recommended near-term order is:
 
-This is still not a fully automated agent runner. It is the minimum product-like workflow before APD starts calling models itself.
+1. #65 Single `Start Research` workflow and brief UI cleanup.
+2. #62 and #63 Web-assisted and source-grounded execution.
+3. #68 Research harness architecture docs and roadmap alignment.
+4. #69 Research skill tree and manifest.
+5. #70 Skill discovery and injection into phase prompts.
+6. #71 Research trace and event log.
+7. #72 Controlled research eval harness.
+8. #73 Model and harness scorecards.
+9. #74 Deterministic browser smoke coverage for the primary brief workflow.
+10. #22 Corpus browser and accepted-knowledge surfaces.
+11. #38, #39, #40, and #41 Review semantics, reasoning relationships, follow-up tasks, and candidate promotion refinements.
+12. Build-forward handoff: validation briefs, prototype briefs, requirements, issue drafts, and scaffolded project outputs.
 
-## Phase 2: Make run review candidate-centered
+This ordering reflects a practical dependency chain:
 
-Goal: make APD feel like a product investigation cockpit rather than a structured report viewer.
+- document the harness
+- define the skill layer
+- inject skills into the loop
+- add traceability
+- add evals
+- add scorecards
+- then expand corpus and post-review workflows on top of a measurable runtime
 
-Relevant issues:
+## Legacy baseline work
 
-- #35 Improve run detail UI for product-research review workflow
-- #38 Add explicit reasoning relationship model
-- #39 Add theme review surface and semantics
-- #40 Refine candidate review and promotion workflow
+Completed or baseline work that should remain supported, but no longer define the main product story:
 
-Expected result:
+- #31 Research brief creation UI
+- #32 Browser-based draft import flow
+- #34 Agent draft validation and repair workflow
 
-The user starts with product candidates, then drills down into validation gates, themes, claims, and evidence. The review actions fit the object being reviewed: claims are accepted/disputed/dismissed; themes are supported/weak/merged; candidates are rejected, watched, validated, prototyped later, or approved for build-forward work.
+Those paths still matter for testing, debugging, or importing externally created drafts. They should be documented as supporting workflows, not as the architectural center of APD.
 
-## Phase 3: Turn review into next actions
+## Harness maturity workstream
 
-Goal: make human review feed the next research or product-development loop.
+### Phase A: Make the harness explicit
 
-Relevant issues:
-
-- #41 Generate follow-up research tasks from review feedback
-- future issue: generate validation brief from candidate gates
-- future issue: generate prototype brief from promoted candidate
-
-Expected result:
-
-A disputed claim can become a follow-up research task. A weak theme can request more evidence. A candidate marked validate_next can produce validation questions, source requests, or interview prompts. A candidate marked prototype_later or build_approved can produce a prototype brief.
-
-## Phase 4: Make the corpus first-class
-
-Goal: make accumulated research inspectable and reusable across runs.
-
-Relevant issues:
-
-- #22 Add corpus browser as first-class product surface
-- future issue: define accepted knowledge layer
-- future issue: search across runs and reviewed knowledge
-- future issue: show related runs, recurring themes, and repeated candidates
-
-Expected result:
-
-APD is no longer only a run viewer. It becomes a workspace where sources, claims, themes, candidates, review states, decisions, and artifacts can be inspected across runs.
-
-Accepted or supported knowledge should be visually distinct from unreviewed draft output.
-
-## Phase 5: Add research contexts and source ingestion
-
-Goal: let users prime research runs with selected data sources.
+Goal:
+- document the runtime as a harness with fixed phases, tools, context assembly, safety rules, traces, and review boundaries
 
 Relevant issues:
-
-- #23 Add source pack model for reusable research contexts
-- #24 Add public URL source ingestion
-- #28 Add research brief and run config model
-- future issue: uploaded-file source ingestion
-- future issue: GitHub repository or issue source ingestion
+- #68 Research harness architecture docs
+- #69 Research skill tree and manifest
+- #70 Skill discovery and prompt integration
 
 Expected result:
+- future implementers understand that APD owns the outer research loop and the model operates inside that loop
 
-A user can define a source pack, create a research brief, and tell an external or future internal agent what sources are allowed for a run. Source access should be explicit and scoped, not global.
+### Phase B: Make the harness observable and measurable
 
-## Phase 6: Prepare for model/provider integrations
-
-Goal: avoid hardcoding APD to one AI provider or runtime.
+Goal:
+- make research executions inspectable, replayable, and comparable across harness or model changes
 
 Relevant issues:
-
-- #25 Add model provider abstraction design and local stubs
-- #33 Add future local agent runner design and stub
-- #26 Design workspace and user boundary for future multi-user APD
+- #71 Research trace/event log
+- #72 Research eval harness
+- #73 Model scorecards
+- #74 Browser smoke coverage
 
 Expected result:
+- APD can explain what happened during a run, compare harness changes across versions, and measure research quality beyond vibes
 
-APD has clear boundaries for model providers, source access, and user/workspace ownership. It remains local-first now, but does not paint itself into a corner if a hosted or multi-user version becomes useful.
+### Phase C: Make reviewed knowledge reusable
 
-## Phase 7: Build-forward workflow
+Goal:
+- turn one-off runs into reusable research memory and actionable next steps
 
-Goal: turn a promoted product candidate into useful product-building artifacts.
+Relevant issues:
+- #22 Corpus browser
+- #38 Explicit reasoning relationships
+- #39 Theme review semantics
+- #40 Candidate promotion workflow
+- #41 Follow-up research tasks
 
-Future issues should cover:
+Expected result:
+- APD becomes a workspace for accumulated product reasoning rather than only a one-run viewer
 
+### Phase D: Build-forward handoff
+
+Goal:
+- turn reviewed candidates into grounded downstream artifacts
+
+Future work should cover:
+
+- validation brief generation
 - prototype brief export
 - requirements and non-goals generation
 - GitHub issue draft export
 - scaffolded repository generation
-- repo-rails integration for generated projects
-- handoff from APD research run to a build project
+- handoff from APD research runs to build projects
 
 Expected result:
+- a reviewed opportunity can become a build package without skipping the research and review loop
 
-When a candidate is sufficiently reviewed and promoted, APD can create a build package. The package may include a prototype brief, requirements, backlog, issue drafts, and possibly a runnable scaffolded repository.
+## Provider and deployment posture
 
-The goal is not to guarantee a production app. The goal is to produce a grounded, inspectable, runnable starting point.
+APD remains local-first for now.
 
-## Recommended near-term order
-
-1. #34 Agent draft validation and repair workflow
-2. #31 Research brief creation UI
-3. #32 Browser-based draft import flow
-4. #35 Candidate-centered run detail UI
-5. #38 Explicit reasoning relationships
-6. #39 Theme review
-7. #40 Candidate promotion
-8. #41 Follow-up research tasks
-9. #22 Corpus browser
-
-This order keeps the dogfood loop usable while moving the product toward the reviewed product-investigation workflow.
+Future provider and deployment work should support the harness architecture rather than bypass it. Provider integrations should fit inside APD's phase boundaries, safety rules, traceability, and eval framework. Hosted or multi-user capabilities remain future design work, not the current product center.


### PR DESCRIPTION
## Summary
- add a new research harness architecture doc that explains APD as a guided product-research harness rather than a manual prompt/import workflow or generic agent wrapper
- rewrite the briefs and roadmap docs around the current `Start Research` flow and the near-term harness maturity sequence
- refine product vision and the execution-boundary open question so the docs no longer point future implementers back toward the older manual mental model

Refs #68

## Files Changed
- `docs/explanation/research-harness-architecture.md`: new repo-specific architecture doc covering harness vs framework, current loop, intended research phases, tools, skills, context assembly, safety, traces, evals, scorecards, human review, and near-term architecture map
- `docs/explanation/product-vision.md`: clarify that the model is a worker inside APD's harness and link to the new architecture doc
- `docs/planning/post-mvp-roadmap.md`: reorder the near-term roadmap around harness maturity, traceability, evals, and scorecards rather than the older manual-import chronology
- `docs/briefs.md`: rewrite as a user workflow doc centered on `Start Research`, execution results, candidate-first review, and legacy/debug manual import
- `docs/planning/open-questions.md`: update the stale execution-boundary question so it reflects the current local harness path instead of the old manual-only path

## Verification
Local:
- `uv run python scripts/check_repo_readiness.py`
- `./scripts/test.ps1`

Both commands passed locally.

## Architecture Notes
- The main mental-model change is that the docs now describe APD as the harness around the model: APD owns phase progression, tool boundaries, context assembly, validation, persistence, observability, and review. The model is not the product.
- I intentionally folded the terms and core concepts into one architecture doc instead of adding a separate reference glossary. For this repo state, keeping the harness story in one place is clearer than splitting it across two thin docs.
- I refined the issue's phase list slightly by documenting the phases as conceptual harness phases, not as a promise that each phase must immediately become a separate runtime function or model call. The current code still collapses some of them into broader steps, and the docs now say that explicitly.
- I also updated `open-questions.md` because leaving the older manual-agent execution language in place would have contradicted the new architecture doc and roadmap.
- This prepares #69 and #70 by defining what skills are, where they fit, and how phase-scoped context assembly should work. It prepares #71 by making traces first-class harness data rather than incidental debug output. It prepares #72 and #73 by defining the evaluation dimensions the harness should surface and preserve.
- This is documentation and roadmap alignment only. No runtime behavior, provider capability, source fetching behavior, migrations, or eval implementation was added.