### PR TITLE
Add APD research model scorecards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ Thumbs.db
 research-corpus/runs/*
 artifacts/runs/*
 evals/research/results/*.json
+evals/research/scorecards/*.json
+evals/research/scorecards/*.md
 
 # Keep the run container docs/structure
 !research-corpus/runs/README.md

--- a/apd/evals/__init__.py
+++ b/apd/evals/__init__.py
@@ -1,3 +1,4 @@
 from apd.evals.research_runner import run_fixture_research_evals
+from apd.evals.research_scorecard import build_research_scorecard_report
 
-__all__ = ["run_fixture_research_evals"]
+__all__ = ["run_fixture_research_evals", "build_research_scorecard_report"]

--- a/apd/evals/research_scorecard.py
+++ b/apd/evals/research_scorecard.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import glob
+import json
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+
+_GLOB_CHARS = set("*?[]")
+REQUIRED_TOP_LEVEL_FIELDS = {"generated_at", "harness", "cases"}
+REQUIRED_HARNESS_FIELDS = {"model", "runner"}
+REQUIRED_CASE_FIELDS = {"id", "status", "execution", "metrics"}
+
+
+@dataclass(frozen=True)
+class LoadedEvalResult:
+    path: Path
+    data: dict[str, Any]
+
+
+def expand_result_paths(patterns: list[str]) -> list[Path]:
+    resolved: list[Path] = []
+    for pattern in patterns:
+        raw_pattern = str(pattern or "").strip()
+        if not raw_pattern:
+            continue
+        if any(char in raw_pattern for char in _GLOB_CHARS):
+            matches = sorted(Path(match).resolve() for match in glob.glob(raw_pattern))
+            resolved.extend(matches)
+            continue
+        path = Path(raw_pattern)
+        if path.is_file():
+            resolved.append(path.resolve())
+            continue
+        raise ValueError(f"Result file does not exist: {raw_pattern}")
+
+    unique_paths = sorted(dict.fromkeys(resolved))
+    if not unique_paths:
+        raise ValueError("No eval result files matched the provided --results patterns.")
+    return unique_paths
+
+
+def load_eval_result_file(path: Path) -> LoadedEvalResult:
+    try:
+        raw_data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Result file does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in result file {path}: line {exc.lineno} column {exc.colno}") from exc
+
+    if not isinstance(raw_data, dict):
+        raise ValueError(f"Eval result file must be a JSON object: {path}")
+
+    missing_top_level = sorted(field for field in REQUIRED_TOP_LEVEL_FIELDS if field not in raw_data)
+    if missing_top_level:
+        raise ValueError(f"Eval result file {path} is missing required fields: {', '.join(missing_top_level)}")
+
+    harness = raw_data.get("harness")
+    if not isinstance(harness, dict):
+        raise ValueError(f"Eval result file {path} has invalid harness metadata.")
+    missing_harness = sorted(field for field in REQUIRED_HARNESS_FIELDS if field not in harness or not harness.get(field))
+    if missing_harness:
+        raise ValueError(f"Eval result file {path} is missing harness fields: {', '.join(missing_harness)}")
+
+    cases = raw_data.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError(f"Eval result file {path} must contain a non-empty cases list.")
+    for index, case in enumerate(cases, start=1):
+        if not isinstance(case, dict):
+            raise ValueError(f"Eval result file {path} case #{index} must be an object.")
+        missing_case = sorted(field for field in REQUIRED_CASE_FIELDS if field not in case)
+        if missing_case:
+            raise ValueError(
+                f"Eval result file {path} case #{index} is missing required fields: {', '.join(missing_case)}"
+            )
+
+    return LoadedEvalResult(path=path.resolve(), data=raw_data)
+
+
+def build_research_scorecard_report(result_paths: list[str] | list[Path]) -> dict[str, Any]:
+    loaded_results = [load_eval_result_file(path if isinstance(path, Path) else Path(path)) for path in _coerce_paths(result_paths)]
+    summaries = [summarize_eval_result(loaded) for loaded in loaded_results]
+    report = {
+        "schema_version": "1.0",
+        "generated_at": _iso_now(),
+        "scorecards": summaries,
+        "comparison": _build_comparison_section(summaries),
+    }
+    return report
+
+
+def summarize_eval_result(loaded: LoadedEvalResult) -> dict[str, Any]:
+    data = loaded.data
+    harness = dict(data.get("harness") or {})
+    cases = list(data.get("cases") or [])
+    case_count = len(cases)
+
+    total_valid_source_links = sum(_metric_number(case, "valid_source_links") for case in cases)
+    total_unknown_references = sum(_metric_number(case, "unknown_source_reference_count") for case in cases)
+    total_reference_events = total_valid_source_links + total_unknown_references
+    valid_source_link_rate = 1.0 if total_reference_events == 0 else round(total_valid_source_links / total_reference_events, 3)
+    unknown_reference_rate = 0.0 if total_reference_events == 0 else round(total_unknown_references / total_reference_events, 3)
+
+    average_attempts_by_phase = _average_attempts_by_phase(cases)
+    summary = {
+        "model": str(harness.get("model") or _first_execution_value(cases, "model") or "unknown"),
+        "runner_label": str(harness.get("runner") or _first_execution_value(cases, "harness") or "unknown"),
+        "mode": str(harness.get("mode") or _first_execution_value(cases, "mode") or "unknown"),
+        "result_file_path": str(loaded.path),
+        "generated_at": str(data.get("generated_at") or ""),
+        "eval_case_count": case_count,
+        "import_success_rate": _rate(cases, lambda case: bool(_metric_bool(case, "import_success"))),
+        "schema_validation_success_rate": _rate(cases, lambda case: bool(_metric_bool(case, "schema_validation_success"))),
+        "valid_source_link_rate": valid_source_link_rate,
+        "unknown_reference_rate": unknown_reference_rate,
+        "expected_claim_trait_coverage": _average_metric(cases, "expected_claim_trait_coverage"),
+        "expected_theme_trait_coverage": _average_metric(cases, "expected_theme_trait_coverage"),
+        "expected_candidate_trait_coverage": _average_metric(cases, "expected_candidate_trait_coverage"),
+        "forbidden_claim_hits": int(sum(_metric_number(case, "forbidden_claim_hit_count") for case in cases)),
+        "average_retry_count": _average_metric(cases, "retry_count"),
+        "average_attempts_by_phase": average_attempts_by_phase,
+        "median_runtime_seconds": _median_metric(cases, "runtime_seconds"),
+        "status_counts": _status_counts(cases),
+        "average_overall_score": _average_overall_score(cases, data.get("aggregate")),
+        "approximations": {
+            "grounded_evidence_link_validity": "Computed from total valid_source_links divided by valid_source_links plus unknown_source_reference_count across cases.",
+            "failure_breakdown": "Uses case status counts because the #72 result schema does not persist a separate phase-failure histogram.",
+        },
+    }
+    return summary
+
+
+def render_scorecard_markdown(report: dict[str, Any]) -> str:
+    scorecards = list(report.get("scorecards") or [])
+    lines = [
+        "| model | runner | cases | import | schema | valid links | unknown refs | claim cov | theme cov | candidate cov | forbidden | avg retries | median runtime | avg score |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for scorecard in scorecards:
+        lines.append(
+            "| {model} | {runner} | {cases} | {import_rate} | {schema_rate} | {valid_rate} | {unknown_rate} | {claim_cov} | {theme_cov} | {candidate_cov} | {forbidden} | {avg_retries} | {median_runtime} | {avg_score} |".format(
+                model=scorecard["model"],
+                runner=scorecard["runner_label"],
+                cases=scorecard["eval_case_count"],
+                import_rate=_pct(scorecard["import_success_rate"]),
+                schema_rate=_pct(scorecard["schema_validation_success_rate"]),
+                valid_rate=_pct(scorecard["valid_source_link_rate"]),
+                unknown_rate=_pct(scorecard["unknown_reference_rate"]),
+                claim_cov=_pct(scorecard["expected_claim_trait_coverage"]),
+                theme_cov=_pct(scorecard["expected_theme_trait_coverage"]),
+                candidate_cov=_pct(scorecard["expected_candidate_trait_coverage"]),
+                forbidden=scorecard["forbidden_claim_hits"],
+                avg_retries=_fmt_number(scorecard["average_retry_count"]),
+                median_runtime=_fmt_number(scorecard["median_runtime_seconds"], digits=4),
+                avg_score=_fmt_number(scorecard["average_overall_score"]),
+            )
+        )
+
+    for scorecard in scorecards:
+        lines.extend(
+            [
+                "",
+                f"### {scorecard['model']} / {scorecard['runner_label']}",
+                f"- result file: {scorecard['result_file_path']}",
+                f"- generated_at: {scorecard['generated_at']}",
+                f"- mode: {scorecard['mode']}",
+                f"- case status counts: {_render_mapping(scorecard['status_counts'])}",
+                f"- average attempts by phase: {_render_mapping(scorecard['average_attempts_by_phase'])}",
+            ]
+        )
+
+    comparison = dict(report.get("comparison") or {})
+    deltas = list(comparison.get("deltas_vs_first") or [])
+    if deltas:
+        lines.extend(
+            [
+                "",
+                "## Comparison",
+                "| candidate | delta avg score | delta import | delta unknown refs | delta avg retries |",
+                "| --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for delta in deltas:
+            lines.append(
+                "| {label} | {avg_score} | {import_rate} | {unknown_rate} | {avg_retries} |".format(
+                    label=delta["label"],
+                    avg_score=_signed(delta["delta_average_overall_score"]),
+                    import_rate=_signed_pct(delta["delta_import_success_rate"]),
+                    unknown_rate=_signed_pct(delta["delta_unknown_reference_rate"]),
+                    avg_retries=_signed(delta["delta_average_retry_count"]),
+                )
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "- grounded evidence link validity is approximated from valid source links versus unknown source or excerpt reference counts emitted by the #72 eval runner",
+            "- failure breakdown uses case status counts because #72 does not yet persist a dedicated per-phase failure histogram in the result JSON",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_scorecard_artifacts(report: dict[str, Any], *, out_json: Path | None = None, out_md: Path | None = None) -> dict[str, str]:
+    written: dict[str, str] = {}
+    if out_json is not None:
+        out_json.parent.mkdir(parents=True, exist_ok=True)
+        out_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        written["json"] = str(out_json.resolve())
+    if out_md is not None:
+        out_md.parent.mkdir(parents=True, exist_ok=True)
+        out_md.write_text(render_scorecard_markdown(report), encoding="utf-8")
+        written["markdown"] = str(out_md.resolve())
+    return written
+
+
+def _coerce_paths(result_paths: list[str] | list[Path]) -> list[Path]:
+    if not result_paths:
+        raise ValueError("Provide at least one eval result file with --results.")
+    raw_patterns = [str(path) for path in result_paths]
+    return expand_result_paths(raw_patterns)
+
+
+def _build_comparison_section(scorecards: list[dict[str, Any]]) -> dict[str, Any]:
+    if len(scorecards) < 2:
+        return {"baseline": None, "deltas_vs_first": []}
+    baseline = scorecards[0]
+    deltas: list[dict[str, Any]] = []
+    for scorecard in scorecards[1:]:
+        deltas.append(
+            {
+                "label": f"{scorecard['model']} / {scorecard['runner_label']}",
+                "delta_average_overall_score": round(scorecard["average_overall_score"] - baseline["average_overall_score"], 3),
+                "delta_import_success_rate": round(scorecard["import_success_rate"] - baseline["import_success_rate"], 3),
+                "delta_unknown_reference_rate": round(scorecard["unknown_reference_rate"] - baseline["unknown_reference_rate"], 3),
+                "delta_average_retry_count": round(scorecard["average_retry_count"] - baseline["average_retry_count"], 3),
+            }
+        )
+    return {
+        "baseline": {
+            "model": baseline["model"],
+            "runner_label": baseline["runner_label"],
+            "result_file_path": baseline["result_file_path"],
+        },
+        "deltas_vs_first": deltas,
+    }
+
+
+def _average_attempts_by_phase(cases: list[dict[str, Any]]) -> dict[str, float]:
+    totals: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    for case in cases:
+        attempts = dict(_metric_mapping(case, "attempts_by_phase"))
+        for phase, value in attempts.items():
+            totals[str(phase)] = totals.get(str(phase), 0.0) + float(value)
+            counts[str(phase)] = counts.get(str(phase), 0) + 1
+    averages: dict[str, float] = {}
+    for phase in sorted(totals):
+        averages[phase] = round(totals[phase] / counts[phase], 3)
+    return averages
+
+
+def _average_metric(cases: list[dict[str, Any]], metric_name: str) -> float:
+    if not cases:
+        return 0.0
+    return round(sum(_metric_number(case, metric_name) for case in cases) / len(cases), 3)
+
+
+def _average_overall_score(cases: list[dict[str, Any]], aggregate: Any) -> float:
+    if isinstance(aggregate, dict) and aggregate.get("average_overall_score") is not None:
+        return round(float(aggregate["average_overall_score"]), 3)
+    scores = [float((case.get("score_summary") or {}).get("overall_score") or 0.0) for case in cases]
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 3)
+
+
+def _first_execution_value(cases: list[dict[str, Any]], field_name: str) -> str | None:
+    for case in cases:
+        execution = case.get("execution")
+        if isinstance(execution, dict) and execution.get(field_name):
+            return str(execution[field_name])
+    return None
+
+
+def _median_metric(cases: list[dict[str, Any]], metric_name: str) -> float:
+    values = [_metric_number(case, metric_name) for case in cases]
+    if not values:
+        return 0.0
+    return round(float(median(values)), 4)
+
+
+def _metric_bool(case: dict[str, Any], metric_name: str) -> bool:
+    metrics = case.get("metrics")
+    if not isinstance(metrics, dict):
+        return False
+    return bool(metrics.get(metric_name))
+
+
+def _metric_mapping(case: dict[str, Any], metric_name: str) -> dict[str, Any]:
+    metrics = case.get("metrics")
+    if not isinstance(metrics, dict):
+        return {}
+    value = metrics.get(metric_name)
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _metric_number(case: dict[str, Any], metric_name: str) -> float:
+    metrics = case.get("metrics")
+    if not isinstance(metrics, dict):
+        return 0.0
+    value = metrics.get(metric_name)
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    return 0.0
+
+
+def _pct(value: float) -> str:
+    return f"{round(float(value) * 100, 1):.1f}%"
+
+
+def _rate(cases: list[dict[str, Any]], predicate) -> float:
+    if not cases:
+        return 0.0
+    return round(sum(1 for case in cases if predicate(case)) / len(cases), 3)
+
+
+def _render_mapping(values: dict[str, Any]) -> str:
+    if not values:
+        return "none"
+    return ", ".join(f"{key}={values[key]}" for key in sorted(values))
+
+
+def _signed(value: float) -> str:
+    return f"{float(value):+.3f}"
+
+
+def _signed_pct(value: float) -> str:
+    return f"{round(float(value) * 100, 1):+.1f}%"
+
+
+def _status_counts(cases: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for case in cases:
+        status = str(case.get("status") or "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return counts
+
+
+def _fmt_number(value: float, *, digits: int = 3) -> str:
+    return f"{float(value):.{digits}f}"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/docs/reference/research-scorecards.md
+++ b/docs/reference/research-scorecards.md
@@ -1,0 +1,122 @@
+# Research Scorecards
+
+APD research scorecards summarize one or more eval result JSON files produced by the fixture-only research eval harness from issue #72.
+
+## Overview
+
+The scorecard tool does not rerun evals.
+
+It reads existing result files, computes aggregate comparisons, prints a markdown-friendly table to stdout, and can optionally write JSON or Markdown artifacts.
+
+Use it when you want to compare:
+
+- two local models against the same eval suite
+- one model across two harness revisions
+- one harness configuration before and after a prompt or validation change
+
+## Running Scorecards
+
+Compare one or more result files with:
+
+```bash
+uv run python scripts/run_research_scorecard.py --results evals/research/results/*.json
+```
+
+You can also pass explicit files:
+
+```bash
+uv run python scripts/run_research_scorecard.py --results path/to/a.json path/to/b.json
+```
+
+Optional artifact output:
+
+```bash
+uv run python scripts/run_research_scorecard.py \
+  --results evals/research/results/*.json \
+  --out-json evals/research/scorecards/latest.json \
+  --out-md evals/research/scorecards/latest.md
+```
+
+Runtime scorecard artifacts under `evals/research/scorecards/` are ignored by git.
+
+## Loaded Fields
+
+The scorecard loader uses the #72 eval result schema directly.
+
+From each result file it reads:
+
+- top-level `generated_at`
+- top-level `harness.model`
+- top-level `harness.runner`
+- top-level `harness.mode`
+- each case `status`
+- each case `metrics`
+- each case `score_summary.overall_score`
+
+If a result file is missing required fields, the command fails clearly instead of inventing defaults.
+
+## Scorecard Metrics
+
+Each scorecard row includes:
+
+- model
+- runner label
+- result file path
+- generated time
+- eval case count
+- import success rate
+- schema validation success rate
+- valid source link rate
+- unknown reference rate
+- expected claim trait coverage
+- expected theme trait coverage
+- expected candidate trait coverage
+- forbidden claim hits
+- average retry count
+- average attempts by phase
+- median runtime
+- case status counts
+- average overall score
+
+## Approximations
+
+The #72 result schema is already useful, but it does not separate every future scorecard dimension yet.
+
+Current approximations:
+
+- grounded evidence link validity is computed from `valid_source_links / (valid_source_links + unknown_source_reference_count)` across cases
+- unknown reference rate is computed from `unknown_source_reference_count / (valid_source_links + unknown_source_reference_count)` across cases
+- failure breakdown is represented as case status counts because the #72 result JSON does not yet persist a dedicated per-phase failure histogram
+
+These approximations are deliberate. The scorecard tool only reports metrics that the eval result JSON can currently support.
+
+## Comparing Runs
+
+When you pass more than one result file, the first file is treated as the baseline.
+
+The comparison section reports deltas for:
+
+- average overall score
+- import success rate
+- unknown reference rate
+- average retry count
+
+Typical workflow:
+
+1. Run evals with one model or harness label.
+2. Run evals again with a second model or harness label.
+3. Pass both result files to the scorecard script.
+4. Compare average score, unknown references, retry count, and status counts.
+
+## Reading the Output
+
+Interpretation guidance:
+
+- higher import and schema success rates are better
+- higher valid link rate and lower unknown reference rate are better
+- higher trait coverage means the generated output stayed closer to the expected wedge
+- fewer forbidden claim hits are better
+- lower retry counts usually mean the harness needed fewer repairs to complete the suite
+- median runtime helps compare stability and speed without overreacting to outliers
+
+No live web, live model, hosted API, or external service is required for scorecards. They operate entirely on previously generated eval result JSON files.

--- a/scripts/check_repo_readiness.py
+++ b/scripts/check_repo_readiness.py
@@ -16,6 +16,7 @@ RESEARCH_EVAL_CASES_DIR = "evals/research/cases"
 RESEARCH_EVAL_FIXTURES_DIR = "evals/research/fixtures/pages"
 RESEARCH_EVAL_RESULTS_DIR = "evals/research/results"
 RESEARCH_EVAL_DOC_PATH = "docs/reference/research-eval-harness.md"
+RESEARCH_SCORECARD_DOC_PATH = "docs/reference/research-scorecards.md"
 RESEARCH_SKILL_SPECS = [
     ("research_protocol", "skills/research/research_protocol.md"),
     ("question_framing", "skills/research/question_framing.md"),
@@ -85,8 +86,11 @@ REQUIRED_FILES = [
     "scripts/clean_empty_run_dirs.py",
     "apd/evals/__init__.py",
     "apd/evals/research_runner.py",
+    "apd/evals/research_scorecard.py",
     "scripts/run_research_evals.py",
+    "scripts/run_research_scorecard.py",
     RESEARCH_EVAL_DOC_PATH,
+    RESEARCH_SCORECARD_DOC_PATH,
     "LAUNCH_MODEL_SUMMARY.md",
 ]
 
@@ -245,6 +249,16 @@ RESEARCH_EVAL_DOC_HEADINGS = {
     "## case schema",
     "## scoring",
     "## adding cases",
+}
+
+RESEARCH_SCORECARD_DOC_HEADINGS = {
+    "## overview",
+    "## running scorecards",
+    "## loaded fields",
+    "## scorecard metrics",
+    "## approximations",
+    "## comparing runs",
+    "## reading the output",
 }
 
 MIN_NONEMPTY_LINES = {
@@ -829,6 +843,10 @@ def validate_research_eval_harness() -> list[str]:
     return errors
 
 
+def validate_research_scorecards() -> list[str]:
+    return validate_markdown(RESEARCH_SCORECARD_DOC_PATH, RESEARCH_SCORECARD_DOC_HEADINGS)
+
+
 def validate_research_manifest(relative_path: str) -> list[str]:
     errors: list[str] = []
     data, load_error = load_json(relative_path)
@@ -1062,6 +1080,7 @@ def validate_repo() -> int:
     errors.extend(validate_active_run())
     errors.extend(validate_research_skill_manifest(RESEARCH_SKILL_MANIFEST_PATH))
     errors.extend(validate_research_eval_harness())
+    errors.extend(validate_research_scorecards())
     for skill_id, skill_path in RESEARCH_SKILL_SPECS:
         errors.extend(validate_research_skill_doc(skill_path, expected_id=skill_id))
 

--- a/scripts/run_research_scorecard.py
+++ b/scripts/run_research_scorecard.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from apd.evals.research_scorecard import build_research_scorecard_report, render_scorecard_markdown, write_scorecard_artifacts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build APD research scorecards from one or more eval result JSON files.")
+    parser.add_argument("--results", nargs="+", required=True, help="Eval result JSON paths or glob patterns.")
+    parser.add_argument("--out-json", help="Optional path to write the aggregated scorecard JSON artifact.")
+    parser.add_argument("--out-md", help="Optional path to write the markdown summary artifact.")
+    args = parser.parse_args(argv)
+
+    report = build_research_scorecard_report(args.results)
+    markdown = render_scorecard_markdown(report)
+    print(markdown)
+
+    write_scorecard_artifacts(
+        report,
+        out_json=Path(args.out_json) if args.out_json else None,
+        out_md=Path(args.out_md) if args.out_md else None,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_research_scorecard.py
+++ b/tests/test_research_scorecard.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from apd.evals.research_scorecard import build_research_scorecard_report, expand_result_paths, load_eval_result_file, render_scorecard_markdown, write_scorecard_artifacts
+from scripts.run_research_scorecard import main as run_scorecard_main
+
+
+def _make_case(
+    case_id: str,
+    *,
+    status: str = "imported",
+    import_success: bool = True,
+    schema_success: bool = True,
+    valid_links: int = 1,
+    unknown_refs: int = 0,
+    claim_cov: float = 1.0,
+    theme_cov: float = 1.0,
+    candidate_cov: float = 1.0,
+    forbidden_hits: int = 0,
+    retry_count: int = 0,
+    attempts_by_phase: dict[str, int] | None = None,
+    runtime_seconds: float = 0.02,
+    overall_score: float = 1.0,
+) -> dict:
+    return {
+        "id": case_id,
+        "status": status,
+        "execution": {
+            "mode": "fixture_only",
+            "provider": "fixture-mocked",
+            "model": "synthetic-model",
+            "harness": "synthetic-runner",
+            "attempts_by_phase": attempts_by_phase or {"candidate_batch": 1, "claim_theme_batch": 1},
+            "retry_count": retry_count,
+        },
+        "metrics": {
+            "import_success": import_success,
+            "schema_validation_success": schema_success,
+            "valid_source_links": valid_links,
+            "unknown_source_reference_count": unknown_refs,
+            "expected_claim_trait_coverage": claim_cov,
+            "expected_theme_trait_coverage": theme_cov,
+            "expected_candidate_trait_coverage": candidate_cov,
+            "forbidden_claim_hit_count": forbidden_hits,
+            "retry_count": retry_count,
+            "attempts_by_phase": attempts_by_phase or {"candidate_batch": 1, "claim_theme_batch": 1},
+            "runtime_seconds": runtime_seconds,
+        },
+        "score_summary": {"overall_score": overall_score},
+    }
+
+
+def _write_result(path: Path, *, model: str, runner: str, cases: list[dict]) -> Path:
+    payload = {
+        "schema_version": "1.0",
+        "generated_at": "2026-04-29T00:00:00+00:00",
+        "harness": {
+            "mode": "fixture_only",
+            "runner": runner,
+            "model": model,
+            "started_at": "2026-04-29T00:00:00+00:00",
+        },
+        "cases": cases,
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def test_load_eval_result_file_requires_expected_fields(tmp_path):
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        load_eval_result_file(bad_path)
+
+
+def test_build_research_scorecard_report_aggregates_one_file(tmp_path):
+    result_path = _write_result(
+        tmp_path / "one.json",
+        model="qwen3:14b",
+        runner="apd-research-eval-fixture-v1",
+        cases=[
+            _make_case("case-a", runtime_seconds=0.01, overall_score=0.8),
+            _make_case("case-b", unknown_refs=1, claim_cov=0.5, forbidden_hits=1, runtime_seconds=0.03, overall_score=0.6),
+        ],
+    )
+
+    report = build_research_scorecard_report([result_path])
+    scorecard = report["scorecards"][0]
+
+    assert scorecard["model"] == "qwen3:14b"
+    assert scorecard["runner_label"] == "apd-research-eval-fixture-v1"
+    assert scorecard["eval_case_count"] == 2
+    assert scorecard["import_success_rate"] == 1.0
+    assert scorecard["unknown_reference_rate"] == 0.333
+    assert scorecard["forbidden_claim_hits"] == 1
+    assert scorecard["median_runtime_seconds"] == 0.02
+
+
+def test_build_research_scorecard_report_compares_two_files(tmp_path):
+    baseline = _write_result(
+        tmp_path / "baseline.json",
+        model="model-a",
+        runner="runner-a",
+        cases=[_make_case("case-a", overall_score=0.5, unknown_refs=1, runtime_seconds=0.02, retry_count=1)],
+    )
+    candidate = _write_result(
+        tmp_path / "candidate.json",
+        model="model-b",
+        runner="runner-b",
+        cases=[_make_case("case-a", overall_score=0.9, unknown_refs=0, runtime_seconds=0.01, retry_count=0)],
+    )
+
+    report = build_research_scorecard_report([baseline, candidate])
+    comparison = report["comparison"]
+
+    assert comparison["baseline"]["model"] == "model-a"
+    assert comparison["deltas_vs_first"][0]["label"] == "model-b / runner-b"
+    assert comparison["deltas_vs_first"][0]["delta_average_overall_score"] == 0.4
+    assert comparison["deltas_vs_first"][0]["delta_unknown_reference_rate"] == -0.5
+
+
+def test_render_scorecard_markdown_and_write_artifacts(tmp_path):
+    result_path = _write_result(
+        tmp_path / "one.json",
+        model="model-a",
+        runner="runner-a",
+        cases=[_make_case("case-a", status="validation_failed", import_success=False, schema_success=False, overall_score=0.2)],
+    )
+    report = build_research_scorecard_report([result_path])
+
+    markdown = render_scorecard_markdown(report)
+    assert "| model | runner |" in markdown
+    assert "case status counts" in markdown
+    assert "failure breakdown uses case status counts" in markdown
+
+    written = write_scorecard_artifacts(
+        report,
+        out_json=tmp_path / "scorecard.json",
+        out_md=tmp_path / "scorecard.md",
+    )
+    assert Path(written["json"]).exists()
+    assert Path(written["markdown"]).exists()
+
+
+def test_expand_result_paths_and_cli_stdout(tmp_path, capsys):
+    first = _write_result(tmp_path / "a.json", model="model-a", runner="runner-a", cases=[_make_case("case-a")])
+    second = _write_result(tmp_path / "b.json", model="model-b", runner="runner-b", cases=[_make_case("case-b")])
+
+    paths = expand_result_paths([str(tmp_path / "*.json")])
+    assert paths == sorted([first.resolve(), second.resolve()])
+
+    exit_code = run_scorecard_main(["--results", str(tmp_path / "*.json")])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "| model | runner |" in captured.out
+    assert "## Comparison" in captured.out
+
+
+def test_build_research_scorecard_report_errors_when_no_results_supplied():
+    with pytest.raises(ValueError, match="at least one eval result file"):
+        build_research_scorecard_report([])


### PR DESCRIPTION
Refs #73

## Summary
- add a scorecard loader and aggregator that reads #72 research eval result JSON files directly
- add a CLI that renders markdown-friendly scorecard tables and optional JSON/Markdown artifacts
- add focused docs, tests, and readiness checks for scorecards

## Verification
- uv run pytest tests/test_research_scorecard.py -q
- uv run python scripts/run_research_evals.py --fixture-only
- uv run python scripts/run_research_scorecard.py --results evals/research/results/*.json
- .\\scripts\\test.ps1
- uv run python scripts/check_repo_readiness.py

## Notes
- uses the #72 eval result JSON schema rather than rerunning evals inside the scorecard tool
- grounded evidence link validity is approximated from valid source links versus unknown source or excerpt references already emitted by #72
- failure breakdown uses case status counts because #72 does not yet persist a dedicated per-phase failure histogram
- no live web, live model, hosted APIs, or external services are required