### PR TITLE
Add research skill tree manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Use this repository when you want an agent to:
 - `DISCOVERY_RUN_MODE.md` - boundary file for discovery-to-planning runs
 - `DISCOVERY_RUN_PROMPT.md` - detailed discovery-to-planning prompt when a tiny prompt is not enough
 - `agent/` - repo-wide operating instructions, gates, lifecycle map, and conventions
+- `skills/research/` - harness-injected phase-specific research skills and the manifest that will feed APD research prompts
 - `skills/product/` - discovery, scoring, validation, monetization, operability, requirements, design, and planning skills
 - `skills/engineering/` - prototype, implementation loop, debugging, testing, review, release, and deployment guidance
 - `skills/meta/` - anti-slop, evidence, critic, scope-cutting, and stuck-recovery guidance

--- a/docs/explanation/research-harness-architecture.md
+++ b/docs/explanation/research-harness-architecture.md
@@ -386,7 +386,7 @@ Future skill work should follow these rules:
 - skills are injected only when relevant to the current phase
 - APD does not dump the entire skill tree into every prompt
 
-Issue #69 introduces the initial skill tree and manifest. Issue #70 should make skill selection and prompt injection part of the harness runtime.
+The initial research skill tree now lives under `skills/research/manifest.yaml`. Issue #70 should make skill selection and prompt injection part of the harness runtime.
 
 ## Context assembly
 

