### PR TITLE
Integrate research skills into phase prompts

### DIFF
--- a/apd/services/research_brief_service.py
+++ b/apd/services/research_brief_service.py
@@ -8,6 +8,7 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 from apd.domain.models import ResearchBrief, ResearchBriefStatus
+from apd.services.research_skills import render_research_skill_context_for_phase
 
 # ── APD schema field reminders embedded in every generated prompt ─────────────
 _SCHEMA_REMINDERS = """\
@@ -122,6 +123,9 @@ Rules:
 - Do not invent source URLs or citations.
 - If ungrounded, mark metadata as synthetic/model-prior.
 """
+
+_COMPONENT_PHASE_SKILL_CONTEXT_CHARS = 4400
+_COMPONENT_REPAIR_SKILL_CONTEXT_CHARS = 3000
 
 # ── CRUD ─────────────────────────────────────────────────────────────────────
 
@@ -268,6 +272,10 @@ def generate_ollama_component_phase_prompt(
 ) -> str:
     """Return a phase-specific component batch prompt."""
     base = generate_ollama_execution_prompt(brief)
+    skill_context = render_research_skill_context_for_phase(
+        phase_name,
+        max_chars=_COMPONENT_PHASE_SKILL_CONTEXT_CHARS,
+    )
     candidates_block = ", ".join(candidate_ids or [])
     if not candidates_block:
         candidates_block = "(none yet)"
@@ -314,6 +322,8 @@ def generate_ollama_component_phase_prompt(
             ]
         )
     parts = [base, "", "---", "", _COMPONENT_EXECUTION_CONSTRAINTS]
+    if skill_context:
+        parts.extend(["", skill_context])
     if grounded_constraints:
         parts.extend(["", grounded_constraints])
     parts.extend(["", selected, "", "Return only the ResearchComponentBatch JSON object."])
@@ -330,6 +340,10 @@ def generate_ollama_component_repair_prompt(
 ) -> str:
     """Return a phase-specific repair prompt for an invalid component batch."""
     base = generate_ollama_execution_prompt(brief)
