### PR TITLE
Add research run trace event log

### DIFF
--- a/alembic/versions/20260429_0004_add_research_trace_events.py
+++ b/alembic/versions/20260429_0004_add_research_trace_events.py
@@ -1,0 +1,54 @@
+"""add research_trace_events table
+
+Revision ID: 20260429_0004
+Revises: 20260427_0003
+Create Date: 2026-04-29 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260429_0004"
+down_revision = "20260427_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "research_trace_events",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("brief_id", sa.Integer(), sa.ForeignKey("research_briefs.id"), nullable=True),
+        sa.Column("run_id", sa.Integer(), sa.ForeignKey("runs.id"), nullable=True),
+        sa.Column("correlation_id", sa.String(length=255), nullable=True),
+        sa.Column("phase", sa.String(length=64), nullable=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("payload_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(op.f("ix_research_trace_events_brief_id"), "research_trace_events", ["brief_id"], unique=False)
+    op.create_index(op.f("ix_research_trace_events_run_id"), "research_trace_events", ["run_id"], unique=False)
+    op.create_index(
+        op.f("ix_research_trace_events_correlation_id"),
+        "research_trace_events",
+        ["correlation_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_research_trace_events_correlation_id"), table_name="research_trace_events")
+    op.drop_index(op.f("ix_research_trace_events_run_id"), table_name="research_trace_events")
+    op.drop_index(op.f("ix_research_trace_events_brief_id"), table_name="research_trace_events")
+    op.drop_table("research_trace_events")

--- a/apd/domain/models.py
+++ b/apd/domain/models.py
@@ -142,6 +142,10 @@ class Run(Base):
     review_notes: Mapped[list[ReviewNote]] = relationship(back_populates="run", cascade="all, delete-orphan")
     decisions: Mapped[list[Decision]] = relationship(back_populates="run", cascade="all, delete-orphan")
     artifacts: Mapped[list[Artifact]] = relationship(back_populates="run", cascade="all, delete-orphan")
+    research_trace_events: Mapped[list[ResearchTraceEvent]] = relationship(
+        back_populates="run",
+        cascade="all, delete-orphan",
+    )
 
 
 class Source(Base):
@@ -411,6 +415,28 @@ class ResearchBrief(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, onupdate=_utc_now, nullable=False)
     metadata_json: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    research_trace_events: Mapped[list[ResearchTraceEvent]] = relationship(
+        back_populates="brief",
+        cascade="all, delete-orphan",
+    )
+
+
+class ResearchTraceEvent(Base):
+    __tablename__ = "research_trace_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    brief_id: Mapped[Optional[int]] = mapped_column(ForeignKey("research_briefs.id"), index=True)
+    run_id: Mapped[Optional[int]] = mapped_column(ForeignKey("runs.id"), index=True)
+    correlation_id: Mapped[Optional[str]] = mapped_column(String(255), index=True)
+    phase: Mapped[Optional[str]] = mapped_column(String(64))
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    message: Mapped[Optional[str]] = mapped_column(Text)
+    payload_json: Mapped[Optional[dict]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utc_now, nullable=False)
+
+    brief: Mapped[Optional[ResearchBrief]] = relationship(back_populates="research_trace_events")
+    run: Mapped[Optional[Run]] = relationship(back_populates="research_trace_events")
 
 
 class AppSetting(Base):

--- a/apd/services/research_execution_ollama.py
+++ b/apd/services/research_execution_ollama.py
@@ -24,6 +24,12 @@ from apd.services.research_components import (
     ResearchComponentEventType,
     parse_component_batch_from_data,
 )
+from apd.services.research_skills import resolve_research_skills_for_phase
+from apd.services.research_trace import (
+    append_research_trace_event,
+    attach_run_to_trace_events,
+    create_trace_correlation_id,
+)
 
 
 def _iso_now() -> str:
@@ -45,6 +51,32 @@ class ProductQualityGateResult:
     status: str
     error: str | None
     warnings: list[str]
+
+
+def _trace_execution_event(
+    db: Session,
+    brief,
+    *,
+    correlation_id: str | None,
+    event_type: str,
+    phase: str | None = None,
+    message: str | None = None,
+    payload: dict[str, Any] | None = None,
+    run_id: int | None = None,
+) -> None:
+    if not correlation_id:
+        return
+
+    append_research_trace_event(
+        db,
+        brief_id=getattr(brief, "id", None),
+        run_id=run_id,
+        correlation_id=correlation_id,
+        phase=phase,
+        event_type=event_type,
+        message=message,
+        payload=payload,
+    )
 
 
 def get_ollama_execution_config(db: Session | None = None) -> tuple[OllamaExecutionConfig | None, list[str]]:
@@ -135,9 +167,16 @@ def extract_json_object_from_model_output(text: str) -> tuple[dict[str, Any] | N
     return None, "parse_failed: unable_to_extract_json_object"
 
 
-def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
+def execute_research_brief_ollama(
+    db: Session,
+    brief,
+    *,
+    trace_correlation_id: str | None = None,
+) -> dict[str, Any]:
     config, missing_env = get_ollama_execution_config(db)
     now = _iso_now()
+    trace_correlation_id = trace_correlation_id or create_trace_correlation_id(brief_id=brief.id)
+    trace_phase = "draft_execution"
 
     if config is None:
         return {
@@ -149,6 +188,7 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
             "errors": [f"Missing required env: {value}" for value in missing_env],
             "warnings": [],
             "run_id": None,
+            "trace_correlation_id": trace_correlation_id,
         }
 
     prompt = generate_ollama_execution_prompt(brief)
@@ -159,12 +199,64 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
     started_at = now
     finished_at = now
     try:
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="phase_started",
+            phase=trace_phase,
+            message="Draft execution started.",
+            payload={"provider": config.provider, "model": config.model},
+        )
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="model_call_started",
+            phase=trace_phase,
+            message="Started draft model call.",
+            payload={"provider": config.provider, "model": config.model, "attempt": 1, "prompt_chars": len(prompt)},
+        )
         draft_data, parse_error = _call_ollama_for_draft(config, prompt)
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="model_call_completed",
+            phase=trace_phase,
+            message="Completed draft model call.",
+            payload={
+                "provider": config.provider,
+                "model": config.model,
+                "attempt": 1,
+                "success": parse_error is None,
+                "error": parse_error,
+                "response_keys": sorted(draft_data.keys())[:8] if draft_data else [],
+            },
+        )
         if parse_error:
             status = "parse_failed" if parse_error.startswith("parse_failed") else "provider_error"
             errors_list.append(parse_error)
             finished_at = _iso_now()
-            return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_completed",
+                phase=trace_phase,
+                message="Draft execution failed.",
+                payload={"status": status, "error_count": len(errors_list)},
+            )
+            return _build_result(
+                config,
+                status,
+                started_at,
+                finished_at,
+                run_id,
+                errors_list,
+                warnings_list,
+                trace_correlation_id=trace_correlation_id,
+            )
 
         report = validate_agent_draft_data(Path("<ollama-output>"), draft_data)
         package = report.package
@@ -179,7 +271,42 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
 
         if (package is None or not report.is_valid) and config.repair_attempts > 0:
             warnings_list.append("repair_attempted=1")
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="repair_attempted",
+                phase=trace_phase,
+                message="Attempting draft repair after validation failure.",
+                payload={"attempt": 1, "validation_error_count": len(report.grouped_errors or report.errors)},
+            )
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="model_call_started",
+                phase=trace_phase,
+                message="Started repair model call.",
+                payload={"provider": config.provider, "model": config.model, "attempt": 2, "repair": True},
+            )
             repaired_data, repair_error = _call_ollama_for_repair(config, draft_data, report.grouped_errors or report.errors)
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="model_call_completed",
+                phase=trace_phase,
+                message="Completed repair model call.",
+                payload={
+                    "provider": config.provider,
+                    "model": config.model,
+                    "attempt": 2,
+                    "repair": True,
+                    "success": repair_error is None,
+                    "error": repair_error,
+                    "response_keys": sorted(repaired_data.keys())[:8] if repaired_data else [],
+                },
+            )
             if repair_error:
                 errors_list.append(repair_error)
             elif repaired_data is not None:
@@ -196,14 +323,68 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
             if not errors_list:
                 errors_list.extend(_first_errors(report.errors, limit=5))
             finished_at = _iso_now()
-            return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="validation_failed",
+                phase=trace_phase,
+                message="Draft execution failed validation.",
+                payload={"status": status, "errors": _first_errors(report.errors, limit=3)},
+            )
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_completed",
+                phase=trace_phase,
+                message="Draft execution failed.",
+                payload={"status": status, "error_count": len(errors_list)},
+            )
+            return _build_result(
+                config,
+                status,
+                started_at,
+                finished_at,
+                run_id,
+                errors_list,
+                warnings_list,
+                trace_correlation_id=trace_correlation_id,
+            )
 
         quality_result = _evaluate_product_quality_gate(package)
         warnings_list.extend(quality_result.warnings)
         if quality_result.error:
             finished_at = _iso_now()
             errors_list.append(quality_result.error)
-            return _build_result(config, quality_result.status, started_at, finished_at, run_id, errors_list, warnings_list)
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="validation_failed",
+                phase="quality_gate",
+                message="Draft execution failed the quality gate.",
+                payload={"status": quality_result.status, "error": quality_result.error},
+            )
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_completed",
+                phase=trace_phase,
+                message="Draft execution failed.",
+                payload={"status": quality_result.status, "error_count": len(errors_list)},
+            )
+            return _build_result(
+                config,
+                quality_result.status,
+                started_at,
+                finished_at,
+                run_id,
+                errors_list,
+                warnings_list,
+                trace_correlation_id=trace_correlation_id,
+            )
 
         try:
             import_result = import_agent_draft_package(
@@ -216,13 +397,61 @@ def execute_research_brief_ollama(db: Session, brief) -> dict[str, Any]:
             status = "import_failed"
             errors_list.append(f"import_failed: {exc}")
             finished_at = _iso_now()
-            return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_completed",
+                phase=trace_phase,
+                message="Draft execution failed during import.",
+                payload={"status": status, "error_count": len(errors_list)},
+            )
+            return _build_result(
+                config,
+                status,
+                started_at,
+                finished_at,
+                run_id,
+                errors_list,
+                warnings_list,
+                trace_correlation_id=trace_correlation_id,
+            )
 
         run_id = import_result.run_db_id
+        attach_run_to_trace_events(db, correlation_id=trace_correlation_id, run_id=run_id)
         warnings_list.extend(_first_errors(import_result.warnings, limit=5))
         status = "imported"
         finished_at = _iso_now()
-        return _build_result(config, status, started_at, finished_at, run_id, errors_list, warnings_list)
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="import_completed",
+            phase="import",
+            message="Imported draft execution result.",
+            payload={"run_id": run_id, "warning_count": len(import_result.warnings)},
+            run_id=run_id,
+        )
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="phase_completed",
+            phase=trace_phase,
+            message="Draft execution completed.",
+            payload={"status": status, "warning_count": len(warnings_list)},
+            run_id=run_id,
+        )
+        return _build_result(
+            config,
+            status,
+            started_at,
+            finished_at,
+            run_id,
+            errors_list,
+            warnings_list,
+            trace_correlation_id=trace_correlation_id,
+        )
     finally:
         _unload_ollama_model(config)
 
@@ -408,12 +637,19 @@ def execute_research_brief_ollama_components(db: Session, brief) -> dict[str, An
         _unload_ollama_model(config)
 
 
-def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dict[str, Any]:
+def execute_research_brief_ollama_components_grounded(
+    db: Session,
+    brief,
+    *,
+    trace_correlation_id: str | None = None,
+) -> dict[str, Any]:
     from apd.services.web_research import get_grounding_source_packet_for_brief, render_grounding_source_packet
 
     config, missing_env = get_ollama_execution_config(db)
     component_repair_attempts = _parse_component_repair_attempts_env("APD_COMPONENT_REPAIR_ATTEMPTS", default=2)
     now = _iso_now()
+    trace_correlation_id = trace_correlation_id or create_trace_correlation_id(brief_id=brief.id)
+    execution_phase = "grounded_component_execution"
     if config is None:
         return {
             "success": False,
@@ -426,10 +662,39 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
             "run_id": None,
             "grounding_status": "config_missing",
             "grounding_errors": [f"Missing required env: {value}" for value in missing_env],
+            "trace_correlation_id": trace_correlation_id,
         }
+
+    _trace_execution_event(
+        db,
+        brief,
+        correlation_id=trace_correlation_id,
+        event_type="phase_started",
+        phase=execution_phase,
+        message="Grounded component execution started.",
+        payload={"provider": config.provider, "model": config.model},
+    )
 
     grounding_packet = get_grounding_source_packet_for_brief(db, brief)
     if not grounding_packet.sources or not grounding_packet.evidence_excerpts:
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="validation_failed",
+            phase=execution_phase,
+            message="Grounded component execution requires captured sources.",
+            payload={"status": "grounding_missing_sources"},
+        )
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="phase_completed",
+            phase=execution_phase,
+            message="Grounded component execution failed.",
+            payload={"status": "grounding_missing_sources"},
+        )
         return {
             "success": False,
             "provider": "ollama-components-grounded",
@@ -445,6 +710,7 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
             "grounding_errors": ["Run web discovery first to capture sources before grounded component execution."],
             "grounding_source_count": 0,
             "grounding_excerpt_count": 0,
+            "trace_correlation_id": trace_correlation_id,
         }
 
     started_at = now
@@ -477,6 +743,27 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
             prior_raw_batch: dict[str, Any] | None = None
             max_attempts = component_repair_attempts + 1
             attempts_by_phase[phase_name] = 0
+            selected_skill_ids = resolve_research_skills_for_phase(phase_name, max_skills=None)
+
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_started",
+                phase=phase_name,
+                message=f"Component phase {phase_name} started.",
+                payload={"attempt_limit": max_attempts, "candidate_count": len(candidate_ids)},
+            )
+            if selected_skill_ids:
+                _trace_execution_event(
+                    db,
+                    brief,
+                    correlation_id=trace_correlation_id,
+                    event_type="skill_context_selected",
+                    phase=phase_name,
+                    message=f"Selected research skills for {phase_name}.",
+                    payload={"skill_ids": selected_skill_ids, "skill_count": len(selected_skill_ids)},
+                )
 
             for attempt_index in range(max_attempts):
                 attempts_by_phase[phase_name] = attempt_index + 1
@@ -496,21 +783,90 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                         grounded_source_packet=grounded_source_packet,
                     )
 
+                if attempt_index > 0:
+                    _trace_execution_event(
+                        db,
+                        brief,
+                        correlation_id=trace_correlation_id,
+                        event_type="repair_attempted",
+                        phase=phase_name,
+                        message=f"Attempting repair for {phase_name}.",
+                        payload={"attempt": attempt_index + 1, "validation_error_count": len(errors_for_phase)},
+                    )
+
+                _trace_execution_event(
+                    db,
+                    brief,
+                    correlation_id=trace_correlation_id,
+                    event_type="model_call_started",
+                    phase=phase_name,
+                    message=f"Started model call for {phase_name}.",
+                    payload={
+                        "provider": config.provider,
+                        "model": config.model,
+                        "attempt": attempt_index + 1,
+                        "repair": attempt_index > 0,
+                    },
+                )
                 raw_batch_data, parse_error = _call_ollama_for_component_batch(config, prompt)
+                _trace_execution_event(
+                    db,
+                    brief,
+                    correlation_id=trace_correlation_id,
+                    event_type="model_call_completed",
+                    phase=phase_name,
+                    message=f"Completed model call for {phase_name}.",
+                    payload={
+                        "provider": config.provider,
+                        "model": config.model,
+                        "attempt": attempt_index + 1,
+                        "repair": attempt_index > 0,
+                        "success": parse_error is None,
+                        "error": parse_error,
+                        "event_count": len(raw_batch_data.get("events") or []) if raw_batch_data else 0,
+                    },
+                )
                 if parse_error:
                     errors_for_phase = [f"{phase_name}: {parse_error}"]
                     prior_raw_batch = None
+                    _trace_execution_event(
+                        db,
+                        brief,
+                        correlation_id=trace_correlation_id,
+                        event_type="validation_failed",
+                        phase=phase_name,
+                        message=f"Model output for {phase_name} failed parsing.",
+                        payload={"attempt": attempt_index + 1, "kind": "parse", "errors": errors_for_phase[:3]},
+                    )
                     continue
 
                 prior_raw_batch = raw_batch_data
                 batch, batch_errors = parse_component_batch_from_data(raw_batch_data)
                 if batch is None:
                     errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(batch_errors, limit=5)]
+                    _trace_execution_event(
+                        db,
+                        brief,
+                        correlation_id=trace_correlation_id,
+                        event_type="validation_failed",
+                        phase=phase_name,
+                        message=f"Model output for {phase_name} failed batch validation.",
+                        payload={"attempt": attempt_index + 1, "kind": "batch", "errors": errors_for_phase[:3]},
+                    )
                     continue
 
                 phase_errors = _validate_component_phase_batch(phase_name, batch)
                 if phase_errors:
                     errors_for_phase = phase_errors
+                    _trace_execution_event(
+                        db,
+                        brief,
+                        correlation_id=trace_correlation_id,
+                        event_type="validation_failed",
+                        phase=phase_name,
+                        message=f"Component batch for {phase_name} failed phase validation.",
+                        payload={"attempt": attempt_index + 1, "kind": "phase", "errors": errors_for_phase[:3]},
+                    )
                     continue
 
                 grounding_errors = _validate_component_grounding(
@@ -522,11 +878,29 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                 )
                 if grounding_errors:
                     errors_for_phase = grounding_errors
+                    _trace_execution_event(
+                        db,
+                        brief,
+                        correlation_id=trace_correlation_id,
+                        event_type="validation_failed",
+                        phase=phase_name,
+                        message=f"Component batch for {phase_name} failed grounding validation.",
+                        payload={"attempt": attempt_index + 1, "kind": "grounding", "errors": errors_for_phase[:3]},
+                    )
                     continue
 
                 assembly_result = assembler.apply_batch(batch)
                 if not assembly_result.success:
                     errors_for_phase = [f"{phase_name}: {line}" for line in _first_errors(assembly_result.errors, limit=5)]
+                    _trace_execution_event(
+                        db,
+                        brief,
+                        correlation_id=trace_correlation_id,
+                        event_type="validation_failed",
+                        phase=phase_name,
+                        message=f"Component batch for {phase_name} failed assembly.",
+                        payload={"attempt": attempt_index + 1, "kind": "assembly", "errors": errors_for_phase[:3]},
+                    )
                     continue
 
                 if phase_name == "candidate_batch":
@@ -536,6 +910,19 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                         if event.event_type == ResearchComponentEventType.CANDIDATE_PROPOSED
                     ]
                 warnings_list.extend(_first_errors(assembly_result.warnings, limit=5))
+                _trace_execution_event(
+                    db,
+                    brief,
+                    correlation_id=trace_correlation_id,
+                    event_type="phase_completed",
+                    phase=phase_name,
+                    message=f"Component phase {phase_name} completed.",
+                    payload={
+                        "status": "completed",
+                        "attempts": attempts_by_phase[phase_name],
+                        "event_count": len(batch.events),
+                    },
+                )
                 break
             else:
                 finished_at = _iso_now()
@@ -547,6 +934,24 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                             "or try a stronger model."
                         )
                     ]
+                _trace_execution_event(
+                    db,
+                    brief,
+                    correlation_id=trace_correlation_id,
+                    event_type="phase_completed",
+                    phase=phase_name,
+                    message=f"Component phase {phase_name} failed.",
+                    payload={"status": failure_status, "attempts": attempts_by_phase[phase_name], "errors": errors_for_phase[:3]},
+                )
+                _trace_execution_event(
+                    db,
+                    brief,
+                    correlation_id=trace_correlation_id,
+                    event_type="phase_completed",
+                    phase=execution_phase,
+                    message="Grounded component execution failed.",
+                    payload={"status": failure_status, "last_phase": phase_name},
+                )
                 return {
                     **_build_result(
                         config,
@@ -560,6 +965,7 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                         mode="grounded_component_execution",
                         last_phase=phase_name,
                         attempts_by_phase=attempts_by_phase,
+                        trace_correlation_id=trace_correlation_id,
                     ),
                     "grounding_status": "failed",
                     "grounding_errors": _first_errors(errors_for_phase or [f"{phase_name}: failed"], limit=5),
@@ -571,6 +977,24 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
         report = validate_agent_draft_data(Path("<ollama-grounded-components-output>"), assembled_package)
         if not report.is_valid or report.package is None:
             finished_at = _iso_now()
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="validation_failed",
+                phase="final_validation",
+                message="Grounded component execution failed final validation.",
+                payload={"errors": _first_errors(report.errors, limit=3)},
+            )
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_completed",
+                phase=execution_phase,
+                message="Grounded component execution failed.",
+                payload={"status": "validation_failed", "last_phase": "final_validation"},
+            )
             return {
                 **_build_result(
                     config,
@@ -584,6 +1008,7 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                     mode="grounded_component_execution",
                     last_phase="final_validation",
                     attempts_by_phase=attempts_by_phase,
+                    trace_correlation_id=trace_correlation_id,
                 ),
                 "grounding_status": "passed",
                 "grounding_errors": [],
@@ -595,6 +1020,24 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
         warnings_list.extend(quality_result.warnings)
         if quality_result.error:
             finished_at = _iso_now()
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="validation_failed",
+                phase="quality_gate",
+                message="Grounded component execution failed the quality gate.",
+                payload={"status": quality_result.status, "error": quality_result.error},
+            )
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_completed",
+                phase=execution_phase,
+                message="Grounded component execution failed.",
+                payload={"status": quality_result.status, "last_phase": "quality_gate"},
+            )
             return {
                 **_build_result(
                     config,
@@ -608,6 +1051,7 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                     mode="grounded_component_execution",
                     last_phase="quality_gate",
                     attempts_by_phase=attempts_by_phase,
+                    trace_correlation_id=trace_correlation_id,
                 ),
                 "grounding_status": "passed",
                 "grounding_errors": [],
@@ -624,6 +1068,15 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
             )
         except Exception as exc:
             finished_at = _iso_now()
+            _trace_execution_event(
+                db,
+                brief,
+                correlation_id=trace_correlation_id,
+                event_type="phase_completed",
+                phase=execution_phase,
+                message="Grounded component execution failed during import.",
+                payload={"status": "import_failed", "last_phase": "import"},
+            )
             return {
                 **_build_result(
                     config,
@@ -637,6 +1090,7 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                     mode="grounded_component_execution",
                     last_phase="import",
                     attempts_by_phase=attempts_by_phase,
+                    trace_correlation_id=trace_correlation_id,
                 ),
                 "grounding_status": "passed",
                 "grounding_errors": [],
@@ -646,6 +1100,27 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
 
         finished_at = _iso_now()
         warnings_list.extend(import_result.warnings)
+        attach_run_to_trace_events(db, correlation_id=trace_correlation_id, run_id=import_result.run_db_id)
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="import_completed",
+            phase="import",
+            message="Imported grounded component execution result.",
+            payload={"run_id": import_result.run_db_id, "warning_count": len(import_result.warnings)},
+            run_id=import_result.run_db_id,
+        )
+        _trace_execution_event(
+            db,
+            brief,
+            correlation_id=trace_correlation_id,
+            event_type="phase_completed",
+            phase=execution_phase,
+            message="Grounded component execution completed.",
+            payload={"status": "imported", "last_phase": "import"},
+            run_id=import_result.run_db_id,
+        )
         return {
             **_build_result(
                 config,
@@ -659,6 +1134,7 @@ def execute_research_brief_ollama_components_grounded(db: Session, brief) -> dic
                 mode="grounded_component_execution",
                 last_phase="import",
                 attempts_by_phase=attempts_by_phase,
+                trace_correlation_id=trace_correlation_id,
             ),
             "grounding_status": "passed",
             "grounding_errors": [],
@@ -681,6 +1157,7 @@ def _build_result(
     mode: str | None = None,
     last_phase: str | None = None,
     attempts_by_phase: dict[str, int] | None = None,
+    trace_correlation_id: str | None = None,
 ) -> dict[str, Any]:
     result = {
         "success": status == "imported" and run_id is not None,
@@ -699,6 +1176,8 @@ def _build_result(
         result["last_phase"] = last_phase
     if attempts_by_phase is not None:
         result["attempts_by_phase"] = dict(attempts_by_phase)
+    if trace_correlation_id is not None:
+        result["trace_correlation_id"] = trace_correlation_id
     return result
 
 

--- a/apd/services/research_trace.py
+++ b/apd/services/research_trace.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import re
+from typing import Any
+from urllib import parse
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from apd.domain.models import ResearchTraceEvent
+
+
+MAX_TRACE_MESSAGE_CHARS = 400
+MAX_TRACE_STRING_CHARS = 280
+MAX_TRACE_DICT_ITEMS = 16
+MAX_TRACE_LIST_ITEMS = 10
+MAX_TRACE_RESULTS = 200
+_REDACTED = "[redacted]"
+_TRUNCATED = "[truncated]"
+_WINDOWS_PATH_RE = re.compile(r"^[A-Za-z]:\\")
+_UNIX_PATH_PREFIXES = ("/Users/", "/home/", "/var/", "/tmp/")
+_SENSITIVE_KEY_FRAGMENTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "secret",
+    "session",
+    "token",
+)
+_PATH_KEY_FRAGMENTS = ("path", "file")
+
+
+def create_trace_correlation_id(*, brief_id: int | None = None) -> str:
+    prefix = f"brief-{brief_id}" if brief_id is not None else "trace"
+    return f"{prefix}-{uuid4().hex}"
+
+
+def append_research_trace_event(
+    db: Session,
+    *,
+    event_type: str,
+    brief_id: int | None = None,
+    run_id: int | None = None,
+    correlation_id: str | None = None,
+    phase: str | None = None,
+    message: str | None = None,
+    payload: Mapping[str, Any] | None = None,
+) -> ResearchTraceEvent:
+    event = ResearchTraceEvent(
+        brief_id=brief_id,
+        run_id=run_id,
+        correlation_id=(correlation_id or "").strip() or None,
+        phase=(phase or "").strip() or None,
+        event_type=(event_type or "").strip(),
+        message=_sanitize_message(message),
+        payload_json=sanitize_trace_payload(payload) if payload is not None else None,
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def list_research_trace_events(
+    db: Session,
+    *,
+    brief_id: int | None = None,
+    run_id: int | None = None,
+    correlation_id: str | None = None,
+    limit: int = MAX_TRACE_RESULTS,
+) -> list[ResearchTraceEvent]:
+    bounded_limit = max(1, min(limit, MAX_TRACE_RESULTS))
+    stmt = select(ResearchTraceEvent)
+    if brief_id is not None:
+        stmt = stmt.where(ResearchTraceEvent.brief_id == brief_id)
+    if run_id is not None:
+        stmt = stmt.where(ResearchTraceEvent.run_id == run_id)
+    if correlation_id:
+        stmt = stmt.where(ResearchTraceEvent.correlation_id == correlation_id)
+    stmt = stmt.order_by(ResearchTraceEvent.created_at.asc(), ResearchTraceEvent.id.asc()).limit(bounded_limit)
+    return list(db.scalars(stmt))
+
+
+def attach_run_to_trace_events(
+    db: Session,
+    *,
+    correlation_id: str,
+    run_id: int,
+) -> int:
+    if not correlation_id:
+        return 0
+
+    events = list(
+        db.scalars(
+            select(ResearchTraceEvent).where(
+                ResearchTraceEvent.correlation_id == correlation_id,
+                ResearchTraceEvent.run_id.is_(None),
+            )
+        )
+    )
+    for event in events:
+        event.run_id = run_id
+        db.add(event)
+    db.flush()
+    return len(events)
+
+
+def sanitize_trace_payload(payload: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if payload is None:
+        return None
+    sanitized = _sanitize_value(dict(payload), key=None, depth=0)
+    if isinstance(sanitized, dict):
+        return sanitized
+    return {"value": sanitized}
+
+
+def _sanitize_message(message: str | None) -> str | None:
+    if not message:
+        return None
+    collapsed = " ".join(str(message).split())
+    if len(collapsed) <= MAX_TRACE_MESSAGE_CHARS:
+        return collapsed
+    return collapsed[: MAX_TRACE_MESSAGE_CHARS - 3].rstrip() + "..."
+
+
+def _sanitize_value(value: Any, *, key: str | None, depth: int) -> Any:
+    lower_key = (key or "").strip().lower()
+    if depth >= 4:
+        return _TRUNCATED
+
+    if any(fragment in lower_key for fragment in _SENSITIVE_KEY_FRAGMENTS):
+        return _REDACTED
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    if isinstance(value, Mapping):
+        items = list(value.items())
+        sanitized: dict[str, Any] = {}
+        for child_key, child_value in items[:MAX_TRACE_DICT_ITEMS]:
+            sanitized[str(child_key)] = _sanitize_value(child_value, key=str(child_key), depth=depth + 1)
+        if len(items) > MAX_TRACE_DICT_ITEMS:
+            sanitized["_truncated_items"] = len(items) - MAX_TRACE_DICT_ITEMS
+        return sanitized
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        items = list(value)
+        sanitized_items = [
+            _sanitize_value(item, key=key, depth=depth + 1)
+            for item in items[:MAX_TRACE_LIST_ITEMS]
+        ]
+        if len(items) > MAX_TRACE_LIST_ITEMS:
+            sanitized_items.append(f"[{len(items) - MAX_TRACE_LIST_ITEMS} more items omitted]")
+        return sanitized_items
+
+    if isinstance(value, bytes):
+        return f"[{len(value)} bytes omitted]"
+
+    text = str(value).strip()
+    if not text:
+        return text
+
+    if "url" in lower_key:
+        return _sanitize_url(text)
+
+    if any(fragment in lower_key for fragment in _PATH_KEY_FRAGMENTS) or _looks_like_local_path(text):
+        return _REDACTED
+
+    if len(text) <= MAX_TRACE_STRING_CHARS:
+        return text
+    return text[: MAX_TRACE_STRING_CHARS - 3].rstrip() + "..."
+
+
+def _sanitize_url(value: str) -> str:
+    try:
+        parsed_url = parse.urlsplit(value)
+    except Exception:
+        return _REDACTED
+
+    scheme = (parsed_url.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return f"{scheme}://{_REDACTED}" if scheme else _REDACTED
+
+    hostname = parsed_url.hostname or ""
+    if not hostname:
+        return _REDACTED
+
+    netloc = hostname
+    if parsed_url.port:
+        default_port = 80 if scheme == "http" else 443
+        if parsed_url.port != default_port:
+            netloc = f"{hostname}:{parsed_url.port}"
+
+    path = parsed_url.path or "/"
+    safe_url = parse.urlunsplit((scheme, netloc, path, "", ""))
+    if len(safe_url) <= MAX_TRACE_STRING_CHARS:
+        return safe_url
+    return safe_url[: MAX_TRACE_STRING_CHARS - 3].rstrip() + "..."
+
+
+def _looks_like_local_path(value: str) -> bool:
+    if _WINDOWS_PATH_RE.match(value):
+        return True
+    return value.startswith(_UNIX_PATH_PREFIXES)

--- a/apd/services/web_research.py
+++ b/apd/services/web_research.py
@@ -19,7 +19,11 @@ from apd.services.research_execution_ollama import (
     extract_json_object_from_model_output,
     get_ollama_execution_config,
 )
-from apd.services.research_skills import render_research_skill_context_for_phase
+from apd.services.research_skills import (
+    render_research_skill_context_for_phase,
+    resolve_research_skills_for_phase,
+)
+from apd.services.research_trace import append_research_trace_event, create_trace_correlation_id
 
 SCHEMA_VERSION = "1.0"
 MAX_PROPOSED_QUERIES = 5
@@ -401,9 +405,37 @@ def render_grounding_source_packet(packet: GroundingSourcePacket) -> str:
     return "\n".join(lines).strip()
 
 
-def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, object]:
+def run_web_research_for_brief(
+    db: Session,
+    brief: ResearchBrief,
+    *,
+    trace_correlation_id: str | None = None,
+) -> dict[str, object]:
     config, missing = get_ollama_execution_config(db)
     started_at = _iso_now()
+    trace_correlation_id = trace_correlation_id or create_trace_correlation_id(brief_id=brief.id)
+    trace_phase = "web_discovery"
+    trace_run_id: int | None = None
+
+    def _trace(
+        event_type: str,
+        *,
+        run_id: int | None = None,
+        phase: str | None = None,
+        message: str | None = None,
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        append_research_trace_event(
+            db,
+            brief_id=brief.id,
+            run_id=run_id if run_id is not None else trace_run_id,
+            correlation_id=trace_correlation_id,
+            phase=phase or trace_phase,
+            event_type=event_type,
+            message=message,
+            payload=payload,
+        )
+
     if config is None:
         return {
             "success": False,
@@ -417,14 +449,49 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
             "fetched_source_count": 0,
             "skipped_urls": [],
             "sources": [],
+            "trace_correlation_id": trace_correlation_id,
         }
+
+    selected_skill_ids = resolve_research_skills_for_phase("web_discovery", max_skills=None)
+    _trace(
+        "phase_started",
+        message="Web discovery started.",
+        payload={"provider": config.provider, "model": config.model},
+    )
+    if selected_skill_ids:
+        _trace(
+            "skill_context_selected",
+            message="Selected research skills for web discovery.",
+            payload={"skill_ids": selected_skill_ids, "skill_count": len(selected_skill_ids)},
+        )
 
     prompt = build_web_research_target_prompt(brief)
     payload = _build_generate_payload(config, prompt, during_execution=True)
     try:
+        _trace(
+            "model_call_started",
+            message="Started web discovery model call.",
+            payload={"provider": config.provider, "model": config.model, "prompt_chars": len(prompt)},
+        )
         response_data, call_error = _ollama_generate(config, payload)
+        _trace(
+            "model_call_completed",
+            message="Completed web discovery model call.",
+            payload={
+                "provider": config.provider,
+                "model": config.model,
+                "success": call_error is None,
+                "error": call_error,
+                "response_chars": len(str(response_data.get("response") or "")) if response_data else 0,
+            },
+        )
         if call_error:
             finished_at = _iso_now()
+            _trace(
+                "phase_completed",
+                message="Web discovery failed.",
+                payload={"status": "provider_error", "error_count": 1},
+            )
             return {
                 "success": False,
                 "status": "provider_error",
@@ -437,11 +504,22 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
                 "fetched_source_count": 0,
                 "skipped_urls": [],
                 "sources": [],
+                "trace_correlation_id": trace_correlation_id,
             }
 
         raw_output = str(response_data.get("response") or "")
         if not raw_output.strip():
             finished_at = _iso_now()
+            _trace(
+                "validation_failed",
+                message="Web discovery returned an empty response.",
+                payload={"reason": "provider_error: empty_ollama_response"},
+            )
+            _trace(
+                "phase_completed",
+                message="Web discovery failed.",
+                payload={"status": "parse_failed", "error_count": 1},
+            )
             return {
                 "success": False,
                 "status": "parse_failed",
@@ -454,11 +532,22 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
                 "fetched_source_count": 0,
                 "skipped_urls": [],
                 "sources": [],
+                "trace_correlation_id": trace_correlation_id,
             }
 
         targets, parse_error = parse_web_research_targets(raw_output)
         if parse_error or targets is None:
             finished_at = _iso_now()
+            _trace(
+                "validation_failed",
+                message="Web discovery target output failed validation.",
+                payload={"reason": parse_error or "parse_failed: invalid_web_targets"},
+            )
+            _trace(
+                "phase_completed",
+                message="Web discovery failed.",
+                payload={"status": "parse_failed", "error_count": 1},
+            )
             return {
                 "success": False,
                 "status": "parse_failed",
@@ -471,6 +560,7 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
                 "fetched_source_count": 0,
                 "skipped_urls": [],
                 "sources": [],
+                "trace_correlation_id": trace_correlation_id,
             }
 
         queries = list(targets.get("queries") or [])
@@ -478,6 +568,7 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
         capped_queries = queries[:MAX_PROPOSED_QUERIES]
         capped_url_targets = url_targets[:MAX_FETCH_URLS]
         run = _get_or_create_web_research_run(db, brief)
+        trace_run_id = run.id
         skipped_urls: list[dict[str, str]] = []
         source_summaries: list[dict[str, object]] = []
         fetched_source_count = 0
@@ -489,9 +580,21 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
             normalized_url, validation_error = validate_public_url(raw_url)
             if validation_error or normalized_url is None:
                 skipped_urls.append({"url": raw_url, "reason": validation_error or "invalid_url"})
+                _trace(
+                    "url_rejected",
+                    run_id=run.id,
+                    message="Rejected proposed URL.",
+                    payload={"url": raw_url, "reason": validation_error or "invalid_url"},
+                )
                 continue
             if normalized_url in seen_urls:
                 skipped_urls.append({"url": normalized_url, "reason": "duplicate_in_request"})
+                _trace(
+                    "url_rejected",
+                    run_id=run.id,
+                    message="Rejected duplicate proposed URL.",
+                    payload={"url": normalized_url, "reason": "duplicate_in_request"},
+                )
                 continue
             seen_urls.add(normalized_url)
 
@@ -500,9 +603,33 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
             )
             if existing_source is not None:
                 skipped_urls.append({"url": normalized_url, "reason": "duplicate_existing_source"})
+                _trace(
+                    "url_rejected",
+                    run_id=run.id,
+                    message="Rejected already-captured URL.",
+                    payload={"url": normalized_url, "reason": "duplicate_existing_source"},
+                )
                 continue
 
+            _trace(
+                "tool_call_started",
+                run_id=run.id,
+                message="Fetching public web source.",
+                payload={"tool_name": "fetch_public_url", "url": normalized_url},
+            )
             fetch_result = fetch_public_url(normalized_url)
+            _trace(
+                "tool_call_completed",
+                run_id=run.id,
+                message="Completed public web fetch.",
+                payload={
+                    "tool_name": "fetch_public_url",
+                    "url": normalized_url,
+                    "success": bool(fetch_result.get("success")),
+                    "status_code": fetch_result.get("status_code"),
+                    "error": fetch_result.get("error"),
+                },
+            )
             if not fetch_result.get("success"):
                 skipped_urls.append({"url": normalized_url, "reason": str(fetch_result.get("error") or "fetch_failed")})
                 continue
@@ -558,6 +685,19 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
                     "content_type": content_type,
                 }
             )
+            _trace(
+                "source_fetched",
+                run_id=run.id,
+                message="Fetched and stored public web source.",
+                payload={
+                    "capture_run_id": run.id,
+                    "source_id": source.id,
+                    "excerpt_id": excerpt_id,
+                    "url": source.url,
+                    "content_type": content_type,
+                    "extraction_error": extraction_error,
+                },
+            )
 
         run.source_count = db.scalar(select(func.count()).select_from(Source).where(Source.run_id == run.id)) or 0
         db.add(run)
@@ -569,6 +709,19 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
             warnings.append(f"capped_queries_at_{MAX_PROPOSED_QUERIES}")
         if len(url_targets) > MAX_FETCH_URLS:
             warnings.append(f"capped_urls_at_{MAX_FETCH_URLS}")
+        _trace(
+            "phase_completed",
+            run_id=run.id,
+            message="Web discovery completed.",
+            payload={
+                "status": status,
+                "capture_run_id": run.id,
+                "proposed_query_count": len(capped_queries),
+                "proposed_url_count": len(capped_url_targets),
+                "fetched_source_count": fetched_source_count,
+                "skipped_url_count": len(skipped_urls),
+            },
+        )
         result = {
             "success": fetched_source_count > 0,
             "status": status,
@@ -583,6 +736,7 @@ def run_web_research_for_brief(db: Session, brief: ResearchBrief) -> dict[str, o
             "sources": source_summaries[:10],
             "queries": capped_queries,
             "web_research_run_id": run.id,
+            "trace_correlation_id": trace_correlation_id,
         }
         if fetched_source_count == 0:
             result["errors"] = ["No valid public URLs were fetched. Proposed queries were stored for future work."]

--- a/apd/web/routes.py
+++ b/apd/web/routes.py
@@ -32,6 +32,7 @@ from apd.services.research_execution_ollama import (
     get_ollama_execution_config,
 )
 from apd.services.research_execution_stub import execute_research_brief_stub
+from apd.services.research_trace import create_trace_correlation_id, list_research_trace_events
 from apd.services.web_research import get_grounding_source_packet_for_brief, run_web_research_for_brief
 from apd.web.queries import get_recent_runs, get_run_detail
 
@@ -100,12 +101,26 @@ def _component_execution_phase_data(result: dict) -> dict:
     }
 
 
+def _get_last_execution_trace_events(db: Session, brief) -> list:
+    execution = (brief.metadata_json or {}).get("last_execution") or {}
+    correlation_id = str(execution.get("trace_correlation_id") or "").strip()
+    if not correlation_id:
+        return []
+    return list_research_trace_events(
+        db,
+        brief_id=brief.id,
+        correlation_id=correlation_id,
+        limit=120,
+    )
+
+
 def _build_web_assisted_execution_result(
     *,
     model: str,
     started_at: str,
     web_discovery_result: dict,
     component_result: dict,
+    trace_correlation_id: str | None = None,
 ) -> dict:
     errors = _prefixed_messages("web_discovery", web_discovery_result.get("errors"))
     errors.extend(_prefixed_messages("component_execution", component_result.get("errors")))
@@ -113,7 +128,7 @@ def _build_web_assisted_execution_result(
     warnings = _prefixed_messages("web_discovery", web_discovery_result.get("warnings"))
     warnings.extend(_prefixed_messages("component_execution", component_result.get("warnings")))
 
-    return {
+    result = {
         "success": bool(component_result.get("success")),
         "provider": "ollama-components",
         "model": model,
@@ -133,6 +148,9 @@ def _build_web_assisted_execution_result(
             "but this does not prove grounded claims are true. Human review is still required."
         ),
     }
+    if trace_correlation_id:
+        result["trace_correlation_id"] = trace_correlation_id
+    return result
 
 
 @router.get("/", response_class=RedirectResponse, include_in_schema=False)
@@ -352,6 +370,7 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
         raise HTTPException(status_code=404, detail="Research brief not found")
     ollama_config, missing_ollama_env = get_ollama_execution_config(db)
     grounding_packet = get_grounding_source_packet_for_brief(db, brief)
+    trace_events = _get_last_execution_trace_events(db, brief)
     return templates.TemplateResponse(
         request,
         "brief_detail.html",
@@ -362,6 +381,7 @@ def brief_detail(brief_id: int, request: Request, db: Session = Depends(_get_db)
             "ollama_model": ollama_config.model if ollama_config else None,
             "grounded_source_count": len(grounding_packet.sources),
             "grounded_excerpt_count": len(grounding_packet.evidence_excerpts),
+            "trace_events": trace_events,
         },
     )
 
@@ -452,7 +472,8 @@ def research_web_sources(brief_id: int, db: Session = Depends(_get_db)):
     if brief is None:
         raise HTTPException(status_code=404, detail="Research brief not found")
 
-    result = run_web_research_for_brief(db, brief)
+    trace_correlation_id = create_trace_correlation_id(brief_id=brief.id)
+    result = run_web_research_for_brief(db, brief, trace_correlation_id=trace_correlation_id)
     config, _ = get_ollama_execution_config(db)
     _save_last_execution(
         db,
@@ -468,6 +489,7 @@ def research_web_sources(brief_id: int, db: Session = Depends(_get_db)):
             "errors": _prefixed_messages("web_discovery", result.get("errors"))[:5],
             "warnings": _prefixed_messages("web_discovery", result.get("warnings"))[:5],
             "run_id": None,
+            "trace_correlation_id": result.get("trace_correlation_id") or trace_correlation_id,
             "web_discovery": _web_discovery_phase_data(result),
             "source_grounding_status": "not_started",
             "source_grounding_deferred_issue": 63,
@@ -505,6 +527,7 @@ def start_research_ollama_components_grounded(brief_id: int, db: Session = Depen
         return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 
     started_at = _iso_now()
+    trace_correlation_id = create_trace_correlation_id(brief_id=brief.id)
     _save_last_execution(
         db,
         brief,
@@ -517,12 +540,17 @@ def start_research_ollama_components_grounded(brief_id: int, db: Session = Depen
             "warnings": [],
             "run_id": None,
             "mode": "grounded_component_execution",
+            "trace_correlation_id": trace_correlation_id,
             "component_execution": {"status": "pending"},
             "source_grounding_status": "running",
         },
     )
 
-    result = execute_research_brief_ollama_components_grounded(db, brief)
+    result = execute_research_brief_ollama_components_grounded(
+        db,
+        brief,
+        trace_correlation_id=trace_correlation_id,
+    )
     _save_last_execution(db, brief, result)
 
     if result.get("success") and result.get("run_id"):
@@ -553,6 +581,7 @@ def start_research_ollama(brief_id: int, db: Session = Depends(_get_db)):
         )
         return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 
+    trace_correlation_id = create_trace_correlation_id(brief_id=brief.id)
     _save_last_execution(
         db,
         brief,
@@ -564,10 +593,11 @@ def start_research_ollama(brief_id: int, db: Session = Depends(_get_db)):
             "errors": [],
             "warnings": [],
             "run_id": None,
+            "trace_correlation_id": trace_correlation_id,
         },
     )
 
-    result = execute_research_brief_ollama(db, brief)
+    result = execute_research_brief_ollama(db, brief, trace_correlation_id=trace_correlation_id)
     _save_last_execution(db, brief, result)
 
     if result.get("success") and result.get("run_id"):
@@ -600,6 +630,7 @@ def start_research_ollama_components(brief_id: int, db: Session = Depends(_get_d
         return RedirectResponse(url=f"/briefs/{brief.id}", status_code=303)
 
     started_at = _iso_now()
+    trace_correlation_id = create_trace_correlation_id(brief_id=brief.id)
     _save_last_execution(
         db,
         brief,
@@ -612,19 +643,29 @@ def start_research_ollama_components(brief_id: int, db: Session = Depends(_get_d
             "warnings": [],
             "run_id": None,
             "mode": "web_assisted_component_execution",
+            "trace_correlation_id": trace_correlation_id,
             "web_discovery": {"status": "pending"},
             "component_execution": {"status": "pending"},
             "source_grounding_status": "pending",
         },
     )
 
-    web_discovery_result = run_web_research_for_brief(db, brief)
-    component_result = execute_research_brief_ollama_components_grounded(db, brief)
+    web_discovery_result = run_web_research_for_brief(
+        db,
+        brief,
+        trace_correlation_id=trace_correlation_id,
+    )
+    component_result = execute_research_brief_ollama_components_grounded(
+        db,
+        brief,
+        trace_correlation_id=trace_correlation_id,
+    )
     result = _build_web_assisted_execution_result(
         model=config.model,
         started_at=started_at,
         web_discovery_result=web_discovery_result,
         component_result=component_result,
+        trace_correlation_id=trace_correlation_id,
     )
     _save_last_execution(db, brief, result)
 

--- a/apd/web/templates/brief_detail.html
+++ b/apd/web/templates/brief_detail.html
@@ -207,6 +207,31 @@
     </div>
     {% endif %}
 
+    {% if trace_events %}
+    <details class="execution-raw-details">
+      <summary>Show trace events ({{ trace_events | length }})</summary>
+      <div class="execution-trace-events">
+        {% for event in trace_events %}
+        <div style="margin: 0 0 1rem 0; padding-bottom: 1rem; border-bottom: 1px solid rgba(148, 163, 184, 0.2);">
+          <div>
+            <strong>{{ event.created_at.strftime("%Y-%m-%d %H:%M:%S UTC") if event.created_at else "—" }}</strong>
+            <span class="muted">{{ event.event_type }}{% if event.phase %} · {{ event.phase }}{% endif %}</span>
+          </div>
+          {% if event.message %}
+          <div style="margin-top: 0.25rem;">{{ event.message }}</div>
+          {% endif %}
+          {% if event.payload_json %}
+          <details style="margin-top: 0.5rem;">
+            <summary>Payload</summary>
+            <pre class="execution-raw-json">{{ event.payload_json | tojson(indent=2) }}</pre>
+          </details>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </details>
+    {% endif %}
+
     <details class="execution-raw-details">
       <summary>Show raw execution details</summary>
       <pre class="execution-raw-json">{{ execution | tojson(indent=2) }}</pre>

--- a/docs/briefs.md
+++ b/docs/briefs.md
@@ -84,6 +84,8 @@ If the manifest references a missing skill file or invalid skill id, prompt cons
 
 The brief detail page stores and displays a concise `last_execution` summary.
 
+Each research execution also writes a bounded research trace log keyed to that execution's correlation id. Those trace events are durable debugging and observability data for replay preparation, future eval harness work, and model/harness comparison rather than normal user-facing output.
+
 The page prioritizes:
 
 - overall status
@@ -94,6 +96,8 @@ The page prioritizes:
 - readable error summaries
 
 Raw execution JSON is secondary debug material. It remains available behind a collapsed details disclosure.
+
+Raw trace events are also exposed behind a collapsed disclosure near the raw execution payload. Trace payloads are sanitized and bounded so APD does not persist credentials, secrets, or local file paths as trace data.
 
 Common execution outcomes include:
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -17,6 +17,7 @@ EXPECTED_TABLES = {
     "review_notes",
     "decisions",
     "artifacts",
+    "research_trace_events",
 }
 
 

--- a/tests/test_research_execution.py
+++ b/tests/test_research_execution.py
@@ -22,6 +22,7 @@ from apd.services.research_execution_ollama import (
     extract_json_object_from_model_output,
     get_ollama_execution_config,
 )
+from apd.services.research_trace import list_research_trace_events
 from apd.services.research_execution_stub import execute_research_brief_stub
 
 
@@ -380,7 +381,7 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
 
     grounded_ids: dict[str, str] = {}
 
-    def _fake_run_web_research_for_brief(db, brief):
+    def _fake_run_web_research_for_brief(db, brief, trace_correlation_id=None):
         source, excerpt = _seed_captured_web_source(db, brief)
         grounded_ids["source_id"] = f"captured-source-{source.id}"
         grounded_ids["excerpt_id"] = f"captured-excerpt-{excerpt.id}"
@@ -398,6 +399,7 @@ def test_start_research_ollama_components_uses_saved_db_settings(client, monkeyp
             "sources": [{"url": "https://example.com/article", "title": "Example article"}],
             "skipped_urls": [],
             "web_research_run_id": 11,
+            "trace_correlation_id": trace_correlation_id,
         }
 
     monkeypatch.setattr("apd.web.routes.run_web_research_for_brief", _fake_run_web_research_for_brief)
@@ -486,7 +488,7 @@ def test_web_assisted_research_records_web_discovery_phase_in_last_execution(cli
 
     monkeypatch.setattr(
         "apd.web.routes.run_web_research_for_brief",
-        lambda db, brief: {
+        lambda db, brief, trace_correlation_id=None: {
             "success": True,
             "status": "completed",
             "started_at": "2026-04-28T00:00:00+00:00",
@@ -500,11 +502,12 @@ def test_web_assisted_research_records_web_discovery_phase_in_last_execution(cli
             "sources": [{"url": "https://example.com/source", "title": "Captured source"}],
             "skipped_urls": [],
             "web_research_run_id": 12,
+            "trace_correlation_id": trace_correlation_id,
         },
     )
     monkeypatch.setattr(
         "apd.web.routes.execute_research_brief_ollama_components_grounded",
-        lambda db, brief: {
+        lambda db, brief, trace_correlation_id=None: {
             "success": False,
             "provider": "ollama-components-grounded",
             "status": "component_validation_failed",
@@ -520,6 +523,7 @@ def test_web_assisted_research_records_web_discovery_phase_in_last_execution(cli
             "grounding_errors": ["claim_theme_batch: unknown grounded source_id 'captured-source-9999'"],
             "grounding_source_count": 1,
             "grounding_excerpt_count": 1,
+            "trace_correlation_id": trace_correlation_id,
         },
     )
 
@@ -585,6 +589,9 @@ def test_execute_grounded_components_imports_run_with_grounded_evidence_links(db
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
 
     result = execute_research_brief_ollama_components_grounded(db, brief)
+    trace_events = list_research_trace_events(db, brief_id=brief.id, correlation_id=result["trace_correlation_id"])
+    phase_completed = [event.phase for event in trace_events if event.event_type == "phase_completed"]
+    event_types = [event.event_type for event in trace_events]
 
     assert result["success"] is True
     assert result["status"] == "imported"
@@ -592,6 +599,14 @@ def test_execute_grounded_components_imports_run_with_grounded_evidence_links(db
     assert isinstance(result["run_id"], int)
     assert grounded_source_id in captured_payloads[0]["prompt"]
     assert "Use only the provided APD-captured source packet" in captured_payloads[0]["prompt"]
+    assert "skill_context_selected" in event_types
+    assert "model_call_started" in event_types
+    assert "model_call_completed" in event_types
+    assert "import_completed" in event_types
+    assert "candidate_batch" in phase_completed
+    assert "claim_theme_batch" in phase_completed
+    assert "validation_gate_batch" in phase_completed
+    assert "grounded_component_execution" in phase_completed
 
 
 def test_execute_grounded_components_rejects_unknown_source_id(db, monkeypatch):
@@ -622,9 +637,11 @@ def test_execute_grounded_components_rejects_unknown_source_id(db, monkeypatch):
 
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
     result = execute_research_brief_ollama_components_grounded(db, brief)
+    trace_events = list_research_trace_events(db, brief_id=brief.id, correlation_id=result["trace_correlation_id"])
     assert result["success"] is False
     assert result["grounding_status"] == "failed"
     assert any("unknown grounded source_id" in err for err in result["grounding_errors"])
+    assert any(event.event_type == "validation_failed" for event in trace_events)
 
 
 def test_execute_grounded_components_rejects_unknown_excerpt_id(db, monkeypatch):
@@ -946,10 +963,14 @@ def test_execute_ollama_validation_failure_repair_succeeds(db, monkeypatch):
     monkeypatch.setattr("apd.services.research_execution_ollama._ollama_generate", _fake_generate)
 
     result = execute_research_brief_ollama(db, brief)
+    trace_events = list_research_trace_events(db, brief_id=brief.id, correlation_id=result["trace_correlation_id"])
+    event_types = [event.event_type for event in trace_events]
     assert calls["count"] == 2
     assert result["success"] is True
     assert result["status"] == "imported"
     assert isinstance(result["run_id"], int)
+    assert "repair_attempted" in event_types
+    assert "import_completed" in event_types
 
 
 def test_execute_ollama_zero_candidate_fails_quality_gate(db, monkeypatch):
@@ -1121,7 +1142,7 @@ def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):
     )
     monkeypatch.setattr(
         "apd.web.routes.run_web_research_for_brief",
-        lambda db, brief: {
+        lambda db, brief, trace_correlation_id=None: {
             "success": True,
             "status": "completed",
             "started_at": "2026-01-01T00:00:00+00:00",
@@ -1134,11 +1155,12 @@ def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):
             "queries": [],
             "sources": [],
             "skipped_urls": [],
+            "trace_correlation_id": trace_correlation_id,
         },
     )
     monkeypatch.setattr(
         "apd.web.routes.execute_research_brief_ollama",
-        lambda db, brief: {
+        lambda db, brief, trace_correlation_id=None: {
             "success": False,
             "provider": "ollama",
             "model": "llama3",
@@ -1148,6 +1170,7 @@ def test_start_research_ollama_route_uses_mocked_service(client, monkeypatch):
             "errors": ["mocked failure"],
             "warnings": [],
             "run_id": None,
+            "trace_correlation_id": trace_correlation_id,
         },
     )
 
@@ -1170,7 +1193,7 @@ def test_start_research_ollama_components_route_uses_mocked_service(client, monk
     )
     monkeypatch.setattr(
         "apd.web.routes.execute_research_brief_ollama_components_grounded",
-        lambda db, brief: {
+        lambda db, brief, trace_correlation_id=None: {
             "success": False,
             "provider": "ollama-components-grounded",
             "model": "llama3",
@@ -1182,6 +1205,7 @@ def test_start_research_ollama_components_route_uses_mocked_service(client, monk
             "run_id": None,
             "grounding_status": "failed",
             "grounding_errors": ["mocked components failure"],
+            "trace_correlation_id": trace_correlation_id,
         },
     )
 

--- a/tests/test_research_trace.py
+++ b/tests/test_research_trace.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import pytest
+
+from apd.app.db import Base
+from apd.domain.models import Run, RunPhase
+from apd.services.research_brief_service import create_brief
+from apd.services.research_trace import (
+    append_research_trace_event,
+    attach_run_to_trace_events,
+    create_trace_correlation_id,
+    list_research_trace_events,
+)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    db_path = tmp_path / "test_research_trace.db"
+    engine = create_engine(
+        f"sqlite+pysqlite:///{db_path}",
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    with Session() as session:
+        yield session
+
+
+@pytest.fixture()
+def client_and_session(tmp_path, monkeypatch):
+    db_path = tmp_path / "test_research_trace_client.db"
+    db_url = f"sqlite+pysqlite:///{db_path}"
+    test_engine = create_engine(
+        db_url,
+        future=True,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(test_engine)
+    TestSession = sessionmaker(bind=test_engine, autoflush=False, autocommit=False, future=True)
+
+    import apd.app.db as app_db
+    import apd.web.routes as web_routes
+
+    monkeypatch.setattr(app_db, "engine", test_engine)
+    monkeypatch.setattr(app_db, "SessionLocal", TestSession)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from apd.app.main import app
+    from fastapi.testclient import TestClient
+
+    app.dependency_overrides[web_routes._get_db] = _override_get_db
+
+    with TestClient(app, raise_server_exceptions=True) as client:
+        yield client, TestSession
+
+    app.dependency_overrides.clear()
+
+
+def test_trace_event_helpers_create_retrieve_and_attach_run(db):
+    brief = create_brief(db, title="Trace brief", research_question="Q")
+    run = Run(title="Trace run", intent="Q", phase=RunPhase.EVIDENCE_COLLECTED)
+    db.add(run)
+    db.flush()
+
+    correlation_id = create_trace_correlation_id(brief_id=brief.id)
+    append_research_trace_event(
+        db,
+        brief_id=brief.id,
+        correlation_id=correlation_id,
+        event_type="phase_started",
+        phase="web_discovery",
+        message="Trace started.",
+        payload={
+            "api_key": "super-secret",
+            "raw_path": r"C:\Users\jjmgo\private.txt",
+            "url": "https://example.com/thread?token=hidden",
+        },
+    )
+    append_research_trace_event(
+        db,
+        brief_id=brief.id,
+        correlation_id=correlation_id,
+        event_type="validation_failed",
+        phase="claim_theme_batch",
+        payload={"errors": ["missing excerpt"]},
+    )
+
+    events = list_research_trace_events(db, brief_id=brief.id, correlation_id=correlation_id)
+
+    assert len(events) == 2
+    assert events[0].payload_json["api_key"] == "[redacted]"
+    assert events[0].payload_json["raw_path"] == "[redacted]"
+    assert events[0].payload_json["url"] == "https://example.com/thread"
+
+    attached_count = attach_run_to_trace_events(db, correlation_id=correlation_id, run_id=run.id)
+    run_events = list_research_trace_events(db, run_id=run.id)
+
+    assert attached_count == 2
+    assert len(run_events) == 2
+
+
+def test_brief_detail_renders_trace_events_in_collapsed_section(client_and_session):
+    client, TestSession = client_and_session
+
+    with TestSession() as db:
+        brief = create_brief(db, title="Trace UI brief", research_question="What happened?")
+        brief_id = brief.id
+        correlation_id = create_trace_correlation_id(brief_id=brief.id)
+        append_research_trace_event(
+            db,
+            brief_id=brief.id,
+            correlation_id=correlation_id,
+            event_type="validation_failed",
+            phase="claim_theme_batch",
+            message="Grounding mismatch detected.",
+            payload={"authorization": "Bearer secret-token", "error": "unknown grounded source_id"},
+        )
+        brief.metadata_json = {
+            "last_execution": {
+                "status": "component_validation_failed",
+                "trace_correlation_id": correlation_id,
+                "errors": ["component_execution: claim_theme_batch failed"],
+            }
+        }
+        db.add(brief)
+        db.commit()
+
+    response = client.get(f"/briefs/{brief_id}")
+
+    assert response.status_code == 200
+    assert "Show trace events (1)" in response.text
+    assert "Grounding mismatch detected." in response.text
+    assert "validation_failed" in response.text
+    assert "[redacted]" in response.text

--- a/tests/test_web_research.py
+++ b/tests/test_web_research.py
@@ -10,6 +10,7 @@ from apd.app.db import Base
 from apd.domain.models import EvidenceExcerpt, ResearchBrief, Run, RunPhase, Source
 from apd.services.model_execution_settings import save_model_execution_settings
 from apd.services.research_brief_service import create_brief
+from apd.services.research_trace import list_research_trace_events
 from apd.services import web_research
 
 
@@ -109,10 +110,12 @@ def test_run_web_research_stores_source_and_excerpt(db, monkeypatch):
         },
     )
 
-    result = web_research.run_web_research_for_brief(db, brief)
+    result = web_research.run_web_research_for_brief(db, brief, trace_correlation_id="trace-web-success")
 
     assert result["status"] == "completed"
     assert result["fetched_source_count"] == 1
+    trace_events = list_research_trace_events(db, brief_id=brief.id, correlation_id=result["trace_correlation_id"])
+    trace_event_types = [event.event_type for event in trace_events]
 
     saved_run = db.scalar(select(Run).where(Run.id == result["web_research_run_id"]))
     saved_source = db.scalar(select(Source).where(Source.run_id == saved_run.id))
@@ -126,6 +129,14 @@ def test_run_web_research_stores_source_and_excerpt(db, monkeypatch):
     assert saved_excerpt is not None
     assert "backup checks" in saved_excerpt.excerpt_text
     assert saved_brief.metadata_json["web_research_run_id"] == result["web_research_run_id"]
+    assert "phase_started" in trace_event_types
+    assert "skill_context_selected" in trace_event_types
+    assert "model_call_started" in trace_event_types
+    assert "model_call_completed" in trace_event_types
+    assert "tool_call_started" in trace_event_types
+    assert "tool_call_completed" in trace_event_types
+    assert "source_fetched" in trace_event_types
+    assert "phase_completed" in trace_event_types
 
 
 def test_get_grounding_source_packet_for_brief_includes_captured_ids_and_text(db):
@@ -252,13 +263,17 @@ def test_run_web_research_rejects_invalid_urls_without_fetching(db, monkeypatch)
 
     monkeypatch.setattr(web_research, "fetch_public_url", _should_not_fetch)
 
-    result = web_research.run_web_research_for_brief(db, brief)
+    result = web_research.run_web_research_for_brief(db, brief, trace_correlation_id="trace-web-rejected")
+    trace_events = list_research_trace_events(db, brief_id=brief.id, correlation_id=result["trace_correlation_id"])
+    rejected_payloads = [event.payload_json for event in trace_events if event.event_type == "url_rejected"]
 
     assert result["status"] == "no_valid_urls"
     assert result["fetched_source_count"] == 0
     reasons = {item["reason"] for item in result["skipped_urls"]}
     assert "unsupported_scheme" in reasons
     assert "local_host_not_allowed" in reasons
+    assert len(rejected_payloads) == 2
+    assert {payload["reason"] for payload in rejected_payloads} == {"unsupported_scheme", "local_host_not_allowed"}
 
 
 
@@ -307,7 +322,7 @@ def test_capture_only_web_discovery_route_renders_phase_status(client_and_sessio
     assert response.status_code == 303
     brief_id = int(response.headers["location"].split("/")[-1])
 
-    def _fake_run_web_research_for_brief(db, brief):
+    def _fake_run_web_research_for_brief(db, brief, trace_correlation_id=None):
         return {
             "status": "completed",
             "started_at": "2026-04-28T00:00:00+00:00",
@@ -321,6 +336,7 @@ def test_capture_only_web_discovery_route_renders_phase_status(client_and_sessio
             "queries": [{"query": "support escalation pain", "rationale": "seed"}],
             "sources": [{"url": "https://example.com/article", "title": "Example article"}],
             "skipped_urls": [],
+            "trace_correlation_id": trace_correlation_id,
         }
 
     import apd.web.routes as web_routes


### PR DESCRIPTION
Refs #71

## Summary
- add a durable esearch_trace_events table, SQLAlchemy model, Alembic migration, and trace helper service
- instrument web discovery and grounded/plain Ollama execution with bounded trace events and correlation ids
- expose trace events behind a collapsed brief-detail disclosure and add focused trace/instrumentation tests

## Instrumented trace events
- web discovery start/completion
- model call start/completion
- url rejected
- source fetched
- component phase start/completion
- skill context selected
- validation failed
- repair attempted
- import completed

## Safety
- trace payloads are bounded and sanitized to avoid credentials, API keys, secrets, auth headers, and local file paths
- no hosted telemetry or external logging providers were added

## Verification
- uv run pytest tests/test_research_trace.py -q
- uv run pytest tests/test_research_execution.py tests/test_web_research.py -q
- .\\scripts\\test.ps1
- uv run python scripts/check_repo_readiness.py