--- a/scripts/check_repo_readiness.py
+++ b/scripts/check_repo_readiness.py
@@ -9,6 +9,24 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
+RESEARCH_SKILL_MANIFEST_PATH = "skills/research/manifest.yaml"
+RESEARCH_SKILL_SPECS = [
+    ("research_protocol", "skills/research/research_protocol.md"),
+    ("question_framing", "skills/research/question_framing.md"),
+    ("search_strategy", "skills/research/search_strategy.md"),
+    ("url_target_selection", "skills/research/url_target_selection.md"),
+    ("source_triage", "skills/research/source_triage.md"),
+    ("evidence_extraction", "skills/research/evidence_extraction.md"),
+    ("claim_grounding", "skills/research/claim_grounding.md"),
+    ("theme_synthesis", "skills/research/theme_synthesis.md"),
+    ("candidate_generation", "skills/research/candidate_generation.md"),
+    ("validation_gate_design", "skills/research/validation_gate_design.md"),
+    ("research_audit", "skills/research/research_audit.md"),
+]
+RESEARCH_SKILL_FILES = [path for _, path in RESEARCH_SKILL_SPECS]
+RESEARCH_SKILL_IDS = {skill_id for skill_id, _ in RESEARCH_SKILL_SPECS}
+RESEARCH_SKILL_PATH_TO_ID = {path: skill_id for skill_id, path in RESEARCH_SKILL_SPECS}
+
 REQUIRED_FILES = [
     "README.md",
     "START_HERE.md",
@@ -34,6 +52,8 @@ REQUIRED_FILES = [
     "skills/product/agent-operability-skill.md",
     "skills/product/competitor-substitute-analysis-skill.md",
     "skills/engineering/prototype-skill.md",
+    RESEARCH_SKILL_MANIFEST_PATH,
+    *RESEARCH_SKILL_FILES,
     "templates/research-source-note.md",
     "templates/candidate-evidence-map.md",
     "templates/discovery-summary.md",
@@ -94,6 +114,41 @@ ARTIFACT_MANIFEST_FIELDS = {
     "inputs",
     "purpose",
     "notes",
+}
+
+RESEARCH_SKILL_MANIFEST_FIELDS = {
+    "id",
+    "path",
+    "phases",
+    "trigger_terms",
+    "expected_inputs",
+    "expected_outputs",
+    "max_prompt_budget_chars",
+}
+
+RESEARCH_SKILL_DOC_HEADINGS = {
+    "## skill name/id",
+    "## use when",
+    "## inputs",
+    "## procedure",
+    "## output contract",
+    "## quality checks",
+    "## failure modes",
+    "## mini example",
+    "## eval hooks",
+}
+
+KNOWN_RESEARCH_PHASES = {
+    "brief_framing",
+    "research_planning",
+    "web_discovery",
+    "source_triage",
+    "evidence_extraction",
+    "grounded_claim_generation",
+    "theme_synthesis",
+    "candidate_generation",
+    "validation_gate_generation",
+    "audit_gap_analysis",
 }
 
 LAUNCH_SCAFFOLD_MARKER = "launch scaffold"
@@ -397,6 +452,166 @@ def parse_markdown_bullets(text: str) -> dict[str, str]:
 
 def count_candidate_sections(text: str) -> int:
     return sum(1 for line in text.splitlines() if line.strip().startswith("## Candidate:"))
+
+
+def _parse_inline_manifest_value(raw_value: str) -> object:
+    value = raw_value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        items: list[str] = []
+        for part in value[1:-1].split(","):
+            item = part.strip().strip("\"'")
+            if item:
+                items.append(item)
+        return items
+    if re.fullmatch(r"\d+", value):
+        return int(value)
+    return value.strip("\"'")
+
+
+def load_research_skill_manifest(relative_path: str) -> tuple[list[dict[str, object]] | None, list[str]]:
+    text, load_error = load_text(relative_path)
+    if load_error:
+        return None, [load_error]
+    assert text is not None
+
+    skills: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    found_skills_list = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not found_skills_list:
+            if stripped == "skills:":
+                found_skills_list = True
+            continue
+
+        if stripped.startswith("- "):
+            if current is not None:
+                skills.append(current)
+            field_text = stripped[2:]
+            if ":" not in field_text:
+                return None, [f"{relative_path} has an invalid skill entry: {stripped}"]
+            key, value = field_text.split(":", 1)
+            current = {key.strip(): _parse_inline_manifest_value(value)}
+            continue
+
+        if current is None:
+            return None, [f"{relative_path} has fields before the first skill entry."]
+
+        if not line.startswith("    "):
+            return None, [f"{relative_path} has unsupported indentation for skill fields: {stripped}"]
+
+        if ":" not in stripped:
+            return None, [f"{relative_path} has an invalid skill field: {stripped}"]
+
+        key, value = stripped.split(":", 1)
+        current[key.strip()] = _parse_inline_manifest_value(value)
+
+    if current is not None:
+        skills.append(current)
+
+    if not found_skills_list:
+        return None, [f"{relative_path} must contain a top-level `skills:` list."]
+
+    return skills, []
+
+
+def validate_research_skill_doc(relative_path: str, *, expected_id: str | None = None) -> list[str]:
+    errors = validate_markdown(relative_path, RESEARCH_SKILL_DOC_HEADINGS)
+    text, load_error = load_text(relative_path)
+    if load_error:
+        return [load_error]
+    assert text is not None
+
+    if not text.lstrip().startswith("# Research Skill:"):
+        errors.append(f"{relative_path} must start with a `# Research Skill:` heading.")
+
+    match = re.search(r"## Skill name/id\s+`?([a-z0-9_]+)`?", text, re.IGNORECASE)
+    if not match:
+        errors.append(f"{relative_path} must declare a machine-readable skill id under `## Skill name/id`.")
+    elif expected_id and match.group(1).strip() != expected_id:
+        errors.append(
+            f"{relative_path} declares skill id `{match.group(1).strip()}` but manifest expects `{expected_id}`."
+        )
+
+    return errors
+
+
+def validate_research_skill_manifest(relative_path: str) -> list[str]:
+    skills, load_errors = load_research_skill_manifest(relative_path)
+    if load_errors:
+        return load_errors
+    assert skills is not None
+
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    seen_paths: set[str] = set()
+
+    for index, skill in enumerate(skills, start=1):
+        missing = sorted(
+            field for field in RESEARCH_SKILL_MANIFEST_FIELDS if skill.get(field) in (None, "", [])
+        )
+        if missing:
+            errors.append(f"{relative_path} skill #{index} is missing fields: {', '.join(missing)}")
+            continue
+
+        skill_id = str(skill.get("id") or "").strip()
+        path = str(skill.get("path") or "").strip()
+        phases = skill.get("phases")
+        trigger_terms = skill.get("trigger_terms")
+        expected_inputs = skill.get("expected_inputs")
+        expected_outputs = skill.get("expected_outputs")
+        max_prompt_budget_chars = skill.get("max_prompt_budget_chars")
+
+        if skill_id in seen_ids:
+            errors.append(f"{relative_path} contains duplicate skill id: {skill_id}")
+        seen_ids.add(skill_id)
+
+        if path in seen_paths:
+            errors.append(f"{relative_path} contains duplicate skill path: {path}")
+        seen_paths.add(path)
+
+        expected_id = RESEARCH_SKILL_PATH_TO_ID.get(path)
+        if expected_id and skill_id != expected_id:
+            errors.append(f"{relative_path} maps path {path} to id {skill_id}, expected {expected_id}.")
+
+        if not (ROOT / path).is_file():
+            errors.append(f"{relative_path} references a missing skill file: {path}")
+
+        if not isinstance(phases, list) or not phases:
+            errors.append(f"{relative_path} skill `{skill_id}` must declare a non-empty `phases` list.")
+        else:
+            unknown_phases = sorted({str(item).strip() for item in phases} - KNOWN_RESEARCH_PHASES)
+            if unknown_phases:
+                errors.append(
+                    f"{relative_path} skill `{skill_id}` uses unknown phases: {', '.join(unknown_phases)}"
+                )
+
+        for field_name, value in [
+            ("trigger_terms", trigger_terms),
+            ("expected_inputs", expected_inputs),
+            ("expected_outputs", expected_outputs),
+        ]:
+            if not isinstance(value, list) or not all(str(item).strip() for item in value):
+                errors.append(f"{relative_path} skill `{skill_id}` must declare a non-empty `{field_name}` list.")
+
+        if not isinstance(max_prompt_budget_chars, int) or max_prompt_budget_chars <= 0:
+            errors.append(
+                f"{relative_path} skill `{skill_id}` must declare a positive integer `max_prompt_budget_chars`."
+            )
+
+    missing_ids = sorted(RESEARCH_SKILL_IDS - seen_ids)
+    if missing_ids:
+        errors.append(f"{relative_path} is missing required skill ids: {', '.join(missing_ids)}")
+
+    missing_paths = sorted(set(RESEARCH_SKILL_FILES) - seen_paths)
+    if missing_paths:
+        errors.append(f"{relative_path} is missing required skill paths: {', '.join(missing_paths)}")
+
+    return errors
 
 
 def validate_run_index(relative_path: str) -> list[str]:
@@ -751,6 +966,9 @@ def validate_repo() -> int:
     errors.extend(validate_markdown("START_HERE.md", REQUIRED_START_HEADINGS))
     errors.extend(validate_markdown("ACTIVE_RUN.md", REQUIRED_ACTIVE_RUN_HEADINGS))
     errors.extend(validate_active_run())
+    errors.extend(validate_research_skill_manifest(RESEARCH_SKILL_MANIFEST_PATH))
+    for skill_id, skill_path in RESEARCH_SKILL_SPECS:
+        errors.extend(validate_research_skill_doc(skill_path, expected_id=skill_id))
 
     total_missing = len(missing_files) + len(missing_dirs)
     print()

--- a/skills/research/candidate_generation.md
+++ b/skills/research/candidate_generation.md
@@ -1,0 +1,58 @@
+# Research Skill: Candidate Generation
+
+## Skill name/id
+`candidate_generation`
+
+## Use when
+
+- APD needs candidate product wedges from grounded research
+- themes and claims are strong enough to support product judgment
+- the run must avoid broad platform fantasies
+
+## Inputs
+
+- grounded themes and claims
+- substitute behavior and risk notes
+- product constraints from the brief
+- candidate event schema
+
+## Procedure
+
+1. Start from one user, one workflow, and one repeated pain pattern.
+2. Frame a narrow wedge rather than a full platform.
+3. Name the first buyer or user, first workflow, first wedge, and first prototype success event.
+4. Include substitutes, risks, and a plausible first monetization path when possible.
+5. Prefer candidates that are specific enough to validate quickly.
+6. Reject candidates that depend on vague future expansion to make sense.
+
+## Output contract
+
+- produce `candidate.proposed` events
+- include structured candidate fields such as title, summary, target_user, first_workflow, first_wedge, prototype_success_event, monetization_path, substitutes, and risks when the evidence supports them
+- keep any missing details visible as open questions rather than hiding them
+
+## Quality checks
+
+- the candidate is narrow and product-investigation oriented
+- the candidate has a credible workflow and user boundary
+- the wedge can be explained without platform language
+- the candidate can be traced back to evidence and themes
+
+## Failure modes
+
+- broad platform ideas with no smallest sellable wedge
+- candidate summaries that restate themes without a product response
+- no substitutes or risks considered
+- missing first workflow or success event for a leading candidate
+
+## Mini example
+
+Stronger candidate: "Reconciliation exception QA for finance-ops teams using spreadsheets and lightweight ERP exports."
+
+Weaker candidate: "AI finance workspace for every back-office process."
+
+## Eval hooks
+
+- measure wedge specificity
+- measure evidence traceability for candidates
+- measure first-workflow clarity

--- a/skills/research/claim_grounding.md
+++ b/skills/research/claim_grounding.md
@@ -1,0 +1,57 @@
+# Research Skill: Claim Grounding
+
+## Skill name/id
+`claim_grounding`
+
+## Use when
+
+- APD is generating claims from a grounded source packet
+- the current phase needs claim and evidence-link events
+- factual statements must stay tied to known source and excerpt IDs
+
+## Inputs
+
+- grounding packet with source IDs and excerpt IDs
+- claim schema or event contract
+- brief objective and target workflows
+
+## Procedure
+
+1. Write claims that are specific enough to change product judgment.
+2. Tie each factual claim to at least one provided source or excerpt.
+3. Prefer claims about repeated pain, substitute behavior, risks, workflow friction, or buyer conditions.
+4. Use model-prior language only for hypotheses that are not grounded in the packet.
+5. Emit evidence links alongside claims so traceability is explicit.
+6. Never invent source IDs, excerpt IDs, URLs, or citations.
+
+## Output contract
+
+- produce `claim.proposed` events for grounded assertions
+- produce matching `evidence_link.added` events that reference provided source_id and or excerpt_id values
+- keep unsupported ideas out of grounded factual claims
+
+## Quality checks
+
+- every grounded claim has visible evidence support
+- claim wording is concrete and falsifiable
+- only known source and excerpt identifiers are used
+- no invented citations appear in metadata or notes
+
+## Failure modes
+
+- orphan claims with no evidence links
+- vague claims that do not influence product judgment
+- invented identifiers or URLs
+- unsupported synthesis passed off as grounded fact
+
+## Mini example
+
+Good claim: "Finance-ops teams still run manual exception review after automated match rules fail on vendor naming inconsistencies." Supported by one complaint excerpt and one workaround excerpt.
+
+Bad claim: "Most finance teams want AI-native automation" with no packet support.
+
+## Eval hooks
+
+- measure supported-claim rate
+- measure invented-identifier rate
+- measure claim specificity score

--- a/skills/research/evidence_extraction.md
+++ b/skills/research/evidence_extraction.md
@@ -1,0 +1,57 @@
+# Research Skill: Evidence Extraction
+
+## Skill name/id
+`evidence_extraction`
+
+## Use when
+
+- APD needs bounded excerpts rather than full source text
+- later phases require reusable evidence snippets with source linkage
+- the source packet needs to stay within prompt limits
+
+## Inputs
+
+- retained sources or readable source text
+- excerpt budget and excerpt-size limits
+- target workflow, pain, substitute, and risk questions
+
+## Procedure
+
+1. Pull excerpts that preserve who is speaking, what workflow they are in, and what goes wrong.
+2. Prefer concrete evidence over generic opinion.
+3. Keep excerpts short enough for prompt reuse without losing meaning.
+4. Capture location references when possible.
+5. Avoid duplicating the same evidence in slightly different wording.
+6. Note why the excerpt matters if the meaning is not obvious from the quote alone.
+
+## Output contract
+
+- produce excerpt candidates with source linkage and excerpt metadata
+- preserve fields compatible with APD evidence excerpts, such as source_id, excerpt_text, location_reference, and excerpt_type
+- keep any added interpretation separate from the excerpt itself
+
+## Quality checks
+
+- excerpts are linked back to the correct source
+- each excerpt contains concrete workflow or pain evidence
+- excerpt text is bounded and readable
+- interpretation is not mixed into the quote itself
+
+## Failure modes
+
+- excerpts that are too long for prompt reuse
+- paraphrases presented as direct evidence without source linkage
+- generic excerpts that do not support product judgment
+- duplicate excerpts that waste budget
+
+## Mini example
+
+Strong excerpt: a short complaint describing manual invoice matching and the workaround used after the tool fails.
+
+Weak excerpt: a broad statement that automation matters for finance teams.
+
+## Eval hooks
+
+- measure excerpt usefulness for downstream claims
+- measure excerpt duplication rate
+- measure source-link integrity rate

--- a/skills/research/manifest.yaml
+++ b/skills/research/manifest.yaml
@@ -1,0 +1,79 @@
+version: 1
+skills:
+  - id: research_protocol
+    path: skills/research/research_protocol.md
+    phases: [brief_framing, research_planning, web_discovery, source_triage, evidence_extraction, grounded_claim_generation, theme_synthesis, candidate_generation, validation_gate_generation, audit_gap_analysis]
+    trigger_terms: [evidence discipline, traceability, no invented sources, phase scope, safety]
+    expected_inputs: [research brief, phase objective, safety constraints, source availability]
+    expected_outputs: [phase compliance notes, grounded output decisions, uncertainty markers]
+    max_prompt_budget_chars: 1200
+  - id: question_framing
+    path: skills/research/question_framing.md
+    phases: [brief_framing, research_planning]
+    trigger_terms: [vague brief, scope narrowing, research question, non goals, clarify ask]
+    expected_inputs: [raw user curiosity, notes, constraints, desired depth]
+    expected_outputs: [research brief fields, clarification questions, non goals]
+    max_prompt_budget_chars: 900
+  - id: search_strategy
+    path: skills/research/search_strategy.md
+    phases: [research_planning, web_discovery]
+    trigger_terms: [search queries, source diversity, evidence plan, retrieval coverage]
+    expected_inputs: [research brief, target users, likely workflows, source budget]
+    expected_outputs: [query list, source type targets, search rationales]
+    max_prompt_budget_chars: 900
+  - id: url_target_selection
+    path: skills/research/url_target_selection.md
+    phases: [web_discovery]
+    trigger_terms: [direct urls, fetch targets, public pages, safe sources]
+    expected_inputs: [candidate urls, query intent, safety constraints, fetch budget]
+    expected_outputs: [url list, fetch rationales, expected source value]
+    max_prompt_budget_chars: 850
+  - id: source_triage
+    path: skills/research/source_triage.md
+    phases: [source_triage]
+    trigger_terms: [keep source, discard source, relevance, source quality, source packet]
+    expected_inputs: [captured sources, brief objective, source metadata, phase budget]
+    expected_outputs: [retained source ids, dropped source ids, triage notes]
+    max_prompt_budget_chars: 850
+  - id: evidence_extraction
+    path: skills/research/evidence_extraction.md
+    phases: [evidence_extraction]
+    trigger_terms: [excerpt selection, quote extraction, evidence snippets, prompt packet]
+    expected_inputs: [retained sources, source text, excerpt budget, target workflows]
+    expected_outputs: [excerpt candidates, excerpt metadata, why it matters notes]
+    max_prompt_budget_chars: 900
+  - id: claim_grounding
+    path: skills/research/claim_grounding.md
+    phases: [grounded_claim_generation]
+    trigger_terms: [grounded claims, evidence links, source ids, excerpt ids]
+    expected_inputs: [grounding packet, source ids, excerpt ids, claim schema]
+    expected_outputs: [claim.proposed events, evidence_link.added events]
+    max_prompt_budget_chars: 1100
+  - id: theme_synthesis
+    path: skills/research/theme_synthesis.md
+    phases: [theme_synthesis]
+    trigger_terms: [pain patterns, repeated themes, synthesis, clustering]
+    expected_inputs: [grounded claims, excerpts, candidate context, theme schema]
+    expected_outputs: [theme.proposed events, supporting theme links]
+    max_prompt_budget_chars: 950
+  - id: candidate_generation
+    path: skills/research/candidate_generation.md
+    phases: [candidate_generation]
+    trigger_terms: [product wedge, narrow candidate, first buyer, first workflow]
+    expected_inputs: [themes, claims, substitutes, product constraints]
+    expected_outputs: [candidate.proposed events, candidate evidence needs]
+    max_prompt_budget_chars: 1100
+  - id: validation_gate_design
+    path: skills/research/validation_gate_design.md
+    phases: [validation_gate_generation]
+    trigger_terms: [validation gates, missing evidence, candidate blockers, phase maturity]
+    expected_inputs: [candidate ids, research phase model, open risks, evidence gaps]
+    expected_outputs: [validation_gate.proposed events, gate blockers]
+    max_prompt_budget_chars: 900
+  - id: research_audit
+    path: skills/research/research_audit.md
+    phases: [audit_gap_analysis]
+    trigger_terms: [audit, unsupported synthesis, gap analysis, follow up]
+    expected_inputs: [claims, themes, candidates, evidence links, validation errors]
+    expected_outputs: [audit findings, unsupported item ids, follow up questions]
+    max_prompt_budget_chars: 900

--- a/skills/research/question_framing.md
+++ b/skills/research/question_framing.md
@@ -1,0 +1,57 @@
+# Research Skill: Question Framing
+
+## Skill name/id
+`question_framing`
+
+## Use when
+
+- the starting brief is vague, broad, or solution-biased
+- APD needs a brief that can support bounded product research
+- clarification is needed before web discovery or synthesis begins
+
+## Inputs
+
+- raw user curiosity or product direction
+- optional notes, prior context, and explicit constraints
+- desired depth or expected outputs if provided
+
+## Procedure
+
+1. Name the likely user and workflow instead of a broad market category.
+2. Rewrite the ask as a research question about pain, substitutes, opportunity conditions, or validation needs.
+3. Capture hard boundaries, non-goals, and what should not be investigated.
+4. Identify which unknowns are blocking the run from starting.
+5. Ask clarification questions only when a missing boundary would materially change the run.
+6. Avoid turning the brief into a build plan or feature list.
+
+## Output contract
+
+- produce brief-ready fields such as title, research question, constraints, desired depth, expected outputs, and notes
+- include clarification questions only when needed to unblock the brief
+- record explicit non-goals when the prompt risks drifting into a broad platform search
+
+## Quality checks
+
+- the brief is narrow enough to guide a bounded research run
+- the question is product-investigation oriented rather than generic market analysis
+- constraints and non-goals are visible
+- the wording does not assume a solution is already correct
+
+## Failure modes
+
+- broad market scans with no workflow boundary
+- hidden assumptions about the product solution
+- feature brainstorming instead of research framing
+- missing non-goals that allow scope sprawl
+
+## Mini example
+
+Weak framing: "Find AI tools for finance teams."
+
+Better framing: "Investigate repeated reconciliation pain for finance-ops teams using spreadsheets and lightweight ERP exports, with focus on narrow QA wedges rather than full ERP replacement."
+
+## Eval hooks
+
+- measure brief specificity before and after framing
+- measure clarification-question necessity rate
+- measure scope-creep rate in downstream phases

--- a/skills/research/research_audit.md
+++ b/skills/research/research_audit.md
@@ -1,0 +1,57 @@
+# Research Skill: Research Audit
+
+## Skill name/id
+`research_audit`
+
+## Use when
+
+- APD needs a final gap analysis before import, review, or promotion
+- claims or candidates might be overreaching their evidence
+- repair feedback or validation errors need to become explicit follow-up items
+
+## Inputs
+
+- claims, themes, candidates, and validation gates
+- evidence links and source coverage
+- validation errors or repair history if available
+
+## Procedure
+
+1. Look for unsupported claims, weak evidence coverage, and overconfident synthesis.
+2. Identify which candidates depend on thin or one-sided evidence.
+3. Separate import blockers from non-blocking follow-up questions.
+4. Note disconfirming evidence that should stay visible to reviewers.
+5. Turn missing evidence into explicit follow-up questions or validation gates.
+6. Do not invent new event types to represent the audit if the schema does not support them.
+
+## Output contract
+
+- produce a concise structured audit summary for trace metadata, reviewer notes, or a future audit object
+- include unsupported item IDs, missing-evidence areas, disconfirming evidence notes, and follow-up questions when possible
+- keep audit output separate from grounded claims and candidate events
+
+## Quality checks
+
+- unsupported synthesis is called out explicitly
+- the audit distinguishes blockers from lower-priority gaps
+- disconfirming evidence remains visible
+- the audit creates actionable follow-up rather than vague doubt
+
+## Failure modes
+
+- silent acceptance of unsupported claims
+- treating an audit as generic criticism with no actionable output
+- hiding disconfirming evidence to preserve a preferred candidate
+- emitting fake component events for audit concepts that APD does not support yet
+
+## Mini example
+
+Good audit finding: "Candidate `candidate-2` relies on one practitioner blog and no direct complaint evidence; gather at least two direct workflow complaints before promotion."
+
+Bad audit finding: "Need more confidence."
+
+## Eval hooks
+
+- measure unsupported-item detection rate
+- measure blocker precision
+- measure follow-up actionability

--- a/skills/research/research_protocol.md
+++ b/skills/research/research_protocol.md
@@ -1,0 +1,62 @@
+# Research Skill: Research Protocol
+
+## Skill name/id
+`research_protocol`
+
+## Use when
+
+- any APD research phase needs a shared evidence and safety discipline
+- the model might drift into unsupported synthesis or invented sources
+- a repair prompt needs a compact reminder of phase scope and traceability rules
+
+## Inputs
+
+- research brief or phase objective
+- current phase name
+- source packet or source availability status
+- APD output contract and safety constraints
+
+## Procedure
+
+1. Restate the narrow product investigation question in one sentence before producing output.
+2. Separate grounded facts from model-prior hypotheses.
+3. Use only APD-provided sources, source IDs, excerpt IDs, and URLs for factual claims.
+4. Keep output inside the current phase and schema boundary.
+5. Prefer repeated workflow pain over broad market chatter or trend summaries.
+6. Mark uncertainty explicitly when evidence is weak, conflicting, or missing.
+7. Refuse invented citations, fake complaints, and generic platform expansion.
+
+## Output contract
+
+- return only the object type requested by the active phase prompt
+- preserve APD field names, IDs, and event types exactly
+- label unsupported ideas as model-prior or open questions instead of facts
+
+## Quality checks
+
+- every factual claim is tied to provided evidence or clearly marked as model-prior
+- the output stays within the requested phase scope
+- the output shape matches the APD schema or event contract
+- candidate ideas remain narrow and product-oriented
+
+## Failure modes
+
+- invented sources, citations, or excerpt references
+- unsupported claims presented as facts
+- phase drift into generic summaries or brainstorming
+- output that ignores the requested APD schema
+
+## Mini example
+
+Input: candidate generation for complaints about brittle spreadsheet reconciliation.
+
+Good output: one narrow finance-ops reconciliation QA candidate tied to the provided complaint excerpts.
+
+Bad output: a general AI finance platform with no evidence links.
+
+## Eval hooks
+
+- measure invented-source rate
+- measure grounded-claim rate
+- measure schema-valid output rate
+- measure phase-drift rate

--- a/skills/research/search_strategy.md
+++ b/skills/research/search_strategy.md
@@ -1,0 +1,61 @@
+# Research Skill: Search Strategy
+
+## Skill name/id
+`search_strategy`
+
+## Use when
+
+- APD is planning evidence collection before fetching sources
+- the web discovery phase needs better query coverage
+- the run risks overfitting to one source type or one vocabulary choice
+
+## Inputs
+
+- research brief
+- likely user segments and workflows
+- source-count budget and source-type diversity goals
+- any existing claims that need confirmation or disconfirmation
+
+## Procedure
+
+1. Translate the brief into a small set of evidence-seeking questions.
+2. Generate query variants that target complaints, workarounds, substitutes, and practitioner language.
+3. Mix direct pain queries with substitute-comparison queries.
+4. Prefer search terms likely to uncover first-person workflow evidence, not generic industry pages.
+5. Keep the list short enough that APD can enforce URL and fetch budgets.
+6. Avoid query spam, synonyms without purpose, or terms that only produce trend commentary.
+
+## Output contract
+
+- produce a compact query list with short rationales
+- each query should imply why that search is likely to surface concrete product evidence
+- queries should stay compatible with APD's bounded web-discovery JSON format
+
+## Quality checks
+
+- the query set covers more than one source type
+- at least some queries target explicit pain or workaround language
+- queries are not just keyword permutations of the title
+- the list stays within the configured budget
+
+## Failure modes
+
+- generic topic queries that only surface directories or thought leadership
+- too many near-duplicate queries
+- no attention to substitute or workaround evidence
+- search plans that exceed APD's fetch budget
+
+## Mini example
+
+Better query pair:
+
+- `spreadsheet reconciliation pain month end close`
+- `manual invoice matching workaround finance ops`
+
+These are stronger than a generic query such as `finance automation trends`.
+
+## Eval hooks
+
+- measure diversity of returned source types
+- measure complaint or workaround source hit rate
+- measure wasted-query rate

--- a/skills/research/source_triage.md
+++ b/skills/research/source_triage.md
@@ -1,0 +1,58 @@
+# Research Skill: Source Triage
+
+## Skill name/id
+`source_triage`
+
+## Use when
+
+- APD has fetched more source material than should enter the active prompt context
+- some sources look weak, duplicative, or off-topic
+- the run needs a tighter source packet before claim generation
+
+## Inputs
+
+- captured sources and basic metadata
+- brief objective and target workflow
+- current context budget
+- any known evidence gaps
+
+## Procedure
+
+1. Rank sources by direct relevance to the workflow and pain under investigation.
+2. Prefer sources with concrete complaints, workarounds, substitute behavior, or practitioner detail.
+3. Keep diversity across source types when possible.
+4. Deprioritize generic summaries, duplicate perspectives, and low-signal pages.
+5. Reject sources that are off-topic, too shallow, or only supportive background.
+6. Record what evidence is still missing after triage.
+
+## Output contract
+
+- produce retained-source and dropped-source decisions with concise reasons
+- surface which sources should enter the active grounding packet first
+- record missing evidence areas that later phases should respect
+
+## Quality checks
+
+- retained sources are relevant to the brief
+- the packet does not collapse to one redundant source type
+- low-signal pages do not crowd out concrete evidence
+- triage decisions are explainable to a reviewer
+
+## Failure modes
+
+- keeping everything and blowing the prompt budget
+- dropping disconfirming evidence because it is inconvenient
+- overweighting generic context pages
+- making triage decisions with no visible rationale
+
+## Mini example
+
+Keep: a user complaint thread, a practitioner writeup, and a substitute comparison.
+
+Drop or deprioritize: a generic market overview that repeats no workflow details.
+
+## Eval hooks
+
+- measure high-signal-source retention rate
+- measure source diversity after triage
+- measure disconfirming-evidence retention rate

--- a/skills/research/theme_synthesis.md
+++ b/skills/research/theme_synthesis.md
@@ -1,0 +1,56 @@
+# Research Skill: Theme Synthesis
+
+## Skill name/id
+`theme_synthesis`
+
+## Use when
+
+- APD needs repeated pain or behavior patterns grouped into themes
+- grounded claims and excerpts are numerous enough to cluster
+- the run needs reviewer-friendly synthesis without losing traceability
+
+## Inputs
+
+- grounded claims
+- supporting excerpts or evidence links
+- target user and workflow context
+- theme schema or event contract
+
+## Procedure
+
+1. Group repeated claims that point to the same workflow problem or opportunity condition.
+2. Keep themes narrow enough that a reviewer can explain the pattern in one sentence.
+3. Preserve the distinction between a repeated pattern and a one-off anecdote.
+4. Record supporting evidence or claim references for each theme.
+5. Separate pain themes from substitute, risk, or monetization themes when useful.
+6. Avoid letting a theme become a generic market story.
+
+## Output contract
+
+- produce `theme.proposed` events for reviewer-facing patterns
+- keep supporting evidence references available through evidence links or metadata
+- use theme summaries that remain grounded in the underlying claims
+
+## Quality checks
+
+- each theme reflects repeated evidence, not one vivid example
+- themes are distinct enough to avoid duplication
+- summaries remain connected to grounded claims or excerpts
+- themes are useful for later candidate generation
+
+## Failure modes
+
+- themes that are just renamed claims
+- evidence-detached synthesis
+- collapsing unrelated problems into one broad theme
+- trend commentary mistaken for a repeated workflow pattern
+
+## Mini example
+
+Theme: "Exception review remains manual even after rule-based matching" is stronger than "finance automation is broken" because it names the recurring workflow and pain precisely.
+
+## Eval hooks
+
+- measure theme support density
+- measure duplicate-theme rate
+- measure reviewer usefulness of themes for candidate selection

--- a/skills/research/url_target_selection.md
+++ b/skills/research/url_target_selection.md
@@ -1,0 +1,58 @@
+# Research Skill: URL Target Selection
+
+## Skill name/id
+`url_target_selection`
+
+## Use when
+
+- APD needs explicit public URLs to validate and fetch
+- search results or candidate pages need pruning down to a bounded list
+- the run needs safer, higher-value fetch targets
+
+## Inputs
+
+- candidate URLs or source candidates
+- research brief and likely workflows
+- APD safety rules for public URL fetching
+- fetch-count budget
+
+## Procedure
+
+1. Prefer pages that are likely to contain direct user pain, workaround details, or substitute comparisons.
+2. Reject URLs that look generic, duplicative, or low-signal.
+3. Favor URLs that are public, stable, and specific enough to justify a fetch.
+4. Avoid homepages, tag hubs, and trend summaries unless they are supporting context only.
+5. Keep the final list small and ranked by expected evidence value.
+6. Leave safety enforcement to APD, but do not propose obviously unsafe or private targets.
+
+## Output contract
+
+- produce URL entries compatible with APD's current shape: `url` and `rationale`
+- each rationale should explain the expected evidence value of fetching the page
+- the list must fit inside APD's explicit URL budget
+
+## Quality checks
+
+- URLs are public `http` or `https` targets
+- the list is not dominated by generic landing pages
+- rationales are specific to the product investigation
+- the final set is small enough to fetch deliberately
+
+## Failure modes
+
+- proposing unsafe, private, or credentialed URLs
+- selecting many near-duplicate pages from one domain
+- choosing only generic context pages
+- using URLs as fabricated citations rather than fetch targets
+
+## Mini example
+
+Good target: a public forum thread where operators describe manual reconciliation steps.
+
+Weak target: a top-level category page with no concrete workflow evidence.
+
+## Eval hooks
+
+- measure fetched-page usefulness rate
+- measure unsafe-URL rejection rate
+- measure duplicate-domain overuse rate

--- a/skills/research/validation_gate_design.md
+++ b/skills/research/validation_gate_design.md
@@ -1,0 +1,58 @@
+# Research Skill: Validation Gate Design
+
+## Skill name/id
+`validation_gate_design`
+
+## Use when
+
+- APD needs explicit blockers before a candidate can advance
+- candidates have promise but still carry evidence gaps or risk
+- the run is preparing reviewer-facing validation work
+
+## Inputs
+
+- candidate IDs and candidate summaries
+- current research phase model
+- open risks, substitute pressure, and missing evidence
+- validation gate event schema
+
+## Procedure
+
+1. Identify what must be true before a candidate can credibly move forward.
+2. Write gates as concrete checks, not generic reminders.
+3. Link gates to the right candidate whenever possible.
+4. Match the gate to APD's phase vocabulary.
+5. Distinguish between blocking gaps and useful but non-blocking follow-up questions.
+6. Prefer a few high-value gates over a noisy checklist.
+
+## Output contract
+
+- produce `validation_gate.proposed` events
+- include candidate_id, phase, name, description, blocking, evidence_summary, and missing_evidence when supported
+- keep gate wording specific enough that a reviewer knows what evidence would satisfy it
+
+## Quality checks
+
+- each gate is tied to a real uncertainty or risk
+- gate language is specific and testable
+- phase values stay inside APD's maturity model
+- candidate linkage is present when relevant
+
+## Failure modes
+
+- vague gates such as "do more validation"
+- gates that duplicate the candidate summary instead of testing it
+- missing candidate linkage for candidate-specific blockers
+- too many low-value gates that hide the important ones
+
+## Mini example
+
+Strong gate: "Confirm at least three finance-ops teams will pay for exception review QA before replacing spreadsheet checks."
+
+Weak gate: "Validate product-market fit."
+
+## Eval hooks
+
+- measure gate specificity
+- measure gate-to-candidate linkage rate
+- measure blocker usefulness in later review


### PR DESCRIPTION
## Summary
- add a new `skills/research/manifest.yaml` that declares the initial research skill tree, phase coverage, trigger terms, expected inputs and outputs, and prompt-budget hints
- add concise operational research skills for question framing, discovery, triage, evidence extraction, claim grounding, theme synthesis, candidate generation, validation gates, audit, and cross-phase research protocol discipline
- extend `scripts/check_repo_readiness.py` so missing or stale research skill files fail clearly, and add small repo-surface alignment updates in the README and research harness architecture doc

Refs #69

## Files Changed
- `skills/research/manifest.yaml`: initial research skill manifest for deterministic phase-scoped discovery later
- `skills/research/*.md`: initial phase-specific research skills written as operational instructions instead of passive reference docs
- `scripts/check_repo_readiness.py`: require the new manifest and skill files, validate manifest structure, known phases, required fields, and required skill doc headings and ids
- `docs/explanation/research-harness-architecture.md`: update the skill section to point at the now-present manifest path
- `README.md`: expose the new `skills/research/` tree in the repo layout

## Verification
Local:
- `uv run python scripts/check_repo_readiness.py`
- `./scripts/test.ps1`

Both commands passed locally.

## Architecture Notes
- The main design choice here is that the research skills are phase-scoped operational context, not generic research essays. Each file is short, procedural, and tied to an APD phase boundary or output contract.
- I kept the manifest phases aligned with the intended harness phases from the architecture doc rather than the current batch names like `candidate_batch`. That keeps issue #69 focused on the durable skill layer and leaves the mapping or resolver logic to issue #70.
- The readiness validator now checks more than file presence: it validates required manifest fields, known phase names, skill file references, and the required section structure inside each skill doc. That gives the repo an early failure mode when the skill tree drifts.
- I made only small adjacent doc updates because issue #69 is still a content-and-structure task, not prompt integration or runtime behavior.
- This prepares issue #70 by giving the future resolver a stable manifest shape and bounded skill texts to inject into prompts.