+    skill_context = render_research_skill_context_for_phase(
+        phase_name,
+        max_chars=_COMPONENT_REPAIR_SKILL_CONTEXT_CHARS,
+    )
     errors_block = "\n".join(f"- {line}" for line in validation_errors[:8]) or "- unknown validation error"
     invalid_json = "{}" if invalid_batch_data is None else json.dumps(invalid_batch_data, ensure_ascii=False)
     parts = [
@@ -339,6 +353,8 @@ def generate_ollama_component_repair_prompt(
         "",
         _COMPONENT_EXECUTION_CONSTRAINTS,
     ]
+    if skill_context:
+        parts.extend(["", skill_context])
     if grounded_source_packet:
         parts.extend(
             [

--- a/apd/services/research_skills.py
+++ b/apd/services/research_skills.py
@@ -9,6 +9,11 @@ import re
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_RESEARCH_SKILL_MANIFEST = REPO_ROOT / "skills" / "research" / "manifest.yaml"
+PRIORITY_SKILL_SECTION_HEADINGS: tuple[str, ...] = (
+    "## Procedure",
+    "## Output contract",
+    "## Quality checks",
+)
 
 # Runtime phases use a few pragmatic batch names that are intentionally narrower
 # than the durable research-harness phase names in the skill manifest.
@@ -221,6 +226,56 @@ def _trim_to_chars(text: str, max_chars: int) -> str:
     return cleaned[: max_chars - len(marker)].rstrip() + marker
 
 
+def _prioritize_operational_skill_sections(text: str) -> str:
+    cleaned = text.strip()
+    if not cleaned:
+        return cleaned
+
+    leading_lines: list[str] = []
+    sections: list[tuple[str, str]] = []
+    current_heading: str | None = None
+    current_lines: list[str] = []
+
+    for line in cleaned.splitlines():
+        if line.startswith("## "):
+            if current_heading is not None:
+                sections.append((current_heading, "\n".join(current_lines).strip()))
+            current_heading = line
+            current_lines = [line]
+            continue
+
+        if current_heading is None:
+            leading_lines.append(line)
+        else:
+            current_lines.append(line)
+
+    if current_heading is None:
+        return cleaned
+
+    sections.append((current_heading, "\n".join(current_lines).strip()))
+
+    prioritized_sections: list[str] = []
+    seen_headings: set[str] = set()
+    for heading in PRIORITY_SKILL_SECTION_HEADINGS:
+        for section_heading, block in sections:
+            if section_heading == heading:
+                prioritized_sections.append(block)
+                seen_headings.add(section_heading)
+                break
+
+    for section_heading, block in sections:
+        if section_heading in seen_headings:
+            continue
+        prioritized_sections.append(block)
+
+    ordered_chunks: list[str] = []
+    leading_text = "\n".join(leading_lines).strip()
+    if leading_text:
+        ordered_chunks.append(leading_text)
+    ordered_chunks.extend(prioritized_sections)
+    return "\n\n".join(chunk for chunk in ordered_chunks if chunk)
+
+
 def render_research_skill_context(
     skill_ids: list[str] | tuple[str, ...],
     *,
@@ -251,7 +306,8 @@ def render_research_skill_context(
 
         text = spec.file_path.read_text(encoding="utf-8")
         per_skill_budget = max(300, min(spec.max_prompt_budget_chars, remaining))
-        trimmed = _trim_to_chars(text, per_skill_budget)
+        prioritized_text = _prioritize_operational_skill_sections(text)
+        trimmed = _trim_to_chars(prioritized_text, per_skill_budget)
         chunk = "\n".join(
             [
                 "",

--- a/apd/services/research_skills.py
+++ b/apd/services/research_skills.py
@@ -1,0 +1,289 @@
+"""Research skill manifest loading and prompt-context rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RESEARCH_SKILL_MANIFEST = REPO_ROOT / "skills" / "research" / "manifest.yaml"
+
+# Runtime phases use a few pragmatic batch names that are intentionally narrower
+# than the durable research-harness phase names in the skill manifest.
+PHASE_ALIASES: dict[str, tuple[str, ...]] = {
+    "candidate_batch": ("candidate_generation",),
+    "claim_theme_batch": ("grounded_claim_generation", "theme_synthesis"),
+    "validation_gate_batch": ("validation_gate_generation",),
+    "web_research_targets": ("web_discovery",),
+}
+
+
+@dataclass(frozen=True)
+class ResearchSkillSpec:
+    """Manifest entry for one research skill."""
+
+    id: str
+    path: str
+    phases: tuple[str, ...]
+    trigger_terms: tuple[str, ...]
+    expected_inputs: tuple[str, ...]
+    expected_outputs: tuple[str, ...]
+    max_prompt_budget_chars: int
+    repo_root: Path
+
+    @property
+    def file_path(self) -> Path:
+        return self.repo_root / self.path
+
+
+def _parse_inline_manifest_value(raw_value: str) -> object:
+    value = raw_value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        items: list[str] = []
+        for part in value[1:-1].split(","):
+            item = part.strip().strip("\"'")
+            if item:
+                items.append(item)
+        return items
+    if re.fullmatch(r"\d+", value):
+        return int(value)
+    return value.strip("\"'")
+
+
+def _coerce_string_tuple(value: object, *, field_name: str, skill_id: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"Research skill `{skill_id}` field `{field_name}` must be a list.")
+    items = tuple(str(item).strip() for item in value if str(item).strip())
+    if not items:
+        raise ValueError(f"Research skill `{skill_id}` field `{field_name}` must not be empty.")
+    return items
+
+
+def _repo_root_for_manifest(manifest_path: Path) -> Path:
+    # The stable manifest path is <repo>/skills/research/manifest.yaml.
+    try:
+        return manifest_path.resolve().parents[2]
+    except IndexError:
+        return REPO_ROOT
+
+
+def load_research_skill_manifest(
+    manifest_path: str | Path | None = None,
+) -> list[ResearchSkillSpec]:
+    """Load the research skill manifest without adding a runtime YAML dependency.
+
+    The repository manifest deliberately uses a small YAML subset: a top-level
+    ``skills:`` list with scalar fields and inline lists. This parser validates
+    that shape and fails with actionable errors when the skill tree drifts.
+    """
+
+    resolved_manifest_path = Path(manifest_path or DEFAULT_RESEARCH_SKILL_MANIFEST)
+    repo_root = _repo_root_for_manifest(resolved_manifest_path)
+
+    try:
+        text = resolved_manifest_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Missing research skill manifest: {resolved_manifest_path}") from exc
+
+    raw_skills: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    found_skills_list = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if not found_skills_list:
+            if stripped == "skills:":
+                found_skills_list = True
+            continue
+
+        if stripped.startswith("- "):
+            if current is not None:
+                raw_skills.append(current)
+            field_text = stripped[2:]
+            if ":" not in field_text:
+                raise ValueError(f"{resolved_manifest_path} has an invalid skill entry: {stripped}")
+            key, value = field_text.split(":", 1)
+            current = {key.strip(): _parse_inline_manifest_value(value)}
+            continue
+
+        if current is None:
+            raise ValueError(f"{resolved_manifest_path} has fields before the first skill entry.")
+        if not line.startswith("    "):
+            raise ValueError(
+                f"{resolved_manifest_path} has unsupported indentation for skill fields: {stripped}"
+            )
+        if ":" not in stripped:
+            raise ValueError(f"{resolved_manifest_path} has an invalid skill field: {stripped}")
+
+        key, value = stripped.split(":", 1)
+        current[key.strip()] = _parse_inline_manifest_value(value)
+
+    if current is not None:
+        raw_skills.append(current)
+
+    if not found_skills_list:
+        raise ValueError(f"{resolved_manifest_path} must contain a top-level `skills:` list.")
+    if not raw_skills:
+        raise ValueError(f"{resolved_manifest_path} must contain at least one research skill.")
+
+    specs: list[ResearchSkillSpec] = []
+    for index, raw_skill in enumerate(raw_skills, start=1):
+        skill_id = str(raw_skill.get("id") or "").strip()
+        if not skill_id:
+            raise ValueError(f"{resolved_manifest_path} skill #{index} is missing `id`.")
+        path = str(raw_skill.get("path") or "").strip()
+        if not path:
+            raise ValueError(f"{resolved_manifest_path} skill `{skill_id}` is missing `path`.")
+
+        max_budget = raw_skill.get("max_prompt_budget_chars")
+        if not isinstance(max_budget, int) or max_budget <= 0:
+            raise ValueError(
+                f"{resolved_manifest_path} skill `{skill_id}` must declare a positive "
+                "`max_prompt_budget_chars` integer."
+            )
+
+        spec = ResearchSkillSpec(
+            id=skill_id,
+            path=path,
+            phases=_coerce_string_tuple(raw_skill.get("phases"), field_name="phases", skill_id=skill_id),
+            trigger_terms=_coerce_string_tuple(
+                raw_skill.get("trigger_terms"), field_name="trigger_terms", skill_id=skill_id
+            ),
+            expected_inputs=_coerce_string_tuple(
+                raw_skill.get("expected_inputs"), field_name="expected_inputs", skill_id=skill_id
+            ),
+            expected_outputs=_coerce_string_tuple(
+                raw_skill.get("expected_outputs"), field_name="expected_outputs", skill_id=skill_id
+            ),
+            max_prompt_budget_chars=max_budget,
+            repo_root=repo_root,
+        )
+        if not spec.file_path.is_file():
+            raise FileNotFoundError(f"Research skill `{spec.id}` references missing file: {spec.file_path}")
+        specs.append(spec)
+
+    return specs
+
+
+def _expanded_phase_names(phase_name: str) -> tuple[str, ...]:
+    normalized = str(phase_name or "").strip().lower()
+    if not normalized:
+        return tuple()
+    return PHASE_ALIASES.get(normalized, (normalized,))
+
+
+def resolve_research_skills_for_phase(
+    phase_name: str,
+    *,
+    max_skills: int | None = 4,
+    manifest_path: str | Path | None = None,
+) -> list[str]:
+    """Resolve a deterministic, bounded skill list for a runtime phase."""
+
+    phase_names = set(_expanded_phase_names(phase_name))
+    if not phase_names:
+        return []
+
+    specs = load_research_skill_manifest(manifest_path)
+    selected: list[str] = []
+
+    # Research protocol is a cross-phase discipline skill. Keep it first when
+    # applicable so every injected context reminds the model about grounding.
+    for spec in specs:
+        if spec.id == "research_protocol" and phase_names.intersection(spec.phases):
+            selected.append(spec.id)
+            break
+
+    for spec in specs:
+        if spec.id == "research_protocol":
+            continue
+        if phase_names.intersection(spec.phases):
+            selected.append(spec.id)
+
+    if max_skills is not None:
+        return selected[: max(0, max_skills)]
+    return selected
+
+
+def _trim_to_chars(text: str, max_chars: int) -> str:
+    cleaned = text.strip()
+    if len(cleaned) <= max_chars:
+        return cleaned
+    marker = "\n...[research skill context truncated]"
+    if max_chars <= len(marker):
+        return cleaned[:max(0, max_chars)].rstrip()
+    return cleaned[: max_chars - len(marker)].rstrip() + marker
+
+
+def render_research_skill_context(
+    skill_ids: list[str] | tuple[str, ...],
+    *,
+    max_chars: int = 3500,
+    manifest_path: str | Path | None = None,
+) -> str:
+    """Render bounded research skill instructions for prompt injection."""
+
+    if max_chars <= 0 or not skill_ids:
+        return ""
+
+    specs = load_research_skill_manifest(manifest_path)
+    specs_by_id = {spec.id: spec for spec in specs}
+
+    chunks: list[str] = [
+        "## Selected APD research skills",
+        "",
+        "Use these phase-scoped skills as operational instructions. Keep output within the current phase contract.",
+    ]
+
+    remaining = max_chars - len("\n".join(chunks))
+    for skill_id in skill_ids:
+        spec = specs_by_id.get(skill_id)
+        if spec is None:
+            raise ValueError(f"Unknown research skill id requested for prompt context: {skill_id}")
+        if remaining <= 0:
+            break
+
+        text = spec.file_path.read_text(encoding="utf-8")
+        per_skill_budget = max(300, min(spec.max_prompt_budget_chars, remaining))
+        trimmed = _trim_to_chars(text, per_skill_budget)
+        chunk = "\n".join(
+            [
+                "",
+                f"### Research skill: {spec.id}",
+                f"Manifest path: `{spec.path}`",
+                f"Applies to phases: {', '.join(spec.phases)}",
+                "",
+                trimmed,
+            ]
+        )
+        chunks.append(chunk)
+        remaining = max_chars - len("\n".join(chunks))
+
+    return _trim_to_chars("\n".join(chunks), max_chars)
+
+
+def render_research_skill_context_for_phase(
+    phase_name: str,
+    *,
+    max_skills: int | None = 4,
+    max_chars: int = 3500,
+    manifest_path: str | Path | None = None,
+) -> str:
+    """Resolve and render research skill context for one runtime phase."""
+
+    skill_ids = resolve_research_skills_for_phase(
+        phase_name,
+        max_skills=max_skills,
+        manifest_path=manifest_path,
+    )
+    return render_research_skill_context(
+        skill_ids,
+        max_chars=max_chars,
+        manifest_path=manifest_path,
+    )

--- a/apd/services/web_research.py
+++ b/apd/services/web_research.py
@@ -19,6 +19,7 @@ from apd.services.research_execution_ollama import (
     extract_json_object_from_model_output,
     get_ollama_execution_config,
 )
+from apd.services.research_skills import render_research_skill_context_for_phase
 
 SCHEMA_VERSION = "1.0"
 MAX_PROPOSED_QUERIES = 5
@@ -31,6 +32,7 @@ MAX_GROUNDED_PACKET_SOURCES = 5
 MAX_GROUNDED_PACKET_EXCERPTS = 10
 MAX_GROUNDED_PACKET_EXCERPT_CHARS = 1500
 MAX_GROUNDED_PACKET_TOTAL_CHARS = 10000
+WEB_DISCOVERY_SKILL_CONTEXT_CHARS = 4200
 WEB_USER_AGENT = "APD local research prototype/1.0"
 
 _TAG_RE = re.compile(r"<[^>]+>")
@@ -77,6 +79,10 @@ def get_web_research_limits() -> dict[str, int]:
 
 
 def build_web_research_target_prompt(brief: ResearchBrief) -> str:
+    skill_context = render_research_skill_context_for_phase(
+        "web_discovery",
+        max_chars=WEB_DISCOVERY_SKILL_CONTEXT_CHARS,
+    )
     parts = [
         "You are helping APD plan a controlled web research loop.",
         "Return only JSON.",
@@ -87,18 +93,24 @@ def build_web_research_target_prompt(brief: ResearchBrief) -> str:
         f"Cap yourself to at most {MAX_PROPOSED_QUERIES} queries and {MAX_FETCH_URLS} URLs.",
         "Only include public http/https URLs likely relevant to the product investigation.",
         "Do not include localhost, private hosts, file URLs, or authenticated sources.",
-        "",
-        "Return JSON with this shape:",
-        "{",
-        '  "schema_version": "1.0",',
-        '  "queries": [{"query": "string", "rationale": "string"}],',
-        '  "urls": [{"url": "https://example.com", "rationale": "string"}]',
-        "}",
-        "",
-        "Research brief:",
-        f"Title: {brief.title}",
-        f"Research question: {brief.research_question}",
     ]
+    if skill_context:
+        parts.extend(["", skill_context])
+    parts.extend(
+        [
+            "",
+            "Return JSON with this shape:",
+            "{",
+            '  "schema_version": "1.0",',
+            '  "queries": [{"query": "string", "rationale": "string"}],',
+            '  "urls": [{"url": "https://example.com", "rationale": "string"}]',
+            "}",
+            "",
+            "Research brief:",
+            f"Title: {brief.title}",
+            f"Research question: {brief.research_question}",
+        ]
+    )
     if brief.constraints:
         parts.append(f"Constraints: {brief.constraints}")
     if brief.desired_depth:

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -65,6 +65,21 @@ Today that means:
 
 This path is synchronous and local-first. It does not do unrestricted browsing, background jobs, or hosted provider calls.
 
+## Research skill context
+
+APD now treats `skills/research/manifest.yaml` as runtime prompt context, not just documentation.
+
+For each prompt phase, APD deterministically resolves a small set of skills and injects bounded excerpts into the model prompt:
+
+- web discovery uses `research_protocol`, `search_strategy`, and `url_target_selection`
+- candidate batches use `research_protocol` and `candidate_generation`
+- claim/theme batches use `research_protocol`, `claim_grounding`, and `theme_synthesis`
+- validation gate batches use `research_protocol` and `validation_gate_design`
+
+Runtime batch names such as `candidate_batch`, `claim_theme_batch`, and `validation_gate_batch` are mapped to the durable research-harness phase names in the manifest. Skill context is character-bounded before prompt insertion so the model gets operational guidance without dumping the full skill tree into every call.
+
+If the manifest references a missing skill file or invalid skill id, prompt construction should fail clearly. `scripts/check_repo_readiness.py` also validates the manifest and skill files so drift is usually caught before runtime.
+
 ## Execution results and failure states
 
 The brief detail page stores and displays a concise `last_execution` summary.

--- a/tests/test_research_skills.py
+++ b/tests/test_research_skills.py
@@ -51,12 +51,13 @@ def test_resolve_research_skills_for_web_discovery_and_component_aliases():
 
 
 def test_render_research_skill_context_is_bounded_and_operational():
-    context = render_research_skill_context(["search_strategy"], max_chars=2200)
+    context = render_research_skill_context(["search_strategy"], max_chars=1300)
 
-    assert len(context) <= 2200
+    assert len(context) <= 1300
     assert "Research skill: search_strategy" in context
     assert "## Procedure" in context
     assert "## Output contract" in context
+    assert "## Quality checks" in context
 
 
 def test_web_discovery_prompt_includes_selected_research_skills():

--- a/tests/test_research_skills.py
+++ b/tests/test_research_skills.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from apd.domain.models import ResearchBrief
+from apd.services.research_brief_service import (
+    generate_ollama_component_phase_prompt,
+    generate_ollama_component_repair_prompt,
+)
+from apd.services.research_skills import (
+    load_research_skill_manifest,
+    render_research_skill_context,
+    resolve_research_skills_for_phase,
+)
+from apd.services.web_research import build_web_research_target_prompt
+
+
+def _brief() -> ResearchBrief:
+    return ResearchBrief(
+        title="Self-hosting operations pain",
+        research_question=(
+            "Investigate product opportunities for solo developers who self-host "
+            "small apps and struggle with deployment, monitoring, backups, and maintenance."
+        ),
+    )
+
+
+def test_load_research_skill_manifest_reads_initial_skill_tree():
+    specs = load_research_skill_manifest()
+    ids = [spec.id for spec in specs]
+
+    assert "research_protocol" in ids
+    assert "search_strategy" in ids
+    assert "candidate_generation" in ids
+    assert all(spec.max_prompt_budget_chars > 0 for spec in specs)
+
+
+def test_resolve_research_skills_for_web_discovery_and_component_aliases():
+    web_skill_ids = resolve_research_skills_for_phase("web_discovery", max_skills=None)
+    assert web_skill_ids[:3] == [
+        "research_protocol",
+        "search_strategy",
+        "url_target_selection",
+    ]
+
+    claim_theme_skill_ids = resolve_research_skills_for_phase("claim_theme_batch", max_skills=None)
+    assert "research_protocol" in claim_theme_skill_ids
+    assert "claim_grounding" in claim_theme_skill_ids
+    assert "theme_synthesis" in claim_theme_skill_ids
+
+    validation_skill_ids = resolve_research_skills_for_phase("validation_gate_batch", max_skills=None)
+    assert "validation_gate_design" in validation_skill_ids
+
+
+def test_render_research_skill_context_is_bounded_and_operational():
+    context = render_research_skill_context(["search_strategy"], max_chars=1200)
+
+    assert len(context) <= 1200
+    assert "Research skill: search_strategy" in context
+    assert "## Procedure" in context
+    assert "## Output contract" in context
+
+
+def test_web_discovery_prompt_includes_selected_research_skills():
+    prompt = build_web_research_target_prompt(_brief())
+
+    assert "Selected APD research skills" in prompt
+    assert "Research skill: search_strategy" in prompt
+    assert "Research skill: url_target_selection" in prompt
+    assert "Return JSON with this shape" in prompt
+
+
+def test_component_phase_prompts_include_relevant_skill_context():
+    brief = _brief()
+
+    candidate_prompt = generate_ollama_component_phase_prompt(brief, "candidate_batch")
+    assert "Research skill: candidate_generation" in candidate_prompt
+    assert "Phase: candidate_batch" in candidate_prompt
+
+    claim_theme_prompt = generate_ollama_component_phase_prompt(brief, "claim_theme_batch")
+    assert "Research skill: claim_grounding" in claim_theme_prompt
+    assert "Research skill: theme_synthesis" in claim_theme_prompt
+    assert "Phase: claim_theme_batch" in claim_theme_prompt
+
+    validation_prompt = generate_ollama_component_phase_prompt(
+        brief,
+        "validation_gate_batch",
+        candidate_ids=["cand-1"],
+    )
+    assert "Research skill: validation_gate_design" in validation_prompt
+    assert "Existing candidate IDs: cand-1" in validation_prompt
+
+
+def test_repair_prompt_includes_phase_skill_context_and_validation_errors():
+    prompt = generate_ollama_component_repair_prompt(
+        _brief(),
+        phase_name="claim_theme_batch",
+        validation_errors=["event #1 missing external_id"],
+        invalid_batch_data={"schema_version": "1.0", "events": []},
+    )
+
+    assert "Research skill: claim_grounding" in prompt
+    assert "Research skill: theme_synthesis" in prompt
+    assert "event #1 missing external_id" in prompt
+    assert "Return only the corrected ResearchComponentBatch JSON object." in prompt

--- a/tests/test_research_skills.py
+++ b/tests/test_research_skills.py
@@ -51,9 +51,9 @@ def test_resolve_research_skills_for_web_discovery_and_component_aliases():
 
 
 def test_render_research_skill_context_is_bounded_and_operational():
-    context = render_research_skill_context(["search_strategy"], max_chars=1200)
+    context = render_research_skill_context(["search_strategy"], max_chars=2200)
 
-    assert len(context) <= 1200
+    assert len(context) <= 2200
     assert "Research skill: search_strategy" in context
     assert "## Procedure" in context
     assert "## Output contract" in context


### PR DESCRIPTION
Refs #70

## Summary
- add `apd/services/research_skills.py` to load the research skill manifest, resolve phase-relevant skills deterministically, and render bounded prompt context
- inject selected research skill context into web-discovery prompts, component phase prompts, and component repair prompts
- add focused tests covering manifest loading, runtime phase aliases, bounded context rendering, and prompt injection for web discovery / component phases
- document the runtime skill-context behavior in `docs/briefs.md`

## Files Changed
- `apd/services/research_skills.py`: new manifest loader, deterministic resolver, phase aliases, and bounded renderer
- `apd/services/web_research.py`: inject web-discovery skill context into research-target prompts
- `apd/services/research_brief_service.py`: inject phase-scoped skill context into component generation and repair prompts
- `tests/test_research_skills.py`: coverage for skill resolution and prompt inclusion
- `docs/briefs.md`: explain runtime skill prompt injection and phase mappings

## Verification
Not run in this sandbox.

The sandbox could not clone the repo because `github.com` name resolution failed, so this PR was created through the GitHub connector.

Recommended local verification:
- `uv run pytest tests/test_research_skills.py tests/test_research_execution.py tests/test_web_research.py -q`
- `./scripts/test.ps1`
- `uv run python scripts/check_repo_readiness.py`

## Architecture Notes
- Skill selection is deterministic and manifest-driven. No model-based skill discovery, vector search, or new runtime research capability is added here.
- Runtime batch names such as `candidate_batch`, `claim_theme_batch`, and `validation_gate_batch` map to the durable research-harness phases declared in `skills/research/manifest.yaml`.
- Prompt injection is character-bounded so APD provides operational phase guidance without dumping the whole skill tree into every prompt.
- Missing manifests, missing skill files, and unknown skill ids fail clearly during prompt construction or readiness checks.

## Safety Notes
- No hosted provider integrations were added.
- No live web/model calls are required by the new tests.
- This only changes prompt/context assembly; it does not relax URL validation, grounding validation, or import gates.