### PR TITLE
Add APD research eval harness with controlled mini-web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 # Generated autonomous run outputs
 research-corpus/runs/*
 artifacts/runs/*
+evals/research/results/*.json
 
 # Keep the run container docs/structure
 !research-corpus/runs/README.md

--- a/apd/evals/__init__.py
+++ b/apd/evals/__init__.py
@@ -1,0 +1,3 @@
+from apd.evals.research_runner import run_fixture_research_evals
+
+__all__ = ["run_fixture_research_evals"]

--- a/apd/evals/research_runner.py
+++ b/apd/evals/research_runner.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import time
+from typing import Any
+from urllib import parse
+
+import yaml
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from apd.app.db import Base
+from apd.services.agent_draft_import import import_agent_draft_package
+from apd.services.agent_draft_validation import validate_agent_draft_data
+from apd.services.research_components import ComponentDraftAssembler, parse_component_batch_from_data
+from apd.services.web_research import extract_title_and_text
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CASES_DIR = REPO_ROOT / "evals" / "research" / "cases"
+DEFAULT_FIXTURES_DIR = REPO_ROOT / "evals" / "research" / "fixtures"
+DEFAULT_RESULTS_DIR = REPO_ROOT / "evals" / "research" / "results"
+PHASE_ORDER = ("candidate_batch", "claim_theme_batch", "validation_gate_batch")
+
+
+@dataclass(frozen=True)
+class CaseRunResult:
+    case_id: str
+    result: dict[str, Any]
+
+
+def load_research_eval_cases(cases_dir: Path = DEFAULT_CASES_DIR) -> list[dict[str, Any]]:
+    case_paths = sorted(cases_dir.glob("*.yaml"))
+    cases: list[dict[str, Any]] = []
+    for case_path in case_paths:
+        raw_data = yaml.safe_load(case_path.read_text(encoding="utf-8"))
+        if not isinstance(raw_data, dict):
+            raise ValueError(f"Eval case must be a mapping: {case_path}")
+        cases.append(_normalize_case(case_path, raw_data))
+    return cases
+
+
+def run_fixture_research_evals(
+    *,
+    cases_dir: Path = DEFAULT_CASES_DIR,
+    fixtures_dir: Path = DEFAULT_FIXTURES_DIR,
+    results_dir: Path = DEFAULT_RESULTS_DIR,
+    fixture_only: bool = True,
+    model_label: str = "fixture-mocked",
+    harness_label: str = "apd-research-eval-fixture-v1",
+    write_results: bool = True,
+) -> dict[str, Any]:
+    if not fixture_only:
+        raise ValueError("Only fixture-only execution is supported in the first eval harness version.")
+
+    started_at = _iso_now()
+    case_results = [
+        run_fixture_research_eval_case(
+            case,
+            fixtures_dir=fixtures_dir,
+            model_label=model_label,
+            harness_label=harness_label,
+        )
+        for case in load_research_eval_cases(cases_dir)
+    ]
+    aggregate = _build_aggregate_summary(case_results)
+    output = {
+        "schema_version": "1.0",
+        "generated_at": _iso_now(),
+        "harness": {
+            "mode": "fixture_only",
+            "runner": harness_label,
+            "model": model_label,
+            "cases_dir": str(cases_dir.resolve()),
+            "fixtures_dir": str(fixtures_dir.resolve()),
+            "started_at": started_at,
+        },
+        "aggregate": aggregate,
+        "cases": [item.result for item in case_results],
+    }
+    if write_results:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        output_path = results_dir / f"research-evals-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+        output_path.write_text(json.dumps(output, indent=2), encoding="utf-8")
+        output["results_path"] = str(output_path.resolve())
+    return output
+
+
+def run_fixture_research_eval_case(
+    case: dict[str, Any],
+    *,
+    fixtures_dir: Path,
+    model_label: str,
+    harness_label: str,
+) -> CaseRunResult:
+    started = time.perf_counter()
+    sources, excerpts = _build_fixture_packet(case, fixtures_dir)
+    known_source_ids = {item["id"] for item in sources}
+    known_excerpt_ids = {item["id"] for item in excerpts}
+
+    assembler = ComponentDraftAssembler(
+        run_title=case["brief"]["title"],
+        run_intent=case["brief"]["research_question"],
+        agent_name=harness_label,
+        external_draft_id=f"eval-{case['id']}",
+    )
+    assembler.seed_grounding_sources(sources=sources, evidence_excerpts=excerpts)
+
+    attempts_by_phase = {
+        phase: int(value)
+        for phase, value in dict(case["simulated_execution"].get("attempts_by_phase") or {}).items()
+    }
+    assembly_errors: list[str] = []
+    for phase_name in PHASE_ORDER:
+        raw_batch = case["simulated_execution"]["phase_batches"].get(phase_name)
+        if raw_batch is None:
+            continue
+        attempts_by_phase.setdefault(phase_name, 1)
+        batch, batch_errors = parse_component_batch_from_data(raw_batch)
+        if batch is None:
+            assembly_errors.extend(f"{phase_name}: {line}" for line in batch_errors[:5])
+            continue
+        assembly_result = assembler.apply_batch(batch)
+        if not assembly_result.success:
+            assembly_errors.extend(f"{phase_name}: {line}" for line in assembly_result.errors[:5])
+
+    package_data = assembler.package_dict()
+    validation_report = validate_agent_draft_data(Path(f"<research-eval:{case['id']}>"), package_data)
+    import_summary: dict[str, Any] | None = None
+    status = "validation_failed"
+    errors = list(assembly_errors)
+    warnings: list[str] = []
+    if validation_report.is_valid and validation_report.package is not None and not assembly_errors:
+        try:
+            import_summary = _import_package_for_eval(validation_report.package)
+            warnings.extend(import_summary["warnings"])
+            status = "imported"
+        except Exception as exc:
+            errors.append(f"import_failed: {exc}")
+            status = "import_failed"
+    else:
+        errors.extend(validation_report.errors[:5])
+
+    metrics = _score_case(
+        case,
+        package_data=package_data,
+        known_source_ids=known_source_ids,
+        known_excerpt_ids=known_excerpt_ids,
+        attempts_by_phase=attempts_by_phase,
+        validation_success=validation_report.is_valid and not assembly_errors,
+        import_summary=import_summary,
+        runtime_seconds=time.perf_counter() - started,
+        warnings=warnings,
+    )
+    score_summary = _build_score_summary(metrics)
+    result = {
+        "id": case["id"],
+        "title": case["title"],
+        "brief": case["brief"],
+        "status": status,
+        "execution": {
+            "mode": "fixture_only",
+            "provider": "fixture-mocked",
+            "model": model_label,
+            "harness": harness_label,
+            "attempts_by_phase": attempts_by_phase,
+            "retry_count": metrics["retry_count"],
+        },
+        "relevant_source_ids": case["relevant_source_ids"],
+        "irrelevant_source_ids": case["irrelevant_source_ids"],
+        "rubric_metadata": case["rubric_metadata"],
+        "metrics": metrics,
+        "score_summary": score_summary,
+        "warnings": warnings[:10],
+        "errors": errors[:10],
+        "import_summary": import_summary,
+    }
+    return CaseRunResult(case_id=case["id"], result=result)
+
+
+def render_eval_summary_table(output: dict[str, Any]) -> str:
+    lines = [
+        "Case                           Status           Score   Import  UnknownRefs  Retries",
+        "-----------------------------  ---------------  ------  ------  -----------  -------",
+    ]
+    for case in output.get("cases", []):
+        lines.append(
+            "{case_id:<29}  {status:<15}  {score:>6.3f}  {imported:>6}  {unknown:>11}  {retries:>7}".format(
+                case_id=str(case.get("id") or "")[:29],
+                status=str(case.get("status") or "")[:15],
+                score=float(case.get("score_summary", {}).get("overall_score") or 0.0),
+                imported="yes" if case.get("metrics", {}).get("import_success") else "no",
+                unknown=int(case.get("metrics", {}).get("unknown_source_reference_count") or 0),
+                retries=int(case.get("metrics", {}).get("retry_count") or 0),
+            )
+        )
+    aggregate = output.get("aggregate", {})
+    lines.extend(
+        [
+            "",
+            "Aggregate",
+            f"- cases: {aggregate.get('case_count', 0)}",
+            f"- imported: {aggregate.get('import_success_count', 0)}",
+            f"- avg overall score: {float(aggregate.get('average_overall_score') or 0.0):.3f}",
+            f"- total unknown source refs: {aggregate.get('total_unknown_source_reference_count', 0)}",
+        ]
+    )
+    if output.get("results_path"):
+        lines.append(f"- results json: {output['results_path']}")
+    return "\n".join(lines)
+
+
+def _normalize_case(case_path: Path, raw_data: dict[str, Any]) -> dict[str, Any]:
+    brief = dict(raw_data.get("brief") or {})
+    fixture_sources = list(raw_data.get("fixture_sources") or [])
+    simulated_execution = dict(raw_data.get("simulated_execution") or {})
+    phase_batches = dict(simulated_execution.get("phase_batches") or {})
+    if not raw_data.get("id"):
+        raise ValueError(f"Eval case missing id: {case_path}")
+    if not brief.get("title") or not brief.get("research_question"):
+        raise ValueError(f"Eval case brief requires title and research_question: {case_path}")
+    if not fixture_sources:
+        raise ValueError(f"Eval case requires fixture_sources: {case_path}")
+    if not phase_batches:
+        raise ValueError(f"Eval case requires simulated_execution.phase_batches: {case_path}")
+
+    normalized_sources: list[dict[str, Any]] = []
+    for item in fixture_sources:
+        if not isinstance(item, dict) or not item.get("id") or not item.get("path") or not item.get("url"):
+            raise ValueError(f"Eval case fixture_sources entries require id, path, and url: {case_path}")
+        normalized_sources.append(
+            {
+                "id": str(item["id"]),
+                "path": str(item["path"]),
+                "url": str(item["url"]),
+                "title": item.get("title"),
+                "source_type": str(item.get("source_type") or "public_web"),
+                "excerpt_type": str(item.get("excerpt_type") or "web_capture"),
+                "relevant": bool(item.get("relevant", True)),
+            }
+        )
+    relevant_source_ids = list(raw_data.get("relevant_source_ids") or [item["id"] for item in normalized_sources if item["relevant"]])
+    irrelevant_source_ids = list(raw_data.get("irrelevant_source_ids") or [item["id"] for item in normalized_sources if not item["relevant"]])
+    return {
+        "id": str(raw_data["id"]),
+        "title": str(raw_data.get("title") or raw_data["id"]),
+        "brief": {
+            "title": str(brief["title"]),
+            "research_question": str(brief["research_question"]),
+            "constraints": brief.get("constraints"),
+            "desired_depth": brief.get("desired_depth"),
+            "expected_outputs": brief.get("expected_outputs"),
+            "notes": brief.get("notes"),
+        },
+        "fixture_sources": normalized_sources,
+        "relevant_source_ids": [str(item) for item in relevant_source_ids],
+        "irrelevant_source_ids": [str(item) for item in irrelevant_source_ids],
+        "expected_claim_traits": [str(item) for item in list(raw_data.get("expected_claim_traits") or [])],
+        "expected_theme_traits": [str(item) for item in list(raw_data.get("expected_theme_traits") or [])],
+        "expected_candidate_traits": [str(item) for item in list(raw_data.get("expected_candidate_traits") or [])],
+        "forbidden_claim_patterns": [str(item) for item in list(raw_data.get("forbidden_claim_patterns") or [])],
+        "rubric_metadata": dict(raw_data.get("rubric_metadata") or {}),
+        "simulated_execution": {
+            "attempts_by_phase": dict(simulated_execution.get("attempts_by_phase") or {}),
+            "phase_batches": phase_batches,
+        },
+    }
+
+
+def _build_fixture_packet(case: dict[str, Any], fixtures_dir: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    sources: list[dict[str, Any]] = []
+    excerpts: list[dict[str, Any]] = []
+    pages_dir = fixtures_dir / "pages"
+    for item in case["fixture_sources"]:
+        fixture_path = pages_dir / item["path"]
+        raw_body = fixture_path.read_bytes()
+        content_type = "text/html" if fixture_path.suffix.lower() == ".html" else "text/plain"
+        extracted_title, extracted_text, extraction_error = extract_title_and_text(raw_body, content_type)
+        title = str(item.get("title") or extracted_title or item["id"])
+        excerpt_text = (extracted_text or title).strip()
+        source_id = item["id"]
+        excerpt_id = f"{source_id}::excerpt"
+        parsed_url = parse.urlsplit(item["url"])
+        sources.append(
+            {
+                "id": source_id,
+                "title": title,
+                "source_type": item["source_type"],
+                "url": item["url"],
+                "origin": parsed_url.hostname,
+                "summary": excerpt_text[:400],
+                "metadata_json": {
+                    "fixture_case_id": case["id"],
+                    "fixture_path": item["path"],
+                    "relevant": item["relevant"],
+                    "extraction_error": extraction_error,
+                },
+            }
+        )
+        excerpts.append(
+            {
+                "id": excerpt_id,
+                "source_id": source_id,
+                "excerpt_text": excerpt_text,
+                "location_reference": item["path"],
+                "excerpt_type": item["excerpt_type"],
+                "metadata_json": {
+                    "fixture_case_id": case["id"],
+                    "fixture_source_id": source_id,
+                },
+            }
+        )
+    return sources, excerpts
+
+
+def _import_package_for_eval(package) -> dict[str, Any]:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    session_cls = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    try:
+        with session_cls() as db:
+            import_result = import_agent_draft_package(
+                db,
+                package,
+                package_path=None,
+                allow_duplicate_external_id=True,
+            )
+            return {
+                "run_id": import_result.run_db_id,
+                "warnings": list(import_result.warnings),
+                "imported_source_count": import_result.imported_source_count,
+                "imported_excerpt_count": import_result.imported_excerpt_count,
+                "imported_claim_count": import_result.imported_claim_count,
+                "imported_theme_count": import_result.imported_theme_count,
+                "imported_candidate_count": import_result.imported_candidate_count,
+                "imported_validation_gate_count": import_result.imported_validation_gate_count,
+                "imported_evidence_link_count": import_result.imported_evidence_link_count,
+            }
+    finally:
+        engine.dispose()
+
+
+def _score_case(
+    case: dict[str, Any],
+    *,
+    package_data: dict[str, Any],
+    known_source_ids: set[str],
+    known_excerpt_ids: set[str],
+    attempts_by_phase: dict[str, int],
+    validation_success: bool,
+    import_summary: dict[str, Any] | None,
+    runtime_seconds: float,
+    warnings: list[str],
+) -> dict[str, Any]:
+    valid_link_count = 0
+    unknown_reference_count = 0
+    claim_support: dict[str, int] = {str(item.get("id")): 0 for item in package_data.get("claims", [])}
+    for link in package_data.get("evidence_links", []):
+        if not isinstance(link, dict):
+            continue
+        source_id = link.get("source_id")
+        excerpt_id = link.get("excerpt_id")
+        source_ok = source_id is None or str(source_id) in known_source_ids
+        excerpt_ok = excerpt_id is None or str(excerpt_id) in known_excerpt_ids
+        if not source_ok:
+            unknown_reference_count += 1
+        if not excerpt_ok:
+            unknown_reference_count += 1
+        if source_ok and excerpt_ok:
+            valid_link_count += 1
+            if str(link.get("target_type") or "") == "claim" and str(link.get("relationship") or "") == "supports":
+                target_id = str(link.get("target_id") or "")
+                if target_id in claim_support:
+                    claim_support[target_id] += 1
+
+    claims = [str(item.get("statement") or "") for item in package_data.get("claims", []) if isinstance(item, dict)]
+    themes = [" ".join(filter(None, [str(item.get("name") or ""), str(item.get("summary") or "")])).strip() for item in package_data.get("themes", []) if isinstance(item, dict)]
+    candidates = [
+        " ".join(
+            filter(
+                None,
+                [
+                    str(item.get("title") or ""),
+                    str(item.get("summary") or ""),
+                    str(item.get("target_user") or ""),
+                    str(item.get("first_workflow") or ""),
+                    str(item.get("first_wedge") or ""),
+                ],
+            )
+        ).strip()
+        for item in package_data.get("candidates", [])
+        if isinstance(item, dict)
+    ]
+    claim_coverage = _trait_coverage(case["expected_claim_traits"], claims)
+    theme_coverage = _trait_coverage(case["expected_theme_traits"], themes)
+    candidate_coverage = _trait_coverage(case["expected_candidate_traits"], candidates)
+    forbidden_hits = _forbidden_claim_hits(case["forbidden_claim_patterns"], claims)
+    unsupported_claim_count = sum(1 for count in claim_support.values() if count == 0)
+    retry_count = sum(max(int(value) - 1, 0) for value in attempts_by_phase.values())
+
+    return {
+        "import_success": bool(import_summary),
+        "schema_validation_success": validation_success,
+        "valid_source_links": valid_link_count,
+        "unknown_source_reference_count": unknown_reference_count,
+        "unsupported_claim_count": unsupported_claim_count,
+        "expected_claim_trait_coverage": claim_coverage["coverage"],
+        "matched_claim_traits": claim_coverage["matched_traits"],
+        "expected_theme_trait_coverage": theme_coverage["coverage"],
+        "matched_theme_traits": theme_coverage["matched_traits"],
+        "expected_candidate_trait_coverage": candidate_coverage["coverage"],
+        "matched_candidate_traits": candidate_coverage["matched_traits"],
+        "forbidden_claim_hit_count": forbidden_hits,
+        "schema_error_count": 0 if validation_success else 1,
+        "retry_count": retry_count,
+        "attempts_by_phase": attempts_by_phase,
+        "runtime_seconds": round(runtime_seconds, 4),
+        "import_warning_count": len(warnings),
+    }
+
+
+def _trait_coverage(expected_traits: list[str], texts: list[str]) -> dict[str, Any]:
+    if not expected_traits:
+        return {"coverage": 1.0, "matched_traits": []}
+    haystack = "\n".join(texts).lower()
+    matched = [trait for trait in expected_traits if trait.lower() in haystack]
+    coverage = len(matched) / len(expected_traits)
+    return {"coverage": round(coverage, 3), "matched_traits": matched}
+
+
+def _forbidden_claim_hits(patterns: list[str], claims: list[str]) -> int:
+    lowered_claims = [claim.lower() for claim in claims]
+    hits = 0
+    for pattern in patterns:
+        lowered = pattern.lower()
+        if any(lowered in claim for claim in lowered_claims):
+            hits += 1
+    return hits
+
+
+def _build_score_summary(metrics: dict[str, Any]) -> dict[str, Any]:
+    normalized = {
+        "import_success": 1.0 if metrics["import_success"] else 0.0,
+        "schema_validation_success": 1.0 if metrics["schema_validation_success"] else 0.0,
+        "source_link_integrity": 1.0 if metrics["unknown_source_reference_count"] == 0 else 0.0,
+        "claim_support": 1.0 if metrics["unsupported_claim_count"] == 0 else 0.0,
+        "expected_claim_trait_coverage": float(metrics["expected_claim_trait_coverage"]),
+        "expected_theme_trait_coverage": float(metrics["expected_theme_trait_coverage"]),
+        "expected_candidate_trait_coverage": float(metrics["expected_candidate_trait_coverage"]),
+        "forbidden_claim_safety": 1.0 if metrics["forbidden_claim_hit_count"] == 0 else 0.0,
+    }
+    overall_score = round(sum(normalized.values()) / len(normalized), 3)
+    passed_checks = sorted(name for name, value in normalized.items() if value >= 1.0)
+    failed_checks = sorted(name for name, value in normalized.items() if value < 1.0)
+    return {
+        "overall_score": overall_score,
+        "normalized_metrics": normalized,
+        "passed_checks": passed_checks,
+        "failed_checks": failed_checks,
+    }
+
+
+def _build_aggregate_summary(case_results: list[CaseRunResult]) -> dict[str, Any]:
+    case_dicts = [item.result for item in case_results]
+    case_count = len(case_dicts)
+    average_overall_score = round(
+        sum(float(item["score_summary"]["overall_score"]) for item in case_dicts) / case_count,
+        3,
+    )
+    return {
+        "case_count": case_count,
+        "import_success_count": sum(1 for item in case_dicts if item["metrics"]["import_success"]),
+        "schema_validation_success_count": sum(1 for item in case_dicts if item["metrics"]["schema_validation_success"]),
+        "average_overall_score": average_overall_score,
+        "average_expected_claim_trait_coverage": _average_metric(case_dicts, "expected_claim_trait_coverage"),
+        "average_expected_theme_trait_coverage": _average_metric(case_dicts, "expected_theme_trait_coverage"),
+        "average_expected_candidate_trait_coverage": _average_metric(case_dicts, "expected_candidate_trait_coverage"),
+        "total_unknown_source_reference_count": sum(int(item["metrics"]["unknown_source_reference_count"]) for item in case_dicts),
+        "total_forbidden_claim_hit_count": sum(int(item["metrics"]["forbidden_claim_hit_count"]) for item in case_dicts),
+        "total_retry_count": sum(int(item["metrics"]["retry_count"]) for item in case_dicts),
+        "status_counts": _status_counts(case_dicts),
+    }
+
+
+def _average_metric(case_dicts: list[dict[str, Any]], metric_name: str) -> float:
+    if not case_dicts:
+        return 0.0
+    return round(sum(float(item["metrics"][metric_name]) for item in case_dicts) / len(case_dicts), 3)
+
+
+def _status_counts(case_dicts: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in case_dicts:
+        status = str(item.get("status") or "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/docs/reference/research-eval-harness.md
+++ b/docs/reference/research-eval-harness.md
@@ -1,0 +1,103 @@
+# Research Eval Harness
+
+The APD research eval harness is a deterministic, fixture-only way to compare harness changes without depending on live web results or a live local model.
+
+## Overview
+
+The first version uses:
+
+- YAML case files under `evals/research/cases/`
+- fixture HTML or text pages under `evals/research/fixtures/pages/`
+- a simulated APD component-execution path in `apd/evals/research_runner.py`
+- JSON results written to `evals/research/results/`
+
+The runner assembles APD-style draft packages from fixture sources and simulated phase batches, validates them with the existing APD draft validator, imports them into a temporary SQLite database, and then scores the output with deterministic rubric checks.
+
+## Running Evals
+
+Run the fixture-only harness with:
+
+```bash
+uv run python scripts/run_research_evals.py --fixture-only
+```
+
+The command prints a short per-case table plus aggregate totals and writes a timestamped JSON file to `evals/research/results/`.
+
+Use `--model-label` and `--harness-label` when you want to compare two mocked or partially mocked configurations while keeping the same deterministic fixtures.
+
+## Case Schema
+
+Each YAML case should include these top-level fields:
+
+- `id`
+- `title`
+- `brief`
+- `fixture_sources`
+- `relevant_source_ids`
+- `irrelevant_source_ids`
+- `expected_claim_traits`
+- `expected_theme_traits`
+- `expected_candidate_traits`
+- `forbidden_claim_patterns`
+- `rubric_metadata`
+- `simulated_execution`
+
+`brief` should provide at least `title` and `research_question`.
+
+Each `fixture_sources` entry should provide:
+
+- `id`
+- `path`
+- `url`
+- optional `title`
+- optional `source_type`
+- optional `excerpt_type`
+- optional `relevant`
+
+`simulated_execution.phase_batches` should mirror the APD component-batch format already used by grounded execution:
+
+- `candidate_batch`
+- `claim_theme_batch`
+- `validation_gate_batch`
+
+Each batch should contain `schema_version`, `batch_id`, and `events`. Event payloads should use the same typed event schema as `apd/services/research_components.py`.
+
+## Scoring
+
+Each case result includes deterministic metrics intended to stay stable across repeated runs:
+
+- `import_success`
+- `schema_validation_success`
+- `valid_source_links`
+- `unknown_source_reference_count`
+- `unsupported_claim_count`
+- `expected_claim_trait_coverage`
+- `expected_theme_trait_coverage`
+- `expected_candidate_trait_coverage`
+- `forbidden_claim_hit_count`
+- `retry_count`
+- `attempts_by_phase`
+- `runtime_seconds`
+
+The runner also emits `score_summary.overall_score`, which is a simple average of normalized checks and trait-coverage values. It is intentionally basic. The goal is not perfect semantic judgment; the goal is a stable comparison signal that later scorecard work can aggregate.
+
+Interpretation guidance:
+
+- high trait coverage with zero forbidden hits means the simulated output stayed close to the expected wedge
+- non-zero `unknown_source_reference_count` means evidence links pointed at sources or excerpts that were not present in the fixture packet
+- non-zero `unsupported_claim_count` means claims were emitted without a supporting `supports` evidence link to a known fixture source
+- higher `retry_count` means the case is modeling a harness path that needed one or more repair attempts
+
+## Adding Cases
+
+To add a new eval case:
+
+1. Add one YAML file under `evals/research/cases/`.
+2. Add one or more HTML or text fixtures under `evals/research/fixtures/pages/`.
+3. Reference those fixture files from `fixture_sources`.
+4. Define expected claim, theme, and candidate traits as plain keywords or short phrases.
+5. Define any forbidden claim patterns you want to catch.
+6. Add simulated component batches under `simulated_execution.phase_batches`.
+7. Run `uv run python scripts/run_research_evals.py --fixture-only` and confirm the new case appears in the summary and output JSON.
+
+Keep cases narrow. The goal is not to model the whole internet. The goal is to exercise one repeatable research situation with explicit evidence, bait sources, and expected output traits.

--- a/evals/research/cases/hiring_feedback_loop.yaml
+++ b/evals/research/cases/hiring_feedback_loop.yaml
@@ -1,0 +1,110 @@
+id: hiring_feedback_loop
+title: Hiring feedback loop slowdown
+brief:
+  title: Hiring feedback loop slowdown
+  research_question: What repeated recruiting pain appears when interview feedback arrives too slowly?
+fixture_sources:
+  - id: recruiting_ops_thread
+    path: recruiting_ops_thread.html
+    url: https://fixtures.apd.local/recruiting/ops-thread
+    relevant: true
+  - id: candidate_followup_note
+    path: candidate_followup_note.txt
+    url: https://fixtures.apd.local/recruiting/followup-note
+    relevant: true
+  - id: hiring_market_map
+    path: hiring_market_map.txt
+    url: https://fixtures.apd.local/bait/hiring-market-map
+    relevant: false
+relevant_source_ids:
+  - recruiting_ops_thread
+  - candidate_followup_note
+irrelevant_source_ids:
+  - hiring_market_map
+expected_claim_traits:
+  - interview feedback
+  - candidates
+  - slow follow-up
+expected_theme_traits:
+  - feedback latency
+  - hiring loop
+expected_candidate_traits:
+  - debrief
+  - hiring
+  - interview
+forbidden_claim_patterns:
+  - universal recruiting operating system
+rubric_metadata:
+  track: grounded_research
+  focus: decision_latency
+simulated_execution:
+  attempts_by_phase:
+    candidate_batch: 1
+    claim_theme_batch: 1
+    validation_gate_batch: 1
+  phase_batches:
+    candidate_batch:
+      schema_version: "1.0"
+      batch_id: hiring-candidates
+      events:
+        - schema_version: "1.0"
+          event_type: candidate.proposed
+          external_id: cand-hiring-1
+          payload:
+            title: Interview debrief inbox for hiring managers
+            summary: Consolidate interview feedback and unresolved questions before candidates churn out.
+            target_user: Hiring managers
+            first_workflow: Post-interview debrief collection
+            first_wedge: Shared prompt and inbox for interviewer feedback capture
+    claim_theme_batch:
+      schema_version: "1.0"
+      batch_id: hiring-claims
+      events:
+        - schema_version: "1.0"
+          event_type: claim.proposed
+          external_id: claim-hiring-1
+          payload:
+            statement: Teams lose candidates when interview feedback and follow-up decisions move too slowly.
+        - schema_version: "1.0"
+          event_type: claim.proposed
+          external_id: claim-hiring-2
+          payload:
+            statement: The answer is a universal recruiting operating system for every hiring workflow.
+        - schema_version: "1.0"
+          event_type: theme.proposed
+          external_id: theme-hiring-1
+          payload:
+            name: Feedback latency in the hiring loop
+            summary: Interview follow-up stalls because feedback collection is delayed and fragmented.
+        - schema_version: "1.0"
+          event_type: evidence_link.added
+          external_id: link-hiring-1
+          payload:
+            source_id: recruiting_ops_thread
+            excerpt_id: recruiting_ops_thread::excerpt
+            target_type: claim
+            target_id: claim-hiring-1
+            relationship: supports
+            strength: strong
+        - schema_version: "1.0"
+          event_type: evidence_link.added
+          external_id: link-hiring-2
+          payload:
+            source_id: missing_fixture_source
+            excerpt_id: candidate_followup_note::excerpt
+            target_type: claim
+            target_id: claim-hiring-2
+            relationship: supports
+            strength: weak
+    validation_gate_batch:
+      schema_version: "1.0"
+      batch_id: hiring-gates
+      events:
+        - schema_version: "1.0"
+          event_type: validation_gate.proposed
+          external_id: gate-hiring-1
+          payload:
+            candidate_id: cand-hiring-1
+            phase: supported_opportunity
+            name: Confirm that at least one hiring manager would pay for debrief speed alone
+            description: Check whether the narrow debrief workflow solves a costly enough delay to justify adoption.

--- a/evals/research/cases/maintenance_handoff.yaml
+++ b/evals/research/cases/maintenance_handoff.yaml
@@ -1,0 +1,90 @@
+id: maintenance_handoff
+title: MSP shift handoff context loss
+brief:
+  title: MSP shift handoff context loss
+  research_question: What repeatable pain appears when MSP technicians hand off tickets between shifts?
+fixture_sources:
+  - id: handoff_forum_thread
+    path: maintenance_handoff_forum.html
+    url: https://fixtures.apd.local/msp/handoff-thread
+    relevant: true
+  - id: vendor_pricing_page
+    path: vendor_pricing_bait.txt
+    url: https://fixtures.apd.local/bait/vendor-pricing
+    relevant: false
+relevant_source_ids:
+  - handoff_forum_thread
+irrelevant_source_ids:
+  - vendor_pricing_page
+expected_claim_traits:
+  - shift handoffs
+  - ticket context
+  - lose time
+expected_theme_traits:
+  - handoff
+  - context loss
+expected_candidate_traits:
+  - async
+  - handoff
+  - MSP
+forbidden_claim_patterns:
+  - universal AI operations platform
+rubric_metadata:
+  track: grounded_research
+  focus: handoff_pain
+simulated_execution:
+  attempts_by_phase:
+    candidate_batch: 1
+    claim_theme_batch: 1
+    validation_gate_batch: 1
+  phase_batches:
+    candidate_batch:
+      schema_version: "1.0"
+      batch_id: maintenance-handoff-candidates
+      events:
+        - schema_version: "1.0"
+          event_type: candidate.proposed
+          external_id: cand-handoff-1
+          payload:
+            title: Async shift handoff notebook for MSP teams
+            summary: Capture unresolved ticket context before the next technician picks up the queue.
+            target_user: MSP dispatch leads
+            first_workflow: Shift change handoff for active support tickets
+            first_wedge: Structured handoff note capture with unresolved blockers and next actions
+    claim_theme_batch:
+      schema_version: "1.0"
+      batch_id: maintenance-handoff-claims
+      events:
+        - schema_version: "1.0"
+          event_type: claim.proposed
+          external_id: claim-handoff-1
+          payload:
+            statement: MSP technicians lose time during shift handoffs because ticket context is missing or scattered.
+        - schema_version: "1.0"
+          event_type: theme.proposed
+          external_id: theme-handoff-1
+          payload:
+            name: Handoff context loss
+            summary: Teams repeat diagnosis because the next shift inherits incomplete ticket context.
+        - schema_version: "1.0"
+          event_type: evidence_link.added
+          external_id: link-handoff-1
+          payload:
+            source_id: handoff_forum_thread
+            excerpt_id: handoff_forum_thread::excerpt
+            target_type: claim
+            target_id: claim-handoff-1
+            relationship: supports
+            strength: strong
+    validation_gate_batch:
+      schema_version: "1.0"
+      batch_id: maintenance-handoff-gates
+      events:
+        - schema_version: "1.0"
+          event_type: validation_gate.proposed
+          external_id: gate-handoff-1
+          payload:
+            candidate_id: cand-handoff-1
+            phase: supported_opportunity
+            name: Confirm the pattern appears in at least three MSP teams
+            description: Verify that context loss is repeated across multiple handoff workflows, not a single team complaint.

--- a/evals/research/cases/solo_operator_maintenance.yaml
+++ b/evals/research/cases/solo_operator_maintenance.yaml
@@ -1,0 +1,105 @@
+id: solo_operator_maintenance
+title: Solo operator preventive maintenance toil
+brief:
+  title: Solo operator preventive maintenance toil
+  research_question: What repeated maintenance pain creates openings for a narrow preventive-maintenance product?
+fixture_sources:
+  - id: maintenance_blog_post
+    path: solo_operator_maintenance_blog.html
+    url: https://fixtures.apd.local/ops/maintenance-blog
+    relevant: true
+  - id: incident_chat_log
+    path: incident_chat_log.txt
+    url: https://fixtures.apd.local/ops/incident-chat
+    relevant: true
+  - id: trending_ai_news
+    path: trending_ai_news.txt
+    url: https://fixtures.apd.local/bait/trending-ai-news
+    relevant: false
+relevant_source_ids:
+  - maintenance_blog_post
+  - incident_chat_log
+irrelevant_source_ids:
+  - trending_ai_news
+expected_claim_traits:
+  - preventive maintenance
+  - manual checks
+  - solo operator
+expected_theme_traits:
+  - recurring toil
+  - maintenance window
+expected_candidate_traits:
+  - calendar
+  - maintenance
+  - solo operators
+forbidden_claim_patterns:
+  - fully autonomous data center
+rubric_metadata:
+  track: grounded_research
+  focus: recurring_tedium
+simulated_execution:
+  attempts_by_phase:
+    candidate_batch: 1
+    claim_theme_batch: 2
+    validation_gate_batch: 1
+  phase_batches:
+    candidate_batch:
+      schema_version: "1.0"
+      batch_id: maintenance-candidates
+      events:
+        - schema_version: "1.0"
+          event_type: candidate.proposed
+          external_id: cand-maintenance-1
+          payload:
+            title: Preventive maintenance calendar for solo operators
+            summary: Schedule recurring checks, dependencies, and proof of completion without adopting a full ITSM suite.
+            target_user: Solo infrastructure operators
+            first_workflow: Weekly and monthly maintenance windows
+            first_wedge: Calendar-backed checklists with evidence capture
+    claim_theme_batch:
+      schema_version: "1.0"
+      batch_id: maintenance-claims
+      events:
+        - schema_version: "1.0"
+          event_type: claim.proposed
+          external_id: claim-maintenance-1
+          payload:
+            statement: Solo operators still run preventive maintenance with manual checks and scattered notes, which makes maintenance windows brittle.
+        - schema_version: "1.0"
+          event_type: theme.proposed
+          external_id: theme-maintenance-1
+          payload:
+            name: Recurring toil around maintenance windows
+            summary: Preventive maintenance remains a repeated manual workflow instead of a lightweight, reviewable routine.
+        - schema_version: "1.0"
+          event_type: evidence_link.added
+          external_id: link-maintenance-1
+          payload:
+            source_id: maintenance_blog_post
+            excerpt_id: maintenance_blog_post::excerpt
+            target_type: claim
+            target_id: claim-maintenance-1
+            relationship: supports
+            strength: strong
+        - schema_version: "1.0"
+          event_type: evidence_link.added
+          external_id: link-maintenance-2
+          payload:
+            source_id: incident_chat_log
+            excerpt_id: incident_chat_log::excerpt
+            target_type: claim
+            target_id: claim-maintenance-1
+            relationship: supports
+            strength: medium
+    validation_gate_batch:
+      schema_version: "1.0"
+      batch_id: maintenance-gates
+      events:
+        - schema_version: "1.0"
+          event_type: validation_gate.proposed
+          external_id: gate-maintenance-1
+          payload:
+            candidate_id: cand-maintenance-1
+            phase: supported_opportunity
+            name: Confirm at least one buyer would replace spreadsheets rather than a full CMMS
+            description: Validate that the narrow maintenance wedge beats existing spreadsheets and reminders for solo teams.

--- a/evals/research/fixtures/pages/candidate_followup_note.txt
+++ b/evals/research/fixtures/pages/candidate_followup_note.txt
@@ -1,0 +1,1 @@
+Candidate follow-up note: interviewers missed the same-day debrief again, so the decision slipped and the candidate accepted another offer.

--- a/evals/research/fixtures/pages/hiring_market_map.txt
+++ b/evals/research/fixtures/pages/hiring_market_map.txt
@@ -1,0 +1,2 @@
+Market landscape notes about applicant tracking systems, sourcing tools, and talent intelligence vendors.
+This is bait for broad category mapping rather than evidence about debrief latency.

--- a/evals/research/fixtures/pages/incident_chat_log.txt
+++ b/evals/research/fixtures/pages/incident_chat_log.txt
@@ -1,0 +1,2 @@
+Yesterday's maintenance window slipped because the firewall checklist lived in chat and the storage check lived in a notebook.
+As a solo operator I had to piece the workflow back together before I could start the preventive maintenance pass.

--- a/evals/research/fixtures/pages/maintenance_handoff_forum.html
+++ b/evals/research/fixtures/pages/maintenance_handoff_forum.html
@@ -1,0 +1,7 @@
+<html>
+  <head><title>MSP shift handoff thread</title></head>
+  <body>
+    <p>We keep losing 20 to 30 minutes every shift because ticket context disappears between technicians.</p>
+    <p>The handoff note is buried in chat, the PSA comment is incomplete, and the next person has to reconstruct what already happened.</p>
+  </body>
+</html>

--- a/evals/research/fixtures/pages/recruiting_ops_thread.html
+++ b/evals/research/fixtures/pages/recruiting_ops_thread.html
@@ -1,0 +1,7 @@
+<html>
+  <head><title>Recruiting ops thread</title></head>
+  <body>
+    <p>We keep losing candidates because interview feedback dribbles in over two or three days.</p>
+    <p>The coordinator is chasing notes, the hiring manager has no clean debrief, and slow follow-up makes strong candidates drop.</p>
+  </body>
+</html>

--- a/evals/research/fixtures/pages/solo_operator_maintenance_blog.html
+++ b/evals/research/fixtures/pages/solo_operator_maintenance_blog.html
@@ -1,0 +1,7 @@
+<html>
+  <head><title>Solo operator maintenance checklist</title></head>
+  <body>
+    <p>I still run preventive maintenance from a spreadsheet and a pile of reminders.</p>
+    <p>Every maintenance window starts with manual checks, copied notes, and a scramble to prove what I already completed.</p>
+  </body>
+</html>

--- a/evals/research/fixtures/pages/trending_ai_news.txt
+++ b/evals/research/fixtures/pages/trending_ai_news.txt
@@ -1,0 +1,2 @@
+Analyst coverage of broad AI infrastructure trends, venture funding, and market maps.
+No concrete workflow detail about preventive maintenance or operator toil.

--- a/evals/research/fixtures/pages/vendor_pricing_bait.txt
+++ b/evals/research/fixtures/pages/vendor_pricing_bait.txt
@@ -1,0 +1,2 @@
+Pricing tiers for a generic vendor platform.
+Enterprise seat bundles, annual discount tables, and add-on package names.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "jinja2>=3.1,<4",
   "sqlalchemy>=2.0,<3",
   "alembic>=1.13,<2",
+  "pyyaml>=6,<7",
   "uvicorn[standard]>=0.30,<1",
   "python-multipart>=0.0.18",
 ]

--- a/scripts/check_repo_readiness.py
+++ b/scripts/check_repo_readiness.py
@@ -6,10 +6,16 @@ import re
 import sys
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parent.parent
 
 RESEARCH_SKILL_MANIFEST_PATH = "skills/research/manifest.yaml"
+RESEARCH_EVAL_CASES_DIR = "evals/research/cases"
+RESEARCH_EVAL_FIXTURES_DIR = "evals/research/fixtures/pages"
+RESEARCH_EVAL_RESULTS_DIR = "evals/research/results"
+RESEARCH_EVAL_DOC_PATH = "docs/reference/research-eval-harness.md"
 RESEARCH_SKILL_SPECS = [
     ("research_protocol", "skills/research/research_protocol.md"),
     ("question_framing", "skills/research/question_framing.md"),
@@ -77,6 +83,10 @@ REQUIRED_FILES = [
     "scripts/init_prototype_scaffold.py",
     "scripts/start_discovery_run.py",
     "scripts/clean_empty_run_dirs.py",
+    "apd/evals/__init__.py",
+    "apd/evals/research_runner.py",
+    "scripts/run_research_evals.py",
+    RESEARCH_EVAL_DOC_PATH,
     "LAUNCH_MODEL_SUMMARY.md",
 ]
 
@@ -86,6 +96,9 @@ REQUIRED_DIRS = [
     "artifacts/runs",
     "artifacts/shared",
     "artifacts/projects",
+    RESEARCH_EVAL_CASES_DIR,
+    RESEARCH_EVAL_FIXTURES_DIR,
+    RESEARCH_EVAL_RESULTS_DIR,
 ]
 
 RESEARCH_MANIFEST_FIELDS = {
@@ -225,6 +238,14 @@ REQUIRED_ACTIVE_RUN_FIELDS = [
     "- hard boundaries:",
     "- completion point:",
 ]
+
+RESEARCH_EVAL_DOC_HEADINGS = {
+    "## overview",
+    "## running evals",
+    "## case schema",
+    "## scoring",
+    "## adding cases",
+}
 
 MIN_NONEMPTY_LINES = {
     "START_HERE.md": 12,
@@ -735,6 +756,79 @@ def validate_active_run() -> list[str]:
     return errors
 
 
+def validate_research_eval_harness() -> list[str]:
+    errors = validate_markdown(RESEARCH_EVAL_DOC_PATH, RESEARCH_EVAL_DOC_HEADINGS)
+
+    case_dir = ROOT / RESEARCH_EVAL_CASES_DIR
+    case_paths = sorted(case_dir.glob("*.yaml"))
+    if len(case_paths) < 3:
+        errors.append(f"{RESEARCH_EVAL_CASES_DIR} must contain at least 3 YAML eval cases.")
+
+    for case_path in case_paths:
+        try:
+            raw_data = yaml.safe_load(case_path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            errors.append(f"{case_path.relative_to(ROOT).as_posix()} contains invalid YAML: {exc}")
+            continue
+
+        if not isinstance(raw_data, dict):
+            errors.append(f"{case_path.relative_to(ROOT).as_posix()} must be a mapping.")
+            continue
+
+        missing = [
+            field
+            for field in ["id", "brief", "fixture_sources", "simulated_execution"]
+            if field not in raw_data
+        ]
+        if missing:
+            errors.append(
+                f"{case_path.relative_to(ROOT).as_posix()} is missing required fields: {', '.join(missing)}"
+            )
+            continue
+
+        brief = raw_data.get("brief")
+        if not isinstance(brief, dict) or not brief.get("title") or not brief.get("research_question"):
+            errors.append(
+                f"{case_path.relative_to(ROOT).as_posix()} brief must include title and research_question."
+            )
+
+        fixture_sources = raw_data.get("fixture_sources")
+        if not isinstance(fixture_sources, list) or not fixture_sources:
+            errors.append(f"{case_path.relative_to(ROOT).as_posix()} must include at least one fixture source.")
+        else:
+            for index, source in enumerate(fixture_sources, start=1):
+                if not isinstance(source, dict):
+                    errors.append(f"{case_path.relative_to(ROOT).as_posix()} fixture source #{index} must be a mapping.")
+                    continue
+                for field in ["id", "path", "url"]:
+                    if not source.get(field):
+                        errors.append(
+                            f"{case_path.relative_to(ROOT).as_posix()} fixture source #{index} is missing `{field}`."
+                        )
+                fixture_path = ROOT / RESEARCH_EVAL_FIXTURES_DIR / str(source.get("path") or "")
+                if source.get("path") and not fixture_path.is_file():
+                    errors.append(
+                        f"{case_path.relative_to(ROOT).as_posix()} references missing fixture page {source.get('path')}."
+                    )
+
+        simulated_execution = raw_data.get("simulated_execution")
+        if not isinstance(simulated_execution, dict):
+            errors.append(f"{case_path.relative_to(ROOT).as_posix()} simulated_execution must be a mapping.")
+            continue
+
+        phase_batches = simulated_execution.get("phase_batches")
+        if not isinstance(phase_batches, dict) or not phase_batches:
+            errors.append(
+                f"{case_path.relative_to(ROOT).as_posix()} simulated_execution.phase_batches must be a non-empty mapping."
+            )
+
+    fixture_files = [path for path in (ROOT / RESEARCH_EVAL_FIXTURES_DIR).glob("*") if path.is_file()]
+    if len(fixture_files) < 3:
+        errors.append(f"{RESEARCH_EVAL_FIXTURES_DIR} must contain at least 3 fixture page files.")
+
+    return errors
+
+
 def validate_research_manifest(relative_path: str) -> list[str]:
     errors: list[str] = []
     data, load_error = load_json(relative_path)
@@ -967,6 +1061,7 @@ def validate_repo() -> int:
     errors.extend(validate_markdown("ACTIVE_RUN.md", REQUIRED_ACTIVE_RUN_HEADINGS))
     errors.extend(validate_active_run())
     errors.extend(validate_research_skill_manifest(RESEARCH_SKILL_MANIFEST_PATH))
+    errors.extend(validate_research_eval_harness())
     for skill_id, skill_path in RESEARCH_SKILL_SPECS:
         errors.extend(validate_research_skill_doc(skill_path, expected_id=skill_id))
 

--- a/scripts/run_research_evals.py
+++ b/scripts/run_research_evals.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import argparse
+
+from apd.evals.research_runner import render_eval_summary_table, run_fixture_research_evals
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run APD research eval harness against fixture cases.")
+    parser.add_argument("--fixture-only", action="store_true", help="Run the deterministic fixture-only harness.")
+    parser.add_argument("--model-label", default="fixture-mocked", help="Label to record in eval output for the mocked model.")
+    parser.add_argument(
+        "--harness-label",
+        default="apd-research-eval-fixture-v1",
+        help="Label to record in eval output for the harness configuration.",
+    )
+    args = parser.parse_args()
+
+    output = run_fixture_research_evals(
+        fixture_only=args.fixture_only,
+        model_label=args.model_label,
+        harness_label=args.harness_label,
+        write_results=True,
+    )
+    print(render_eval_summary_table(output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_research_evals.py
+++ b/tests/test_research_evals.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from apd.evals.research_runner import load_research_eval_cases, render_eval_summary_table, run_fixture_research_evals
+
+
+def test_run_fixture_research_evals_scores_cases_and_writes_json(tmp_path):
+    output = run_fixture_research_evals(results_dir=tmp_path, fixture_only=True, write_results=True)
+
+    assert output["aggregate"]["case_count"] >= 3
+    assert output["aggregate"]["import_success_count"] == output["aggregate"]["case_count"]
+    assert output["aggregate"]["total_unknown_source_reference_count"] == 1
+    assert output["aggregate"]["total_forbidden_claim_hit_count"] == 1
+
+    cases = {item["id"]: item for item in output["cases"]}
+    assert cases["maintenance_handoff"]["metrics"]["retry_count"] == 0
+    assert cases["solo_operator_maintenance"]["metrics"]["retry_count"] == 1
+    assert cases["hiring_feedback_loop"]["metrics"]["unknown_source_reference_count"] == 1
+    assert cases["hiring_feedback_loop"]["metrics"]["forbidden_claim_hit_count"] == 1
+
+    results_path = Path(output["results_path"])
+    assert results_path.exists()
+    persisted = json.loads(results_path.read_text(encoding="utf-8"))
+    assert persisted["aggregate"]["case_count"] == output["aggregate"]["case_count"]
+
+    summary = render_eval_summary_table(output)
+    assert "Aggregate" in summary
+    assert "maintenance_handoff" in summary
+
+
+def test_load_research_eval_cases_returns_expected_case_shape():
+    cases = load_research_eval_cases()
+    assert len(cases) >= 3
+    assert all(case["brief"]["title"] for case in cases)
+    assert all(case["simulated_execution"]["phase_batches"] for case in cases)

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "python-multipart" },
+    { name = "pyyaml" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -74,6 +75,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
     { name = "python-multipart", specifier = ">=0.0.18" },
+    { name = "pyyaml", specifier = ">=6,<7" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
 ]


### PR DESCRIPTION
Refs #72

## Summary
- add a deterministic fixture-only APD research eval harness
- add YAML eval cases, fixture pages, per-case scoring, aggregate scoring, and JSON result output
- add a CLI runner at scripts/run_research_evals.py
- add focused tests and readiness checks for eval assets
- document how to run evals, add cases, and interpret metrics

## Verification
- uv run pytest tests/test_research_evals.py -q
- uv run python scripts/run_research_evals.py --fixture-only
- .\scripts\test.ps1
- uv run python scripts/check_repo_readiness.py

## Notes
- fixture-only; no live web, live model, hosted APIs, or external services required
- generated eval result JSON files are runtime artifacts and ignored
- prepares #73 scorecards by producing aggregate result JSON